### PR TITLE
fix(release): restore OCI labels on the per-arch image builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # OCI labels must be applied HERE, on the per-arch image config — the
+      # `merge` job's metadata only tags the manifest list. Without this the
+      # images ship with no org.opencontainers.image.source, and GHCR keeps
+      # showing whichever repository last pushed a labelled image.
+      - name: Docker metadata (labels)
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.ns.outputs.owner }}/${{ matrix.image }}
+
       - name: Build + push by digest
         id: build
         uses: docker/build-push-action@v7
@@ -122,6 +132,7 @@ jobs:
           # Dockerfile.web ignores an unknown build-arg.
           build-args: |
             APP_VERSION=${{ github.ref_name }}
+          labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.ns.outputs.owner }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ matrix.arch }}


### PR DESCRIPTION
## What

Regression from #1: the released images ship with **no OCI labels at all**.

The native-build rewrite moved `docker/metadata-action` into the `merge` job, where its output tags the **manifest list**. Labels, however, live on the **per-arch image config** — so with no `labels:` on the build step, nothing was applied.

Verified against the v0.5.0 images:

```
$ docker buildx imagetools inspect ghcr.io/madmatt112/tradr-api:0.5.0 --format '{{ json .Image }}'
labels found: 0
```

## Impact

- `org.opencontainers.image.source` is missing, so GHCR still shows **Repository source: madmatt112/tradr-v2** on both packages — the "Repository source" field is read from that label. Clicking through from a package page lands on an archived, private repo.
- The rest of the standard metadata is gone too: `revision`, `created`, `version`, `title`, `description`, `licenses`.

## Fix

Run `metadata-action` in the `build` job and pass `labels:` to `build-push-action`. This is docker's documented shape for the push-by-digest pattern — metadata in *both* jobs, labels in `build`, tags in `merge`.

## Verification

Can't be exercised by CI (`release.yml` only triggers on `v*` tags). Confirmed on the **next** release by re-running the inspect above and expecting a non-empty label set including `org.opencontainers.image.source=https://github.com/madmatt112/tradr` — at which point GHCR's Repository source should flip on its own.
