### PR TITLE
feat(positions): row actions, whole-row navigation, and auto-close on full exit

### DIFF
--- a/apps/api/src/features/accounting/accounting.test.ts
+++ b/apps/api/src/features/accounting/accounting.test.ts
@@ -132,7 +132,17 @@ async function openPosition(cookie: string, positionId: string, openedAt?: strin
   return res.json();
 }
 
+/**
+ * Ensures the position is closed. A balancing exit auto-closes it (R7
+ * amendment), so callers that fully exit find it already closed and the
+ * explicit route would 409.
+ */
 async function closePosition(cookie: string, positionId: string, closedAt?: string) {
+  const existing = await authedRequest('GET', `/api/positions/${positionId}`, cookie);
+  expect(existing.status).toBe(200);
+  const position = await existing.json();
+  if (position.status === 'closed') return position;
+
   const res = await authedRequest('POST', `/api/positions/${positionId}/close`, cookie, {
     closedAt,
   });
@@ -784,19 +794,27 @@ describe('mid-hook failure leaves the position open with zero ledger rows', () =
       filledAt: '2026-01-01T00:00:00Z',
     });
     await openPosition(cookie, pos.id, '2026-01-01T00:00:00Z');
-    await addFill(cookie, pos.id, {
+
+    // The balancing exit auto-closes the position (R7 amendment), so the bomb
+    // hook now fires inside the FILL request rather than a separate close.
+    // Everything rides one transaction, so the fill that triggered the close
+    // must roll back with it — a saved exit whose close never landed would
+    // leave a fully-exited-but-open position and no ledger row.
+    const exitRes = await authedRequest('POST', `/api/positions/${pos.id}/fills`, cookie, {
       type: 'exit',
       price: '110',
       quantity: '1',
       fees: '0',
       filledAt: '2026-01-02T00:00:00Z',
     });
-
-    const closeRes = await authedRequest('POST', `/api/positions/${pos.id}/close`, cookie, {
-      closedAt: '2026-01-02T00:00:00Z',
-    });
     // The error handler maps thrown Error → 500.
-    expect(closeRes.status).toBeGreaterThanOrEqual(500);
+    expect(exitRes.status).toBeGreaterThanOrEqual(500);
+
+    // The exit fill itself was rolled back — only the entry survives.
+    const detail = await authedRequest('GET', `/api/positions/${pos.id}`, cookie);
+    expect(detail.status).toBe(200);
+    const detailBody = await detail.json();
+    expect(detailBody.fills.filter((f: { type: string }) => f.type === 'exit')).toHaveLength(0);
 
     // Position status reverted to 'open' (close transaction rolled back).
     const positionRows = await db.select().from(positionsTbl).where(eq(positionsTbl.id, pos.id));

--- a/apps/api/src/features/expenses/expenses.test.ts
+++ b/apps/api/src/features/expenses/expenses.test.ts
@@ -448,7 +448,25 @@ async function openPositionFor(cookie: string, positionId: string, openedAt: str
   return res.json();
 }
 
+/**
+ * Ensures the position is closed at `closedAt`.
+ *
+ * A balancing exit auto-closes at that fill's own timestamp (R7 amendment), and
+ * every caller here gives the exit the same timestamp it wants the close at —
+ * so the position is normally already closed, correctly. Asserting that here
+ * keeps these tax-year-boundary tests honest: they depend on the exact closedAt,
+ * so a drift between the fill time and the close time must fail loudly rather
+ * than silently shifting a position into another tax year.
+ */
 async function closePositionFor(cookie: string, positionId: string, closedAt: string) {
+  const existing = await authedRequest('GET', `/api/positions/${positionId}`, cookie);
+  expect(existing.status).toBe(200);
+  const position = await existing.json();
+  if (position.status === 'closed') {
+    expect(new Date(position.closedAt).toISOString()).toBe(new Date(closedAt).toISOString());
+    return position;
+  }
+
   const res = await authedRequest('POST', `/api/positions/${positionId}/close`, cookie, {
     closedAt,
   });

--- a/apps/api/src/features/positions/fills.test.ts
+++ b/apps/api/src/features/positions/fills.test.ts
@@ -111,19 +111,22 @@ async function openPos(cookie: string, positionId: string) {
   return res.json();
 }
 
-async function closePos(cookie: string, positionId: string) {
-  const res = await authedRequest('POST', `/api/positions/${positionId}/close`, cookie, {});
-  expect(res.status).toBe(200);
-  return res.json();
-}
-
-/** Creates a closed position: draft -> add entry -> open -> add exit -> close */
+/**
+ * Creates a closed position: draft -> add entry -> open -> add exit.
+ *
+ * The balancing exit auto-closes the position (R7 amendment), so there is no
+ * explicit close step — calling the route here would 409 against an
+ * already-closed position.
+ */
 async function createClosedPosition(cookie: string, accountId: string) {
   const pos = await createDraftPosition(cookie, accountId);
   await addFill(cookie, pos.id, makeFill({ type: 'entry', quantity: '10' }));
   await openPos(cookie, pos.id);
   await addFill(cookie, pos.id, makeFill({ type: 'exit', quantity: '10', price: '160.00' }));
-  await closePos(cookie, pos.id);
+
+  const res = await authedRequest('GET', `/api/positions/${pos.id}`, cookie);
+  expect(res.status).toBe(200);
+  expect((await res.json()).status).toBe('closed');
   return pos;
 }
 
@@ -254,7 +257,6 @@ describe('fills', () => {
     const fill = await addFill(cookie, pos.id, makeFill({ type: 'entry', quantity: '10' }));
     await openPos(cookie, pos.id);
     await addFill(cookie, pos.id, makeFill({ type: 'exit', quantity: '10', price: '160.00' }));
-    await closePos(cookie, pos.id);
 
     const res = await authedRequest('PUT', `/api/positions/${pos.id}/fills/${fill.id}`, cookie, {
       price: '151.00',
@@ -277,7 +279,6 @@ describe('fills', () => {
     const fill = await addFill(cookie, pos.id, makeFill({ type: 'entry', quantity: '10' }));
     await openPos(cookie, pos.id);
     await addFill(cookie, pos.id, makeFill({ type: 'exit', quantity: '10', price: '160.00' }));
-    await closePos(cookie, pos.id);
 
     const res = await authedRequest('PUT', `/api/positions/${pos.id}/fills/${fill.id}`, cookie, {
       quantity: '15',
@@ -345,7 +346,6 @@ describe('fills', () => {
     const fill = await addFill(cookie, pos.id, makeFill({ type: 'entry', quantity: '10' }));
     await openPos(cookie, pos.id);
     await addFill(cookie, pos.id, makeFill({ type: 'exit', quantity: '10', price: '160.00' }));
-    await closePos(cookie, pos.id);
 
     const res = await authedRequest('DELETE', `/api/positions/${pos.id}/fills/${fill.id}`, cookie);
     expect(res.status).toBe(409);

--- a/apps/api/src/features/positions/positions.query.ts
+++ b/apps/api/src/features/positions/positions.query.ts
@@ -53,6 +53,7 @@ export function findPositionListByUser(
     SELECT p.*,
       a.name AS account_name,
       a.currency AS account_currency,
+      a.timezone AS account_timezone,
       b.name AS brokerage_name,
       fs.stock_per_share_commission,
       fs.stock_min_per_fill,

--- a/apps/api/src/features/positions/positions.service.ts
+++ b/apps/api/src/features/positions/positions.service.ts
@@ -877,7 +877,63 @@ export async function addFill(
     filledAt: string;
   },
 ) {
-  return withTransaction(db, (tx) => addFillTx(tx, positionId, userId, data));
+  const { fill, closed } = await withTransaction(db, async (tx) => {
+    const inserted = await addFillTx(tx, positionId, userId, data);
+
+    // Auto-close (R7 amendment): an open position with nothing left open IS
+    // closed, so the exit that balances entry quantity performs the transition
+    // itself. Without this the position sits `open` with zero open units until
+    // the user runs a separate close, which is a step with no decision in it.
+    //
+    // Deliberately here and NOT in addFillTx: the bulk importers (csv-import,
+    // demo seed) call addFillTx directly and drive their own closePositionTx.
+    // Auto-closing underneath them would make that follow-up call 409 against
+    // an already-closed position. Same outer/inner split as
+    // closePosition/closePositionTx.
+    if (data.type !== 'exit') return { fill: inserted, closed: null };
+
+    const [{ total: entryTotal }] = await sumFillQuantityByType(tx, positionId, 'entry');
+    const [{ total: exitTotal }] = await sumFillQuantityByType(tx, positionId, 'exit');
+    if (!reconciles(entryTotal, exitTotal)) return { fill: inserted, closed: null };
+
+    const lockRows = await findPositionForUpdate(tx, positionId, userId);
+    const position = (lockRows as RawRow[])[0];
+    if (position?.status !== 'open') return { fill: inserted, closed: null };
+
+    // closedAt is the fill's own timestamp — the position closed when its last
+    // exit executed, not when the request was made. That accuracy matters:
+    // closedAt feeds the tax and performance summaries, so stamping "now" onto
+    // a trade being journalled after the fact would misreport it.
+    //
+    // Clamped to openedAt, because a backdated exit CAN legitimately precede
+    // it: `POST /open` with no body stamps openedAt as now, so a user who
+    // records historical fills afterwards has fills older than the open. Left
+    // unclamped, closePositionTx's closeNotBeforeOpen guard would reject the
+    // whole request and the fill itself would fail to save.
+    const openedAt = position.opened_at ? new Date(position.opened_at) : null;
+    const filledAt = new Date(data.filledAt);
+    const closedAt = openedAt && filledAt < openedAt ? openedAt : filledAt;
+
+    // closePositionTx re-locks the row (already held by this tx) and fires the
+    // ledger close hook.
+    const closedRow = await closePositionTx(tx, positionId, userId, closedAt.toISOString());
+    return { fill: inserted, closed: closedRow };
+  });
+
+  // Same fire-and-forget business event a manual close emits, so an auto-close
+  // is not invisible to analytics. After commit, never inside the tx.
+  if (closed) {
+    try {
+      captureServerEvent('position_closed', {
+        distinctId: userId,
+        properties: { assetType: closed.assetType },
+      });
+    } catch {
+      // ignore — capture is fire-and-forget
+    }
+  }
+
+  return fill;
 }
 
 // Tx-accepting variant — runs directly on the passed tx (no re-wrap / savepoint).

--- a/apps/api/src/features/positions/positions.service.ts
+++ b/apps/api/src/features/positions/positions.service.ts
@@ -433,6 +433,7 @@ export async function listPositions(
       updatedAt: row.updated_at,
       accountName: row.account_name,
       accountCurrency: row.account_currency,
+      accountTimezone: row.account_timezone,
       ...pnl,
       brokerageName,
       grossPnl,

--- a/apps/api/src/features/positions/positions.test.ts
+++ b/apps/api/src/features/positions/positions.test.ts
@@ -114,7 +114,19 @@ async function openTestPosition(cookie: string, positionId: string, openedAt?: s
   return res.json();
 }
 
+/**
+ * Ensures the position is closed, whichever way it got there.
+ *
+ * A full exit now auto-closes (R7 amendment), so most callers find the position
+ * already closed and the explicit route call would 409. Tests that exercise the
+ * close ROUTE itself call it directly rather than through this helper.
+ */
 async function closeTestPosition(cookie: string, positionId: string, closedAt?: string) {
+  const existing = await authedRequest('GET', `/api/positions/${positionId}`, cookie);
+  expect(existing.status).toBe(200);
+  const position = await existing.json();
+  if (position.status === 'closed') return position;
+
   const res = await authedRequest('POST', `/api/positions/${positionId}/close`, cookie, {
     closedAt,
   });
@@ -510,12 +522,26 @@ describe('positions', () => {
     });
     await openTestPosition(cookie, pos.id, '2025-01-01T00:00:00Z');
 
-    await addFill(cookie, pos.id, {
+    // Exit only PART of the position, then edit that fill up to full size.
+    // A balancing exit auto-closes (R7 amendment), so the explicit close route
+    // is now reachable only via a path that does not auto-close — editing a
+    // fill is that path, and it is why the route survives the amendment.
+    const partialExit = await addFill(cookie, pos.id, {
       type: 'exit',
       price: '120',
-      quantity: '10',
+      quantity: '4',
       filledAt: '2025-01-02T00:00:00Z',
     });
+    const edit = await authedRequest(
+      'PUT',
+      `/api/positions/${pos.id}/fills/${partialExit.id}`,
+      cookie,
+      { quantity: '10' },
+    );
+    expect(edit.status).toBe(200);
+
+    const stillOpen = await authedRequest('GET', `/api/positions/${pos.id}`, cookie);
+    expect((await stillOpen.json()).status).toBe('open');
 
     const res = await authedRequest('POST', `/api/positions/${pos.id}/close`, cookie, {
       closedAt: '2025-01-02T00:00:00Z',
@@ -561,6 +587,88 @@ describe('positions', () => {
   });
 
   // 15. Close with closedAt before openedAt → 400
+  // R7 amendment — a balancing exit closes the position by itself.
+  it('auto-closes an open position when an exit balances the entry quantity', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const account = await createTestAccount(cookie);
+    const pos = await createTestPosition(cookie, account.id);
+
+    await addFill(cookie, pos.id, {
+      type: 'entry',
+      price: '100',
+      quantity: '10',
+      filledAt: '2025-01-01T00:00:00Z',
+    });
+    await openTestPosition(cookie, pos.id, '2025-01-01T00:00:00Z');
+
+    await addFill(cookie, pos.id, {
+      type: 'exit',
+      price: '120',
+      quantity: '10',
+      filledAt: '2025-01-02T00:00:00Z',
+    });
+
+    const res = await authedRequest('GET', `/api/positions/${pos.id}`, cookie);
+    const body = await res.json();
+    expect(body.status).toBe('closed');
+    // closedAt is the final exit's own timestamp, not the request time.
+    expect(new Date(body.closedAt).toISOString()).toBe('2025-01-02T00:00:00.000Z');
+  });
+
+  it('leaves the position open on a partial exit', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const account = await createTestAccount(cookie);
+    const pos = await createTestPosition(cookie, account.id);
+
+    await addFill(cookie, pos.id, {
+      type: 'entry',
+      price: '100',
+      quantity: '10',
+      filledAt: '2025-01-01T00:00:00Z',
+    });
+    await openTestPosition(cookie, pos.id, '2025-01-01T00:00:00Z');
+
+    await addFill(cookie, pos.id, {
+      type: 'exit',
+      price: '120',
+      quantity: '4',
+      filledAt: '2025-01-02T00:00:00Z',
+    });
+
+    const res = await authedRequest('GET', `/api/positions/${pos.id}`, cookie);
+    expect((await res.json()).status).toBe('open');
+  });
+
+  // The auto-close must never reject the fill it rides on: `POST /open` with no
+  // body stamps openedAt as now, so a journalled backdated exit predates it.
+  it('clamps the auto-close to openedAt when the final exit predates it', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const account = await createTestAccount(cookie);
+    const pos = await createTestPosition(cookie, account.id);
+
+    await addFill(cookie, pos.id, {
+      type: 'entry',
+      price: '100',
+      quantity: '10',
+      filledAt: '2025-01-01T00:00:00Z',
+    });
+    await openTestPosition(cookie, pos.id, '2025-06-01T00:00:00Z');
+
+    const exit = await authedRequest('POST', `/api/positions/${pos.id}/fills`, cookie, {
+      type: 'exit',
+      price: '120',
+      quantity: '10',
+      fees: '0',
+      filledAt: '2025-01-02T00:00:00Z',
+    });
+    expect(exit.status).toBe(201);
+
+    const res = await authedRequest('GET', `/api/positions/${pos.id}`, cookie);
+    const body = await res.json();
+    expect(body.status).toBe('closed');
+    expect(new Date(body.closedAt).toISOString()).toBe('2025-06-01T00:00:00.000Z');
+  });
+
   it('rejects closing with closedAt before openedAt', async () => {
     const { cookie } = await registerAndGetCookie();
     const account = await createTestAccount(cookie);
@@ -574,12 +682,21 @@ describe('positions', () => {
     });
     await openTestPosition(cookie, pos.id, '2025-06-01T00:00:00Z');
 
-    await addFill(cookie, pos.id, {
+    // Partial exit then edit to full, so the position is fully exited but still
+    // open — a balancing exit would auto-close it and the route would 409.
+    const partialExit = await addFill(cookie, pos.id, {
       type: 'exit',
       price: '120',
-      quantity: '10',
+      quantity: '4',
       filledAt: '2025-01-02T00:00:00Z',
     });
+    const edit = await authedRequest(
+      'PUT',
+      `/api/positions/${pos.id}/fills/${partialExit.id}`,
+      cookie,
+      { quantity: '10' },
+    );
+    expect(edit.status).toBe(200);
 
     const res = await authedRequest('POST', `/api/positions/${pos.id}/close`, cookie, {
       closedAt: '2025-01-01T00:00:00Z',

--- a/apps/web/src/features/dashboard/widgets/OpenPositionsWidget.tsx
+++ b/apps/web/src/features/dashboard/widgets/OpenPositionsWidget.tsx
@@ -66,7 +66,7 @@ function OpenPositionsWidget() {
             <TableHead>Asset</TableHead>
             <TableHead className="text-right">Quantity</TableHead>
             <TableHead>Opened</TableHead>
-            <TableHead className="w-12" />
+            <TableHead className="w-24 text-right">Actions</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/apps/web/src/features/dashboard/widgets/OpenPositionsWidget.tsx
+++ b/apps/web/src/features/dashboard/widgets/OpenPositionsWidget.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 
 import { EmptyState } from '@/components/EmptyState';
 import { Numeric } from '@/components/Numeric';
@@ -11,7 +11,9 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { PositionRowActions } from '@/features/positions/components/PositionRowActions';
 import { usePositions } from '@/features/positions/hooks/usePositions';
+import { shouldNavigateFromRowClick } from '@/features/positions/utils/rowNavigation';
 
 const MAX_ROWS = 10;
 
@@ -24,6 +26,7 @@ const MAX_ROWS = 10;
  * the `ibkr-integration` spec.
  */
 function OpenPositionsWidget() {
+  const navigate = useNavigate();
   const { data: positions, isLoading } = usePositions({ status: 'open' });
 
   if (isLoading) {
@@ -63,11 +66,19 @@ function OpenPositionsWidget() {
             <TableHead>Asset</TableHead>
             <TableHead className="text-right">Quantity</TableHead>
             <TableHead>Opened</TableHead>
+            <TableHead className="w-12" />
           </TableRow>
         </TableHeader>
         <TableBody>
           {rows.map((pos) => (
-            <TableRow key={pos.id}>
+            <TableRow
+              key={pos.id}
+              className="cursor-pointer"
+              onClick={(e) => {
+                if (!shouldNavigateFromRowClick(e)) return;
+                navigate({ to: '/positions/$positionId', params: { positionId: pos.id } });
+              }}
+            >
               <TableCell className="font-medium">
                 <Link
                   to="/positions/$positionId"
@@ -88,6 +99,9 @@ function OpenPositionsWidget() {
               </TableCell>
               <TableCell>
                 {pos.openedAt ? new Date(pos.openedAt).toLocaleDateString() : '—'}
+              </TableCell>
+              <TableCell>
+                <PositionRowActions position={pos} />
               </TableCell>
             </TableRow>
           ))}

--- a/apps/web/src/features/positions/__fixtures__/position-fixtures.ts
+++ b/apps/web/src/features/positions/__fixtures__/position-fixtures.ts
@@ -15,6 +15,7 @@ export const makePosition = (overrides: Partial<PositionListItem> = {}): Positio
   accountId: '00000000-0000-0000-0000-000000000010',
   accountName: 'Test Account',
   accountCurrency: 'USD',
+  accountTimezone: 'America/New_York',
   symbol: 'AAPL',
   side: 'long',
   assetType: 'stock',

--- a/apps/web/src/features/positions/components/FillDialog.test.tsx
+++ b/apps/web/src/features/positions/components/FillDialog.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { FeeSchedule } from '@tradr/shared';
+
+import { useAccountFeeSchedule } from '../hooks/useAccountFeeSchedule';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const addFillMutate = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../hooks/usePosition', () => ({
+  useAddFill: vi.fn(() => ({ mutateAsync: addFillMutate, isPending: false })),
+  useUpdateFill: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+}));
+
+vi.mock('../hooks/useAccountFeeSchedule', () => ({
+  useAccountFeeSchedule: vi.fn(() => null),
+}));
+
+import { FillDialog, type FillPositionContext } from './FillDialog';
+
+const schedule: FeeSchedule = {
+  stockPerShareCommission: '0.005',
+  stockMinPerFill: '1',
+  stockMaxPerFill: '0',
+  optionsPerContractCommission: '0.65',
+  optionsPerContractExchangeFee: '0',
+  optionsMinPerFill: '0',
+  optionsMaxPerFill: '0',
+};
+
+const position: FillPositionContext = {
+  accountId: '00000000-0000-0000-0000-000000000010',
+  assetType: 'stock',
+  side: 'long',
+  openUnits: 100,
+  avgEntryPrice: 150,
+  targetPrice: 195,
+  stopLoss: 140,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.mocked(useAccountFeeSchedule).mockReturnValue(null);
+});
+
+function renderDialog(props: Partial<React.ComponentProps<typeof FillDialog>> = {}) {
+  return render(
+    <FillDialog
+      open
+      onOpenChange={vi.fn()}
+      positionId="p1"
+      positionStatus="open"
+      position={position}
+      {...props}
+    />,
+  );
+}
+
+const field = (name: string) => screen.getByLabelText(name) as HTMLInputElement;
+
+describe('FillDialog — price prefill differs by direction', () => {
+  it('prefills an entry with the average entry price', () => {
+    renderDialog({ defaultType: 'entry' });
+    expect(field('Price').value).toBe('150');
+  });
+
+  it('prefills an exit with the target price', () => {
+    renderDialog({ defaultType: 'exit' });
+    expect(field('Price').value).toBe('195');
+  });
+
+  it('leaves the price empty when the position carries no prices', () => {
+    renderDialog({
+      defaultType: 'entry',
+      position: { ...position, avgEntryPrice: null, targetPrice: null, stopLoss: null },
+    });
+    expect(field('Price').value).toBe('');
+  });
+});
+
+describe('FillDialog — quantity presets', () => {
+  it('offers fractions of open size when reducing', () => {
+    renderDialog({ defaultType: 'exit' });
+    expect(screen.getByText('of 100 open')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: '½' }));
+    expect(field('Quantity').value).toBe('50');
+  });
+
+  it('rounds a preset down so it cannot exceed the open size', () => {
+    renderDialog({ defaultType: 'exit', position: { ...position, openUnits: 10 } });
+    fireEvent.click(screen.getByRole('button', { name: '⅓' }));
+    expect(field('Quantity').value).toBe('3.33333333');
+  });
+
+  it('fills the exact open size for All', () => {
+    renderDialog({ defaultType: 'exit' });
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    expect(field('Quantity').value).toBe('100');
+  });
+
+  it('does not offer presets on an entry — there is no denominator', () => {
+    renderDialog({ defaultType: 'entry' });
+    expect(screen.queryByRole('button', { name: 'All' })).toBeNull();
+  });
+
+  it('does not offer presets when nothing is open', () => {
+    renderDialog({ defaultType: 'exit', position: { ...position, openUnits: 0 } });
+    expect(screen.queryByRole('button', { name: 'All' })).toBeNull();
+  });
+});
+
+describe('FillDialog — brokerage fee preview', () => {
+  it('leaves fees editable when the account has no fee schedule', () => {
+    renderDialog({ defaultType: 'entry' });
+    expect(field('Fees').readOnly).toBe(false);
+    expect(screen.queryByLabelText('Override')).toBeNull();
+  });
+
+  it('shows a read-only calculated fee when a schedule exists', () => {
+    vi.mocked(useAccountFeeSchedule).mockReturnValue(schedule);
+    renderDialog({ defaultType: 'entry' });
+
+    fireEvent.change(field('Quantity'), { target: { value: '1000' } });
+    // 1000 shares × 0.005 = 5.00
+    expect(field('Fees').value).toBe('5');
+    expect(field('Fees').readOnly).toBe(true);
+  });
+
+  it('updates the preview as price and quantity change', () => {
+    vi.mocked(useAccountFeeSchedule).mockReturnValue(schedule);
+    renderDialog({ defaultType: 'entry' });
+
+    fireEvent.change(field('Quantity'), { target: { value: '1000' } });
+    expect(field('Fees').value).toBe('5');
+
+    fireEvent.change(field('Quantity'), { target: { value: '4000' } });
+    expect(field('Fees').value).toBe('20');
+  });
+
+  it('re-opens the field when Override is switched on', () => {
+    vi.mocked(useAccountFeeSchedule).mockReturnValue(schedule);
+    renderDialog({ defaultType: 'entry' });
+
+    expect(field('Fees').readOnly).toBe(true);
+    fireEvent.click(screen.getByLabelText('Override'));
+    expect(field('Fees').readOnly).toBe(false);
+  });
+});
+
+// Manual fill fees and the server's brokerageFees are additive, so a calculated
+// fee must NOT be written onto the fill.
+describe('FillDialog — submitted fees avoid double-counting', () => {
+  it('submits 0 when the fee is schedule-derived', async () => {
+    vi.mocked(useAccountFeeSchedule).mockReturnValue(schedule);
+    renderDialog({ defaultType: 'entry' });
+
+    fireEvent.change(field('Quantity'), { target: { value: '1000' } });
+    expect(field('Fees').value).toBe('5');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    await waitFor(() => expect(addFillMutate).toHaveBeenCalled());
+    expect(addFillMutate.mock.calls[0][0]).toMatchObject({ fees: '0' });
+  });
+
+  it('submits the typed value when overridden', async () => {
+    vi.mocked(useAccountFeeSchedule).mockReturnValue(schedule);
+    renderDialog({ defaultType: 'entry' });
+
+    fireEvent.change(field('Quantity'), { target: { value: '1000' } });
+    fireEvent.click(screen.getByLabelText('Override'));
+    fireEvent.change(field('Fees'), { target: { value: '2.75' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    await waitFor(() => expect(addFillMutate).toHaveBeenCalled());
+    expect(addFillMutate.mock.calls[0][0]).toMatchObject({ fees: '2.75' });
+  });
+
+  it('submits the typed value when there is no schedule at all', async () => {
+    renderDialog({ defaultType: 'entry' });
+
+    fireEvent.change(field('Quantity'), { target: { value: '1000' } });
+    fireEvent.change(field('Fees'), { target: { value: '1.10' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    await waitFor(() => expect(addFillMutate).toHaveBeenCalled());
+    expect(addFillMutate.mock.calls[0][0]).toMatchObject({ fees: '1.10' });
+  });
+});
+
+describe('FillDialog — single-purpose type', () => {
+  it('hides the type picker when the caller fixed the direction', () => {
+    renderDialog({ defaultType: 'exit' });
+    expect(screen.queryByText('Type')).toBeNull();
+    expect(screen.getByText('Reduce position')).toBeTruthy();
+  });
+
+  it('still offers the picker on the generic add-fill flow', () => {
+    renderDialog({});
+    expect(screen.getByText('Type')).toBeTruthy();
+    expect(screen.getByText('Add Fill')).toBeTruthy();
+  });
+});

--- a/apps/web/src/features/positions/components/FillDialog.tsx
+++ b/apps/web/src/features/positions/components/FillDialog.tsx
@@ -1,15 +1,18 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
-import { CreateFillSchema, UpdateFillSchema, type CreateFillInput, type UpdateFillInput, type Fill } from '@tradr/shared';
+import {
+  CreateFillSchema,
+  UpdateFillSchema,
+  type CreateFillInput,
+  type UpdateFillInput,
+  type Fill,
+} from '@tradr/shared';
 
 import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -19,9 +22,39 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 
+import { useAccountFeeSchedule } from '../hooks/useAccountFeeSchedule';
 import { useAddFill, useUpdateFill } from '../hooks/usePosition';
+import { QUANTITY_PRESETS, defaultFillPrice, presetQuantity } from '../utils/fillDefaults';
+import { computeFillFee } from '../utils/fillFees';
+
+// A `datetime-local` input yields "YYYY-MM-DDTHH:mm", which the API schemas'
+// `.datetime()` rule rejects (it wants a full ISO instant). The form validates
+// the RAW widget value, so reusing the API schema verbatim made every submit
+// fail zod validation and silently no-op — `handleSubmit` never reached the
+// mutation, and nothing in the dialog surfaced the filledAt error. Validate the
+// widget's own format here; `onSubmit` still converts to ISO before the request,
+// so the API contract is untouched.
+const localDateTime = z
+  .string()
+  .min(1, 'Required')
+  .refine((v) => !Number.isNaN(Date.parse(v)), 'Enter a valid date and time');
+
+const FillFormSchema = CreateFillSchema.extend({ filledAt: localDateTime });
+const FillEditFormSchema = UpdateFillSchema.extend({ filledAt: localDateTime.optional() });
+
+/** The parts of a position the dialog needs to prefill and price a fill. */
+export interface FillPositionContext {
+  accountId: string;
+  assetType: 'stock' | 'option';
+  side: 'long' | 'short';
+  openUnits: number;
+  avgEntryPrice: number | null;
+  targetPrice: number | null;
+  stopLoss: number | null;
+}
 
 interface Props {
   open: boolean;
@@ -30,15 +63,47 @@ interface Props {
   positionStatus: string;
   isClosedPosition?: boolean;
   fill?: Fill | null;
+  /**
+   * Pre-selects the fill type and hides the type picker. Set by the row's
+   * single-purpose "+" (entry) and "−" (exit) buttons, which each mean exactly
+   * one type — re-asking in the dialog would be redundant. Omitted on the
+   * detail page's generic "Add Fill", which still offers the choice.
+   */
+  defaultType?: 'entry' | 'exit';
+  /**
+   * Enables the prefill, quantity presets and brokerage fee preview. Supplied
+   * by the add-fill flows; omitted when correcting an existing fill, where
+   * none of those apply and the recorded fee must stay editable.
+   */
+  position?: FillPositionContext;
 }
 
-export function FillDialog({ open, onOpenChange, positionId, positionStatus, isClosedPosition, fill }: Props) {
+export function FillDialog({
+  open,
+  onOpenChange,
+  positionId,
+  positionStatus,
+  isClosedPosition,
+  fill,
+  defaultType,
+  position,
+}: Props) {
   const isEdit = !!fill;
   const addFill = useAddFill(positionId);
   const updateFill = useUpdateFill(positionId);
+  const feeSchedule = useAccountFeeSchedule(position?.accountId);
+
+  // Manual fees and the server's schedule-derived brokerageFees are ADDITIVE
+  // (pnl.ts subtracts fill fees from realizedPnl, then netPnl subtracts
+  // brokerageFees again). So when a schedule exists the dialog previews what
+  // the server will charge and submits fees: '0' — writing the number here
+  // would bill it twice. Turning on Override re-opens the field and does
+  // stack on top of the schedule; the copy below says so.
+  const feeIsCalculable = !isEdit && !!position && feeSchedule !== null;
+  const [feeOverride, setFeeOverride] = useState(false);
 
   const form = useForm<CreateFillInput>({
-    resolver: zodResolver(isEdit ? UpdateFillSchema : CreateFillSchema),
+    resolver: zodResolver(isEdit ? FillEditFormSchema : FillFormSchema),
     defaultValues: fill
       ? {
           type: fill.type as 'entry' | 'exit',
@@ -49,7 +114,7 @@ export function FillDialog({ open, onOpenChange, positionId, positionStatus, isC
           filledAt: fill.filledAt ? new Date(fill.filledAt).toISOString().slice(0, 16) : '',
         }
       : {
-          type: 'entry',
+          type: defaultType ?? 'entry',
           price: '',
           quantity: '',
           fees: '0',
@@ -57,6 +122,48 @@ export function FillDialog({ open, onOpenChange, positionId, positionStatus, isC
           filledAt: new Date().toISOString().slice(0, 16),
         },
   });
+
+  // The dialog stays mounted across opens, so `defaultValues` (read once at
+  // useForm time) would keep the type from the FIRST open — clicking "+" then
+  // "−" would reuse 'entry'. Re-seed on each open instead, which is also where
+  // the price prefill lands.
+  useEffect(() => {
+    if (!open || isEdit) return;
+    const type = defaultType ?? 'entry';
+    form.reset({
+      type,
+      price: position ? defaultFillPrice(type, position) : '',
+      quantity: '',
+      fees: '0',
+      notes: null,
+      filledAt: new Date().toISOString().slice(0, 16),
+    });
+    setFeeOverride(false);
+    // `form` is stable across renders; re-seed only on an open transition or a
+    // change of direction.
+  }, [open, defaultType, isEdit, position, form]);
+
+  const watchedType = form.watch('type');
+  const watchedPrice = form.watch('price');
+  const watchedQuantity = form.watch('quantity');
+
+  // Recomputed on every keystroke so the preview tracks price and quantity.
+  const previewFee =
+    feeIsCalculable && feeSchedule && position
+      ? computeFillFee({
+          schedule: feeSchedule,
+          assetType: position.assetType,
+          positionSide: position.side,
+          type: watchedType,
+          price: watchedPrice,
+          quantity: watchedQuantity,
+        })
+      : null;
+
+  // Presets are fractions of currently-open size, so they only mean something
+  // when reducing a position that still has something open.
+  const showQuantityPresets =
+    !isEdit && !!position && watchedType === 'exit' && position.openUnits > 0;
 
   const onSubmit = form.handleSubmit(async (data) => {
     const filledAt = new Date(data.filledAt).toISOString();
@@ -69,7 +176,10 @@ export function FillDialog({ open, onOpenChange, positionId, positionStatus, isC
       if (filledAt !== fill!.filledAt) updateData.filledAt = filledAt;
       await updateFill.mutateAsync({ fillId: fill!.id, data: updateData });
     } else {
-      await addFill.mutateAsync({ ...data, filledAt });
+      // Schedule-derived fees are the server's job — submitting the previewed
+      // number here would have the position count it twice.
+      const fees = feeIsCalculable && !feeOverride ? '0' : data.fees;
+      await addFill.mutateAsync({ ...data, fees, filledAt });
     }
     onOpenChange(false);
     form.reset();
@@ -78,28 +188,44 @@ export function FillDialog({ open, onOpenChange, positionId, positionStatus, isC
   const isPending = addFill.isPending || updateFill.isPending;
 
   // Determine available fill types
-  const typeOptions = positionStatus === 'draft'
-    ? [{ value: 'entry', label: 'Entry' }]
-    : [{ value: 'entry', label: 'Entry' }, { value: 'exit', label: 'Exit' }];
+  const typeOptions =
+    positionStatus === 'draft'
+      ? [{ value: 'entry', label: 'Entry' }]
+      : [
+          { value: 'entry', label: 'Entry' },
+          { value: 'exit', label: 'Exit' },
+        ];
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{isEdit ? 'Edit Fill' : 'Add Fill'}</DialogTitle>
+          <DialogTitle>
+            {isEdit
+              ? 'Edit Fill'
+              : defaultType === 'entry'
+                ? 'Add to position'
+                : defaultType === 'exit'
+                  ? 'Reduce position'
+                  : 'Add Fill'}
+          </DialogTitle>
         </DialogHeader>
         <form onSubmit={onSubmit} className="space-y-4">
-          {!isEdit && (
+          {!isEdit && !defaultType && (
             <div className="space-y-2">
               <Label>Type</Label>
               <Select
                 value={form.watch('type')}
                 onValueChange={(val) => form.setValue('type', val as 'entry' | 'exit')}
               >
-                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
                 <SelectContent>
                   {typeOptions.map((opt) => (
-                    <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
@@ -119,19 +245,95 @@ export function FillDialog({ open, onOpenChange, positionId, positionStatus, isC
                 placeholder="0"
                 disabled={isClosedPosition && isEdit}
               />
+              {showQuantityPresets && position && (
+                <div className="flex items-center gap-1">
+                  {QUANTITY_PRESETS.map((preset) => (
+                    <Button
+                      key={preset.label}
+                      type="button"
+                      variant="outline"
+                      size="xs"
+                      className="cursor-pointer"
+                      onClick={() =>
+                        form.setValue(
+                          'quantity',
+                          presetQuantity(position.openUnits, preset.fraction, position.assetType),
+                          { shouldValidate: true },
+                        )
+                      }
+                    >
+                      {preset.label}
+                    </Button>
+                  ))}
+                  <span className="ml-1 text-xs text-muted-foreground">
+                    of {position.openUnits} open
+                  </span>
+                </div>
+              )}
             </div>
           </div>
 
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label htmlFor="fees">Fees</Label>
-              <Input id="fees" {...form.register('fees')} placeholder="0.00" />
+              <div className="flex items-center justify-between gap-2">
+                <Label htmlFor="fees">Fees</Label>
+                {feeIsCalculable && (
+                  <div className="flex items-center gap-2">
+                    <Label
+                      htmlFor="fee-override"
+                      className="text-xs font-normal text-muted-foreground"
+                    >
+                      Override
+                    </Label>
+                    <Switch
+                      id="fee-override"
+                      className="cursor-pointer"
+                      checked={feeOverride}
+                      onCheckedChange={setFeeOverride}
+                    />
+                  </div>
+                )}
+              </div>
+              {feeIsCalculable && !feeOverride ? (
+                <>
+                  <Input
+                    id="fees"
+                    readOnly
+                    tabIndex={-1}
+                    className="bg-muted text-muted-foreground"
+                    value={previewFee ?? ''}
+                    placeholder="Enter price and quantity"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Calculated from the account&apos;s brokerage fee schedule.
+                  </p>
+                </>
+              ) : (
+                <>
+                  <Input id="fees" {...form.register('fees')} placeholder="0.00" />
+                  {feeIsCalculable && feeOverride && (
+                    <p className="text-xs text-muted-foreground">
+                      Added on top of the brokerage schedule, which still applies to this position.
+                    </p>
+                  )}
+                </>
+              )}
             </div>
             <div className="space-y-2">
-              <Label htmlFor="filledAt">Date & Time</Label>
+              <Label htmlFor="filledAt">Date &amp; Time</Label>
               <Input id="filledAt" type="datetime-local" {...form.register('filledAt')} />
             </div>
           </div>
+
+          {/* Validation errors were previously invisible, so a rejected submit
+              looked like a dead button. */}
+          {Object.values(form.formState.errors).length > 0 && (
+            <ul className="space-y-1 text-sm text-destructive">
+              {Object.entries(form.formState.errors).map(([field, error]) => (
+                <li key={field}>{error?.message as string}</li>
+              ))}
+            </ul>
+          )}
 
           <div className="space-y-2">
             <Label htmlFor="fill-notes">Notes</Label>
@@ -139,7 +341,12 @@ export function FillDialog({ open, onOpenChange, positionId, positionStatus, isC
           </div>
 
           <div className="flex justify-end gap-2">
-            <Button type="button" variant="outline" className="cursor-pointer" onClick={() => onOpenChange(false)}>
+            <Button
+              type="button"
+              variant="outline"
+              className="cursor-pointer"
+              onClick={() => onOpenChange(false)}
+            >
               Cancel
             </Button>
             <Button type="submit" className="cursor-pointer" disabled={isPending}>

--- a/apps/web/src/features/positions/components/PositionDetail.reopen.test.tsx
+++ b/apps/web/src/features/positions/components/PositionDetail.reopen.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { PositionDetail } from '@tradr/shared';
 
+import { TooltipProvider } from '@/components/ui/tooltip';
+
 import { usePosition, useReopenPosition } from '../hooks/usePosition';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -26,6 +28,16 @@ vi.mock('./FillTable', () => ({ FillTable: () => null }));
 vi.mock('./PositionEditDialog', () => ({ PositionEditDialog: () => null }));
 
 import { PositionDetailView } from './PositionDetail';
+
+// The disabled Open/Close affordances carry tooltips; __root.tsx provides the
+// TooltipProvider at runtime, so supply one here as the dashboard route test does.
+function renderDetail() {
+  return render(
+    <TooltipProvider>
+      <PositionDetailView positionId="p1" />
+    </TooltipProvider>,
+  );
+}
 
 type PositionResult = ReturnType<typeof usePosition>;
 
@@ -89,7 +101,7 @@ describe('PositionDetail — Reopen button (R13 same-day)', () => {
       accountTimezone: 'UTC',
       openedAt: `${TODAY_UTC}T09:00:00.000Z`,
     });
-    render(<PositionDetailView positionId="p1" />);
+    renderDetail();
     expect(screen.getByRole('button', { name: 'Reopen' })).toBeTruthy();
   });
 
@@ -99,13 +111,13 @@ describe('PositionDetail — Reopen button (R13 same-day)', () => {
       accountTimezone: 'UTC',
       openedAt: '2020-01-01T09:00:00.000Z',
     });
-    render(<PositionDetailView positionId="p1" />);
+    renderDetail();
     expect(screen.queryByRole('button', { name: 'Reopen' })).toBeNull();
   });
 
   it('does not show Reopen for a non-closed (open) position', () => {
     mockDetail({ status: 'open', openedAt: `${TODAY_UTC}T09:00:00.000Z`, closedAt: null });
-    render(<PositionDetailView positionId="p1" />);
+    renderDetail();
     expect(screen.queryByRole('button', { name: 'Reopen' })).toBeNull();
   });
 
@@ -121,7 +133,7 @@ describe('PositionDetail — Reopen button (R13 same-day)', () => {
       openedAt: `${TODAY_UTC}T09:00:00.000Z`,
     });
 
-    render(<PositionDetailView positionId="p1" />);
+    renderDetail();
     fireEvent.click(screen.getByRole('button', { name: 'Reopen' }));
 
     expect(mutate).toHaveBeenCalledTimes(1);
@@ -132,7 +144,7 @@ describe('PositionDetail — Reopen button (R13 same-day)', () => {
 describe('PositionDetail — delete confirmation copy', () => {
   it('warns about balance, tax/performance (incl. prior tax years) and wash-sale on a closed position', () => {
     mockDetail({ status: 'closed', openedAt: '2020-01-01T09:00:00.000Z' });
-    render(<PositionDetailView positionId="p1" />);
+    renderDetail();
 
     // Only the header Delete exists before the dialog opens.
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
@@ -145,11 +157,57 @@ describe('PositionDetail — delete confirmation copy', () => {
 
   it('keeps the lighter copy for a non-closed (open) position', () => {
     mockDetail({ status: 'open', openedAt: `${TODAY_UTC}T09:00:00.000Z`, closedAt: null });
-    render(<PositionDetailView positionId="p1" />);
+    renderDetail();
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
 
-    expect(screen.getByText(/Are you sure you want to delete this position\?/i)).toBeTruthy();
+    expect(screen.getByText(/Are you sure you want to delete "AAPL"\?/i)).toBeTruthy();
     expect(screen.queryByText(/wash-sale classification/i)).toBeNull();
+  });
+});
+
+// R11-AC4/AC5: Open/Close are shown for their status and disabled until the
+// position is eligible, rather than hidden (the pre-amendment behavior).
+describe('PositionDetail — Open/Close shown-and-disabled', () => {
+  function openButton(name: string): HTMLButtonElement {
+    return screen.getByRole('button', { name }) as HTMLButtonElement;
+  }
+
+  it('shows Open Position disabled on a draft with no entry fills', () => {
+    mockDetail({ status: 'draft', fills: [], closedAt: null });
+    renderDetail();
+    expect(openButton('Open Position').disabled).toBe(true);
+  });
+
+  it('enables Open Position once an entry fill exists', () => {
+    mockDetail({
+      status: 'draft',
+      closedAt: null,
+      fills: [{ id: 'f1', type: 'entry' }] as unknown as PositionDetail['fills'],
+    });
+    renderDetail();
+    expect(openButton('Open Position').disabled).toBe(false);
+  });
+
+  it('shows Close Position disabled while only partly exited', () => {
+    mockDetail({
+      status: 'open',
+      closedAt: null,
+      totalEntryQuantity: 100,
+      totalExitQuantity: 40,
+    });
+    renderDetail();
+    expect(openButton('Close Position').disabled).toBe(true);
+  });
+
+  it('enables Close Position once fully exited', () => {
+    mockDetail({
+      status: 'open',
+      closedAt: null,
+      totalEntryQuantity: 100,
+      totalExitQuantity: 100,
+    });
+    renderDetail();
+    expect(openButton('Close Position').disabled).toBe(false);
   });
 });

--- a/apps/web/src/features/positions/components/PositionDetail.tsx
+++ b/apps/web/src/features/positions/components/PositionDetail.tsx
@@ -26,29 +26,7 @@ import {
   useReopenPosition,
 } from '../hooks/usePosition';
 import { decodeOptionContract } from '../utils/optionContract';
-
-// R13 same-day reopen visibility: a closed position may be reopened only while
-// its openedAt still falls on the current trading day in the ACCOUNT's timezone
-// (never UTC — a US-Eastern evening session crosses UTC midnight but stays one
-// trading day). Compares the zone-local YYYY-MM-DD keys of openedAt and now via
-// Intl 'en-CA' (ISO order), mirroring the server's authoritative zonedDateKey.
-// Fallback: if the account timezone is somehow unavailable, show the button and
-// let the server's 409 surface as a toast rather than hiding a valid action.
-function isOpenedTodayInAccountTz(
-  openedAt: string | null,
-  accountTimezone: string | undefined,
-  now: Date,
-): boolean {
-  if (!accountTimezone) return true;
-  if (openedAt === null) return false;
-  const fmt = new Intl.DateTimeFormat('en-CA', {
-    timeZone: accountTimezone,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  });
-  return fmt.format(new Date(openedAt)) === fmt.format(now);
-}
+import { isOpenedTodayInAccountTz } from '../utils/reopenWindow';
 
 import { FillDialog } from './FillDialog';
 import { FillTable } from './FillTable';

--- a/apps/web/src/features/positions/components/PositionDetail.tsx
+++ b/apps/web/src/features/positions/components/PositionDetail.tsx
@@ -16,6 +16,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { formatCurrency } from '@/lib/format';
 
 import {
@@ -71,11 +72,16 @@ export function PositionDetailView({ positionId }: Props) {
   const optionContract =
     position.assetType === 'option' ? decodeOptionContract(position.symbol) : null;
 
+  // R11-AC4/AC5: Open and Close are SHOWN for their status and disabled until
+  // the position is eligible — the reason rides on a tooltip, mirroring the
+  // disabled "New Position" affordance in PositionList (R10-AC6). Reopen is
+  // different: the R11 amendment scopes it to "only when" the same-day window
+  // is open, so it stays conditionally rendered.
   const hasEntryFills = position.fills.some((f) => f.type === 'entry');
-  const canOpen = isDraft && hasEntryFills;
+  const canOpen = hasEntryFills;
   const isFullyExited =
     position.totalEntryQuantity > 0 && position.totalEntryQuantity === position.totalExitQuantity;
-  const canClose = isOpen && isFullyExited;
+  const canClose = isFullyExited;
 
   // Reopen (R13): closed positions whose openedAt is still the current trading
   // day in the account's timezone. Server is authoritative and 409s a prior-day
@@ -121,23 +127,37 @@ export function PositionDetailView({ positionId }: Props) {
           <Button variant="outline" className="cursor-pointer" onClick={() => setEditOpen(true)}>
             Edit
           </Button>
-          {canOpen && (
-            <Button
-              className="cursor-pointer"
-              onClick={() => openPosition.mutate({})}
-              disabled={openPosition.isPending}
-            >
-              {openPosition.isPending ? 'Opening...' : 'Open Position'}
-            </Button>
+          {isDraft && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <Button
+                    className="cursor-pointer"
+                    onClick={() => openPosition.mutate({})}
+                    disabled={openPosition.isPending || !canOpen}
+                  >
+                    {openPosition.isPending ? 'Opening...' : 'Open Position'}
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              {!canOpen && <TooltipContent>Add an entry fill first</TooltipContent>}
+            </Tooltip>
           )}
-          {canClose && (
-            <Button
-              className="cursor-pointer"
-              onClick={() => closePosition.mutate({})}
-              disabled={closePosition.isPending}
-            >
-              {closePosition.isPending ? 'Closing...' : 'Close Position'}
-            </Button>
+          {isOpen && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <Button
+                    className="cursor-pointer"
+                    onClick={() => closePosition.mutate({})}
+                    disabled={closePosition.isPending || !canClose}
+                  >
+                    {closePosition.isPending ? 'Closing...' : 'Close Position'}
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              {!canClose && <TooltipContent>Exit the full quantity first</TooltipContent>}
+            </Tooltip>
           )}
           {canReopen && (
             <Button
@@ -333,10 +353,11 @@ export function PositionDetailView({ positionId }: Props) {
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Delete position</AlertDialogTitle>
+            {/* R4 amendment: the dialog SHALL name the position. */}
             <AlertDialogDescription>
               {isClosed
-                ? "Deleting this closed position removes its realized P&L from the account balance and from tax and performance summaries — including prior tax years — and may change other positions' wash-sale classification. This cannot be undone."
-                : 'Are you sure you want to delete this position? This cannot be undone.'}
+                ? `Deleting the closed position "${position.symbol}" removes its realized P&L from the account balance and from tax and performance summaries — including prior tax years — and may change other positions' wash-sale classification. This cannot be undone.`
+                : `Are you sure you want to delete "${position.symbol}"? This cannot be undone.`}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/apps/web/src/features/positions/components/PositionDetail.tsx
+++ b/apps/web/src/features/positions/components/PositionDetail.tsx
@@ -375,6 +375,15 @@ export function PositionDetailView({ positionId }: Props) {
         onOpenChange={setFillDialogOpen}
         positionId={positionId}
         positionStatus={position.status}
+        position={{
+          accountId: position.accountId,
+          assetType: position.assetType,
+          side: position.side,
+          openUnits: position.totalEntryQuantity - position.totalExitQuantity,
+          avgEntryPrice: position.avgEntryPrice,
+          targetPrice: position.targetPrice,
+          stopLoss: position.stopLoss,
+        }}
       />
     </div>
   );

--- a/apps/web/src/features/positions/components/PositionList.pnl.test.tsx
+++ b/apps/web/src/features/positions/components/PositionList.pnl.test.tsx
@@ -11,6 +11,13 @@ import { usePositions } from '@/features/positions/hooks/usePositions';
 // Stub the router <Link> with a plain anchor — no router context needed.
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ children, ...rest }: { children: React.ReactNode }) => <a {...rest}>{children}</a>,
+  useNavigate: () => vi.fn(),
+}));
+
+// Row actions need TanStack Query + Radix portals; this suite is about the P&L
+// cell only, so stub them out.
+vi.mock('./PositionRowActions', () => ({
+  PositionRowActions: () => null,
 }));
 
 vi.mock('@/features/accounts/hooks/useAccounts', () => ({

--- a/apps/web/src/features/positions/components/PositionList.telemetry.test.tsx
+++ b/apps/web/src/features/positions/components/PositionList.telemetry.test.tsx
@@ -11,6 +11,12 @@ vi.mock('@/lib/telemetry/posthog', () => ({
   captureClientEvent: (...args: unknown[]) => captureClientEvent(...args),
 }));
 
+// Stub the router — the list calls useNavigate() for whole-row navigation.
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...rest }: { children: React.ReactNode }) => <a {...rest}>{children}</a>,
+  useNavigate: () => vi.fn(),
+}));
+
 // Mock the data hooks so the component renders without TanStack Query / the API.
 // One account is enough for the enabled "New Position" button to render.
 vi.mock('@/features/accounts/hooks/useAccounts', () => ({

--- a/apps/web/src/features/positions/components/PositionList.tsx
+++ b/apps/web/src/features/positions/components/PositionList.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 
 import { Numeric } from '@/components/Numeric';
@@ -21,8 +21,10 @@ import { captureClientEvent } from '@/lib/telemetry/posthog';
 
 import { usePositions } from '../hooks/usePositions';
 import { decodeOptionContract } from '../utils/optionContract';
+import { shouldNavigateFromRowClick } from '../utils/rowNavigation';
 
 import { CreatePositionDialog } from './CreatePositionDialog';
+import { PositionRowActions } from './PositionRowActions';
 
 const STATUS_TABS = [
   { value: 'all', label: 'All' },
@@ -32,6 +34,7 @@ const STATUS_TABS = [
 ] as const;
 
 export function PositionList() {
+  const navigate = useNavigate();
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [dialogOpen, setDialogOpen] = useState(false);
   const { data: accounts } = useAccounts();
@@ -108,6 +111,7 @@ export function PositionList() {
               <TableHead className="text-right"># Open</TableHead>
               <TableHead className="text-right"># Closed</TableHead>
               <TableHead className="text-right">P&L</TableHead>
+              <TableHead className="w-12" />
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -115,7 +119,14 @@ export function PositionList() {
               const optionContract =
                 pos.assetType === 'option' ? decodeOptionContract(pos.symbol) : null;
               return (
-                <TableRow key={pos.id} className="cursor-pointer">
+                <TableRow
+                  key={pos.id}
+                  className="cursor-pointer"
+                  onClick={(e) => {
+                    if (!shouldNavigateFromRowClick(e)) return;
+                    navigate({ to: '/positions/$positionId', params: { positionId: pos.id } });
+                  }}
+                >
                   <TableCell>
                     <Link
                       to="/positions/$positionId"
@@ -188,6 +199,9 @@ export function PositionList() {
                         Fees: {formatCurrency(pos.brokerageFees, pos.accountCurrency)}
                       </span>
                     )}
+                  </TableCell>
+                  <TableCell>
+                    <PositionRowActions position={pos} />
                   </TableCell>
                 </TableRow>
               );

--- a/apps/web/src/features/positions/components/PositionList.tsx
+++ b/apps/web/src/features/positions/components/PositionList.tsx
@@ -111,7 +111,7 @@ export function PositionList() {
               <TableHead className="text-right"># Open</TableHead>
               <TableHead className="text-right"># Closed</TableHead>
               <TableHead className="text-right">P&L</TableHead>
-              <TableHead className="w-12" />
+              <TableHead className="w-32 text-right">Actions</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>

--- a/apps/web/src/features/positions/components/PositionRowActions.test.tsx
+++ b/apps/web/src/features/positions/components/PositionRowActions.test.tsx
@@ -69,23 +69,34 @@ describe('PositionRowActions — lifecycle gating', () => {
     expect(screen.queryByRole('menuitem', { name: 'Add fill' })).toBeNull();
   });
 
-  it('offers Open position only on a draft that has an entry fill', async () => {
+  // R11-AC4/AC5: shown-and-disabled, never hidden, for their own status.
+  it('enables Open position on a draft that has an entry fill', async () => {
     await openMenu({ status: 'draft', totalEntryQuantity: 100, totalExitQuantity: 0 });
-    expect(screen.getByRole('menuitem', { name: 'Open position' })).toBeTruthy();
+    const item = screen.getByRole('menuitem', { name: 'Open position' });
+    expect(item.getAttribute('data-disabled')).toBeNull();
   });
 
-  it('hides Open position on a draft with no fills yet', async () => {
+  it('shows Open position disabled on a draft with no fills yet', async () => {
     await openMenu({ status: 'draft', totalEntryQuantity: 0, totalExitQuantity: 0 });
+    const item = screen.getByRole('menuitem', { name: 'Open position' });
+    expect(item.getAttribute('data-disabled')).not.toBeNull();
+  });
+
+  it('does not offer Open position on a non-draft position', async () => {
+    await openMenu({ status: 'open' });
     expect(screen.queryByRole('menuitem', { name: 'Open position' })).toBeNull();
   });
 
-  it('offers Close position only once the position is fully exited', async () => {
+  it('enables Close position once the position is fully exited', async () => {
     await openMenu({ status: 'open', totalEntryQuantity: 100, totalExitQuantity: 100 });
-    expect(screen.getByRole('menuitem', { name: 'Close position' })).toBeTruthy();
-    cleanup();
+    const item = screen.getByRole('menuitem', { name: 'Close position' });
+    expect(item.getAttribute('data-disabled')).toBeNull();
+  });
 
+  it('shows Close position disabled while the position is only partly exited', async () => {
     await openMenu({ status: 'open', totalEntryQuantity: 100, totalExitQuantity: 40 });
-    expect(screen.queryByRole('menuitem', { name: 'Close position' })).toBeNull();
+    const item = screen.getByRole('menuitem', { name: 'Close position' });
+    expect(item.getAttribute('data-disabled')).not.toBeNull();
   });
 
   it('offers Reopen for a closed position opened today in the account timezone', async () => {
@@ -198,7 +209,24 @@ describe('PositionRowActions — delete confirmation', () => {
     const user = await openMenu({ status: 'open' });
     await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
 
-    expect(screen.getByText(/Are you sure you want to delete this position\?/i)).toBeTruthy();
+    expect(screen.getByText(/Are you sure you want to delete "AAPL"\?/i)).toBeTruthy();
     expect(screen.queryByText(/wash-sale classification/i)).toBeNull();
+  });
+
+  // R4 amendment: the confirmation dialog SHALL name the position.
+  it('names the position in both the closed and non-closed copy', async () => {
+    const user = await openMenu({ status: 'open', symbol: 'MSFT' });
+    await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    expect(screen.getByText(/"MSFT"/)).toBeTruthy();
+    cleanup();
+
+    const user2 = await openMenu({
+      status: 'closed',
+      symbol: 'NVDA260321C120',
+      accountTimezone: 'UTC',
+      openedAt: '2020-01-01T09:00:00.000Z',
+    });
+    await user2.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    expect(screen.getByText(/"NVDA260321C120"/)).toBeTruthy();
   });
 });

--- a/apps/web/src/features/positions/components/PositionRowActions.test.tsx
+++ b/apps/web/src/features/positions/components/PositionRowActions.test.tsx
@@ -54,24 +54,43 @@ function action(name: string): HTMLButtonElement {
 describe('PositionRowActions — actions are inline buttons, not a menu', () => {
   it('exposes each action as its own button with an accessible name', () => {
     renderActions({ status: 'open', totalEntryQuantity: 100, totalExitQuantity: 100 });
-    expect(action('Add fill')).toBeTruthy();
+    expect(action('Add to position')).toBeTruthy();
     expect(action('Close position')).toBeTruthy();
     expect(action('Delete')).toBeTruthy();
     // No dropdown trigger stands between the user and the actions.
     expect(screen.queryByRole('menuitem')).toBeNull();
   });
 
-  it('offers Add fill on draft and open, but not on closed', () => {
+  it('offers Add to position on draft and open, but not on closed', () => {
     renderActions({ status: 'draft' });
-    expect(action('Add fill')).toBeTruthy();
+    expect(action('Add to position')).toBeTruthy();
     cleanup();
 
     renderActions({ status: 'open' });
-    expect(action('Add fill')).toBeTruthy();
+    expect(action('Add to position')).toBeTruthy();
     cleanup();
 
     renderActions({ status: 'closed', closedAt: `${TODAY_UTC}T13:00:00.000Z` });
-    expect(screen.queryByRole('button', { name: 'Add fill' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Add to position' })).toBeNull();
+  });
+
+  // Exit fills 409 on a draft (R5-AC3), so the "−" button is open-only.
+  it('offers Reduce position only on an open position', () => {
+    renderActions({ status: 'open', totalEntryQuantity: 100, totalExitQuantity: 0 });
+    expect(action('Reduce position').disabled).toBe(false);
+    cleanup();
+
+    renderActions({ status: 'draft', totalEntryQuantity: 100 });
+    expect(screen.queryByRole('button', { name: 'Reduce position' })).toBeNull();
+    cleanup();
+
+    renderActions({ status: 'closed', closedAt: `${TODAY_UTC}T13:00:00.000Z` });
+    expect(screen.queryByRole('button', { name: 'Reduce position' })).toBeNull();
+  });
+
+  it('disables Reduce position when nothing is left open to reduce', () => {
+    renderActions({ status: 'open', totalEntryQuantity: 100, totalExitQuantity: 100 });
+    expect(action('Reduce position').disabled).toBe(true);
   });
 });
 
@@ -165,9 +184,9 @@ describe('PositionRowActions — actions fire the right mutation', () => {
     expect(mutate).toHaveBeenCalledWith({});
   });
 
-  it('Add fill opens the fill dialog rather than mutating', () => {
+  it('Add to position opens the fill dialog rather than mutating', () => {
     renderActions({ status: 'open' });
-    fireEvent.click(action('Add fill'));
+    fireEvent.click(action('Add to position'));
 
     expect(screen.getByTestId('fill-dialog')).toBeTruthy();
   });

--- a/apps/web/src/features/positions/components/PositionRowActions.test.tsx
+++ b/apps/web/src/features/positions/components/PositionRowActions.test.tsx
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
-import { render, screen, cleanup } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, cleanup, fireEvent, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { PositionListItem } from '@tradr/shared';
 
+import { TooltipProvider } from '@/components/ui/tooltip';
 import { makePosition } from '@/features/positions/__fixtures__/position-fixtures';
 
 import {
@@ -15,10 +15,6 @@ import {
 } from '../hooks/usePosition';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-
-vi.mock('@tanstack/react-router', () => ({
-  Link: ({ children, ...rest }: { children: React.ReactNode }) => <a {...rest}>{children}</a>,
-}));
 
 vi.mock('../hooks/usePosition', () => ({
   useDeletePosition: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
@@ -42,191 +38,196 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-async function openMenu(overrides: Partial<PositionListItem> = {}) {
-  const user = userEvent.setup();
-  render(<PositionRowActions position={makePosition(overrides)} />);
-  await user.click(screen.getByRole('button', { name: /Actions for/ }));
-  return user;
+// __root.tsx provides TooltipProvider app-wide; supply one for isolated renders.
+function renderActions(overrides: Partial<PositionListItem> = {}) {
+  return render(
+    <TooltipProvider>
+      <PositionRowActions position={makePosition(overrides)} />
+    </TooltipProvider>,
+  );
 }
 
+function action(name: string): HTMLButtonElement {
+  return screen.getByRole('button', { name }) as HTMLButtonElement;
+}
+
+describe('PositionRowActions — actions are inline buttons, not a menu', () => {
+  it('exposes each action as its own button with an accessible name', () => {
+    renderActions({ status: 'open', totalEntryQuantity: 100, totalExitQuantity: 100 });
+    expect(action('Add fill')).toBeTruthy();
+    expect(action('Close position')).toBeTruthy();
+    expect(action('Delete')).toBeTruthy();
+    // No dropdown trigger stands between the user and the actions.
+    expect(screen.queryByRole('menuitem')).toBeNull();
+  });
+
+  it('offers Add fill on draft and open, but not on closed', () => {
+    renderActions({ status: 'draft' });
+    expect(action('Add fill')).toBeTruthy();
+    cleanup();
+
+    renderActions({ status: 'open' });
+    expect(action('Add fill')).toBeTruthy();
+    cleanup();
+
+    renderActions({ status: 'closed', closedAt: `${TODAY_UTC}T13:00:00.000Z` });
+    expect(screen.queryByRole('button', { name: 'Add fill' })).toBeNull();
+  });
+});
+
+// R11-AC4/AC5: shown-and-disabled for their own status, never hidden.
 describe('PositionRowActions — lifecycle gating', () => {
-  it('always offers View details and Delete', async () => {
-    await openMenu();
-    expect(screen.getByRole('menuitem', { name: 'View details' })).toBeTruthy();
-    expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeTruthy();
+  it('enables Open position on a draft that has an entry fill', () => {
+    renderActions({ status: 'draft', totalEntryQuantity: 100, totalExitQuantity: 0 });
+    expect(action('Open position').disabled).toBe(false);
   });
 
-  it('offers Add fill on a draft and an open position, but not a closed one', async () => {
-    await openMenu({ status: 'draft' });
-    expect(screen.getByRole('menuitem', { name: 'Add fill' })).toBeTruthy();
-    cleanup();
-
-    await openMenu({ status: 'open' });
-    expect(screen.getByRole('menuitem', { name: 'Add fill' })).toBeTruthy();
-    cleanup();
-
-    await openMenu({ status: 'closed', closedAt: `${TODAY_UTC}T13:00:00.000Z` });
-    expect(screen.queryByRole('menuitem', { name: 'Add fill' })).toBeNull();
+  it('shows Open position disabled on a draft with no fills yet', () => {
+    renderActions({ status: 'draft', totalEntryQuantity: 0, totalExitQuantity: 0 });
+    expect(action('Open position').disabled).toBe(true);
   });
 
-  // R11-AC4/AC5: shown-and-disabled, never hidden, for their own status.
-  it('enables Open position on a draft that has an entry fill', async () => {
-    await openMenu({ status: 'draft', totalEntryQuantity: 100, totalExitQuantity: 0 });
-    const item = screen.getByRole('menuitem', { name: 'Open position' });
-    expect(item.getAttribute('data-disabled')).toBeNull();
+  it('does not offer Open position on a non-draft position', () => {
+    renderActions({ status: 'open' });
+    expect(screen.queryByRole('button', { name: 'Open position' })).toBeNull();
   });
 
-  it('shows Open position disabled on a draft with no fills yet', async () => {
-    await openMenu({ status: 'draft', totalEntryQuantity: 0, totalExitQuantity: 0 });
-    const item = screen.getByRole('menuitem', { name: 'Open position' });
-    expect(item.getAttribute('data-disabled')).not.toBeNull();
+  it('enables Close position once fully exited', () => {
+    renderActions({ status: 'open', totalEntryQuantity: 100, totalExitQuantity: 100 });
+    expect(action('Close position').disabled).toBe(false);
   });
 
-  it('does not offer Open position on a non-draft position', async () => {
-    await openMenu({ status: 'open' });
-    expect(screen.queryByRole('menuitem', { name: 'Open position' })).toBeNull();
+  it('shows Close position disabled while only partly exited', () => {
+    renderActions({ status: 'open', totalEntryQuantity: 100, totalExitQuantity: 40 });
+    expect(action('Close position').disabled).toBe(true);
   });
 
-  it('enables Close position once the position is fully exited', async () => {
-    await openMenu({ status: 'open', totalEntryQuantity: 100, totalExitQuantity: 100 });
-    const item = screen.getByRole('menuitem', { name: 'Close position' });
-    expect(item.getAttribute('data-disabled')).toBeNull();
-  });
-
-  it('shows Close position disabled while the position is only partly exited', async () => {
-    await openMenu({ status: 'open', totalEntryQuantity: 100, totalExitQuantity: 40 });
-    const item = screen.getByRole('menuitem', { name: 'Close position' });
-    expect(item.getAttribute('data-disabled')).not.toBeNull();
-  });
-
-  it('offers Reopen for a closed position opened today in the account timezone', async () => {
-    await openMenu({
+  it('offers Reopen for a closed position opened today in the account timezone', () => {
+    renderActions({
       status: 'closed',
       accountTimezone: 'UTC',
       openedAt: `${TODAY_UTC}T09:00:00.000Z`,
     });
-    expect(screen.getByRole('menuitem', { name: 'Reopen' })).toBeTruthy();
+    expect(action('Reopen')).toBeTruthy();
   });
 
-  it('hides Reopen for a closed position opened on a previous day', async () => {
-    await openMenu({
+  it('hides Reopen for a closed position opened on a previous day', () => {
+    renderActions({
       status: 'closed',
       accountTimezone: 'UTC',
       openedAt: '2020-01-01T09:00:00.000Z',
     });
-    expect(screen.queryByRole('menuitem', { name: 'Reopen' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Reopen' })).toBeNull();
   });
 });
 
 describe('PositionRowActions — actions fire the right mutation', () => {
-  it('Open position calls the open mutation', async () => {
+  it('Open position calls the open mutation', () => {
     const mutate = vi.fn();
     vi.mocked(useOpenPosition).mockReturnValue({
       mutate,
       isPending: false,
     } as unknown as ReturnType<typeof useOpenPosition>);
 
-    const user = await openMenu({ status: 'draft', totalEntryQuantity: 100 });
-    await user.click(screen.getByRole('menuitem', { name: 'Open position' }));
+    renderActions({ status: 'draft', totalEntryQuantity: 100 });
+    fireEvent.click(action('Open position'));
 
     expect(mutate).toHaveBeenCalledWith({});
   });
 
-  it('Close position calls the close mutation', async () => {
+  it('Close position calls the close mutation', () => {
     const mutate = vi.fn();
     vi.mocked(useClosePosition).mockReturnValue({
       mutate,
       isPending: false,
     } as unknown as ReturnType<typeof useClosePosition>);
 
-    const user = await openMenu({
-      status: 'open',
-      totalEntryQuantity: 100,
-      totalExitQuantity: 100,
-    });
-    await user.click(screen.getByRole('menuitem', { name: 'Close position' }));
+    renderActions({ status: 'open', totalEntryQuantity: 100, totalExitQuantity: 100 });
+    fireEvent.click(action('Close position'));
 
     expect(mutate).toHaveBeenCalledWith({});
   });
 
-  it('Reopen calls the reopen mutation', async () => {
+  it('Reopen calls the reopen mutation', () => {
     const mutate = vi.fn();
     vi.mocked(useReopenPosition).mockReturnValue({
       mutate,
       isPending: false,
     } as unknown as ReturnType<typeof useReopenPosition>);
 
-    const user = await openMenu({
+    renderActions({
       status: 'closed',
       accountTimezone: 'UTC',
       openedAt: `${TODAY_UTC}T09:00:00.000Z`,
     });
-    await user.click(screen.getByRole('menuitem', { name: 'Reopen' }));
+    fireEvent.click(action('Reopen'));
 
     expect(mutate).toHaveBeenCalledWith({});
   });
 
-  it('Add fill opens the fill dialog rather than mutating', async () => {
-    const user = await openMenu({ status: 'open' });
-    await user.click(screen.getByRole('menuitem', { name: 'Add fill' }));
+  it('Add fill opens the fill dialog rather than mutating', () => {
+    renderActions({ status: 'open' });
+    fireEvent.click(action('Add fill'));
 
     expect(screen.getByTestId('fill-dialog')).toBeTruthy();
   });
 });
 
 describe('PositionRowActions — delete confirmation', () => {
-  it('confirms before deleting, then calls the delete mutation', async () => {
+  it('confirms before deleting, then calls the delete mutation', () => {
     const mutate = vi.fn();
     vi.mocked(useDeletePosition).mockReturnValue({
       mutate,
       isPending: false,
     } as unknown as ReturnType<typeof useDeletePosition>);
 
-    const user = await openMenu({ status: 'open' });
-    await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    renderActions({ status: 'open' });
+    fireEvent.click(action('Delete'));
 
-    // Menu click alone must not delete — the dialog stands between.
+    // The icon click alone must not delete — the dialog stands between.
     expect(mutate).not.toHaveBeenCalled();
 
-    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    // Scope to the dialog: the row's own trash icon is also named "Delete".
+    const dialog = screen.getByRole('alertdialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }));
     expect(mutate).toHaveBeenCalledTimes(1);
   });
 
-  it('carries the closed-position tax warning', async () => {
-    await openMenu({
+  it('carries the closed-position tax warning', () => {
+    renderActions({
       status: 'closed',
       accountTimezone: 'UTC',
       openedAt: '2020-01-01T09:00:00.000Z',
     });
-    await userEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    fireEvent.click(action('Delete'));
 
     expect(screen.getByText(/removes its realized P&L from the account balance/i)).toBeTruthy();
     expect(screen.getByText(/including prior tax years/i)).toBeTruthy();
     expect(screen.getByText(/wash-sale classification/i)).toBeTruthy();
   });
 
-  it('keeps the lighter copy on a non-closed position', async () => {
-    const user = await openMenu({ status: 'open' });
-    await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
-
-    expect(screen.getByText(/Are you sure you want to delete "AAPL"\?/i)).toBeTruthy();
-    expect(screen.queryByText(/wash-sale classification/i)).toBeNull();
-  });
-
   // R4 amendment: the confirmation dialog SHALL name the position.
-  it('names the position in both the closed and non-closed copy', async () => {
-    const user = await openMenu({ status: 'open', symbol: 'MSFT' });
-    await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
+  it('names the position in both the closed and non-closed copy', () => {
+    renderActions({ status: 'open', symbol: 'MSFT' });
+    fireEvent.click(action('Delete'));
     expect(screen.getByText(/"MSFT"/)).toBeTruthy();
     cleanup();
 
-    const user2 = await openMenu({
+    renderActions({
       status: 'closed',
       symbol: 'NVDA260321C120',
       accountTimezone: 'UTC',
       openedAt: '2020-01-01T09:00:00.000Z',
     });
-    await user2.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    fireEvent.click(action('Delete'));
     expect(screen.getByText(/"NVDA260321C120"/)).toBeTruthy();
+  });
+
+  it('keeps the lighter copy on a non-closed position', () => {
+    renderActions({ status: 'open' });
+    fireEvent.click(action('Delete'));
+
+    expect(screen.getByText(/Are you sure you want to delete "AAPL"\?/i)).toBeTruthy();
+    expect(screen.queryByText(/wash-sale classification/i)).toBeNull();
   });
 });

--- a/apps/web/src/features/positions/components/PositionRowActions.test.tsx
+++ b/apps/web/src/features/positions/components/PositionRowActions.test.tsx
@@ -7,19 +7,13 @@ import type { PositionListItem } from '@tradr/shared';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { makePosition } from '@/features/positions/__fixtures__/position-fixtures';
 
-import {
-  useDeletePosition,
-  useOpenPosition,
-  useClosePosition,
-  useReopenPosition,
-} from '../hooks/usePosition';
+import { useDeletePosition, useOpenPosition, useReopenPosition } from '../hooks/usePosition';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 vi.mock('../hooks/usePosition', () => ({
   useDeletePosition: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useOpenPosition: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
-  useClosePosition: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useReopenPosition: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
@@ -53,12 +47,27 @@ function action(name: string): HTMLButtonElement {
 
 describe('PositionRowActions — actions are inline buttons, not a menu', () => {
   it('exposes each action as its own button with an accessible name', () => {
-    renderActions({ status: 'open', totalEntryQuantity: 100, totalExitQuantity: 100 });
+    renderActions({ status: 'open', totalEntryQuantity: 100, totalExitQuantity: 40 });
     expect(action('Add to position')).toBeTruthy();
-    expect(action('Close position')).toBeTruthy();
+    expect(action('Reduce position')).toBeTruthy();
     expect(action('Delete')).toBeTruthy();
     // No dropdown trigger stands between the user and the actions.
     expect(screen.queryByRole('menuitem')).toBeNull();
+  });
+
+  // A balancing exit auto-closes server-side (R7 amendment), so "−" then All is
+  // the close; a dedicated button could never be reached in an enabled state.
+  it('offers no Close action in any status', () => {
+    for (const overrides of [
+      { status: 'draft' as const },
+      { status: 'open' as const, totalEntryQuantity: 100, totalExitQuantity: 100 },
+      { status: 'open' as const, totalEntryQuantity: 100, totalExitQuantity: 40 },
+      { status: 'closed' as const },
+    ]) {
+      renderActions(overrides);
+      expect(screen.queryByRole('button', { name: 'Close position' })).toBeNull();
+      cleanup();
+    }
   });
 
   it('offers Add to position on draft and open, but not on closed', () => {
@@ -94,7 +103,7 @@ describe('PositionRowActions — actions are inline buttons, not a menu', () => 
   });
 });
 
-// R11-AC4/AC5: shown-and-disabled for their own status, never hidden.
+// R11-AC4: Open is shown-and-disabled on a draft, never hidden.
 describe('PositionRowActions — lifecycle gating', () => {
   it('enables Open position on a draft that has an entry fill', () => {
     renderActions({ status: 'draft', totalEntryQuantity: 100, totalExitQuantity: 0 });
@@ -109,16 +118,6 @@ describe('PositionRowActions — lifecycle gating', () => {
   it('does not offer Open position on a non-draft position', () => {
     renderActions({ status: 'open' });
     expect(screen.queryByRole('button', { name: 'Open position' })).toBeNull();
-  });
-
-  it('enables Close position once fully exited', () => {
-    renderActions({ status: 'open', totalEntryQuantity: 100, totalExitQuantity: 100 });
-    expect(action('Close position').disabled).toBe(false);
-  });
-
-  it('shows Close position disabled while only partly exited', () => {
-    renderActions({ status: 'open', totalEntryQuantity: 100, totalExitQuantity: 40 });
-    expect(action('Close position').disabled).toBe(true);
   });
 
   it('offers Reopen for a closed position opened today in the account timezone', () => {
@@ -150,19 +149,6 @@ describe('PositionRowActions — actions fire the right mutation', () => {
 
     renderActions({ status: 'draft', totalEntryQuantity: 100 });
     fireEvent.click(action('Open position'));
-
-    expect(mutate).toHaveBeenCalledWith({});
-  });
-
-  it('Close position calls the close mutation', () => {
-    const mutate = vi.fn();
-    vi.mocked(useClosePosition).mockReturnValue({
-      mutate,
-      isPending: false,
-    } as unknown as ReturnType<typeof useClosePosition>);
-
-    renderActions({ status: 'open', totalEntryQuantity: 100, totalExitQuantity: 100 });
-    fireEvent.click(action('Close position'));
 
     expect(mutate).toHaveBeenCalledWith({});
   });

--- a/apps/web/src/features/positions/components/PositionRowActions.test.tsx
+++ b/apps/web/src/features/positions/components/PositionRowActions.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { PositionListItem } from '@tradr/shared';
+
+import { makePosition } from '@/features/positions/__fixtures__/position-fixtures';
+
+import {
+  useDeletePosition,
+  useOpenPosition,
+  useClosePosition,
+  useReopenPosition,
+} from '../hooks/usePosition';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...rest }: { children: React.ReactNode }) => <a {...rest}>{children}</a>,
+}));
+
+vi.mock('../hooks/usePosition', () => ({
+  useDeletePosition: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useOpenPosition: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useClosePosition: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useReopenPosition: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+vi.mock('./FillDialog', () => ({
+  FillDialog: ({ open }: { open: boolean }) => (open ? <div data-testid="fill-dialog" /> : null),
+}));
+
+import { PositionRowActions } from './PositionRowActions';
+
+// The same-day reopen guard compares openedAt's calendar date to *today* in the
+// account timezone; anchor "today" to the real UTC date against a 'UTC' account.
+const TODAY_UTC = new Date().toISOString().slice(0, 10);
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+async function openMenu(overrides: Partial<PositionListItem> = {}) {
+  const user = userEvent.setup();
+  render(<PositionRowActions position={makePosition(overrides)} />);
+  await user.click(screen.getByRole('button', { name: /Actions for/ }));
+  return user;
+}
+
+describe('PositionRowActions — lifecycle gating', () => {
+  it('always offers View details and Delete', async () => {
+    await openMenu();
+    expect(screen.getByRole('menuitem', { name: 'View details' })).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeTruthy();
+  });
+
+  it('offers Add fill on a draft and an open position, but not a closed one', async () => {
+    await openMenu({ status: 'draft' });
+    expect(screen.getByRole('menuitem', { name: 'Add fill' })).toBeTruthy();
+    cleanup();
+
+    await openMenu({ status: 'open' });
+    expect(screen.getByRole('menuitem', { name: 'Add fill' })).toBeTruthy();
+    cleanup();
+
+    await openMenu({ status: 'closed', closedAt: `${TODAY_UTC}T13:00:00.000Z` });
+    expect(screen.queryByRole('menuitem', { name: 'Add fill' })).toBeNull();
+  });
+
+  it('offers Open position only on a draft that has an entry fill', async () => {
+    await openMenu({ status: 'draft', totalEntryQuantity: 100, totalExitQuantity: 0 });
+    expect(screen.getByRole('menuitem', { name: 'Open position' })).toBeTruthy();
+  });
+
+  it('hides Open position on a draft with no fills yet', async () => {
+    await openMenu({ status: 'draft', totalEntryQuantity: 0, totalExitQuantity: 0 });
+    expect(screen.queryByRole('menuitem', { name: 'Open position' })).toBeNull();
+  });
+
+  it('offers Close position only once the position is fully exited', async () => {
+    await openMenu({ status: 'open', totalEntryQuantity: 100, totalExitQuantity: 100 });
+    expect(screen.getByRole('menuitem', { name: 'Close position' })).toBeTruthy();
+    cleanup();
+
+    await openMenu({ status: 'open', totalEntryQuantity: 100, totalExitQuantity: 40 });
+    expect(screen.queryByRole('menuitem', { name: 'Close position' })).toBeNull();
+  });
+
+  it('offers Reopen for a closed position opened today in the account timezone', async () => {
+    await openMenu({
+      status: 'closed',
+      accountTimezone: 'UTC',
+      openedAt: `${TODAY_UTC}T09:00:00.000Z`,
+    });
+    expect(screen.getByRole('menuitem', { name: 'Reopen' })).toBeTruthy();
+  });
+
+  it('hides Reopen for a closed position opened on a previous day', async () => {
+    await openMenu({
+      status: 'closed',
+      accountTimezone: 'UTC',
+      openedAt: '2020-01-01T09:00:00.000Z',
+    });
+    expect(screen.queryByRole('menuitem', { name: 'Reopen' })).toBeNull();
+  });
+});
+
+describe('PositionRowActions — actions fire the right mutation', () => {
+  it('Open position calls the open mutation', async () => {
+    const mutate = vi.fn();
+    vi.mocked(useOpenPosition).mockReturnValue({
+      mutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useOpenPosition>);
+
+    const user = await openMenu({ status: 'draft', totalEntryQuantity: 100 });
+    await user.click(screen.getByRole('menuitem', { name: 'Open position' }));
+
+    expect(mutate).toHaveBeenCalledWith({});
+  });
+
+  it('Close position calls the close mutation', async () => {
+    const mutate = vi.fn();
+    vi.mocked(useClosePosition).mockReturnValue({
+      mutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useClosePosition>);
+
+    const user = await openMenu({
+      status: 'open',
+      totalEntryQuantity: 100,
+      totalExitQuantity: 100,
+    });
+    await user.click(screen.getByRole('menuitem', { name: 'Close position' }));
+
+    expect(mutate).toHaveBeenCalledWith({});
+  });
+
+  it('Reopen calls the reopen mutation', async () => {
+    const mutate = vi.fn();
+    vi.mocked(useReopenPosition).mockReturnValue({
+      mutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useReopenPosition>);
+
+    const user = await openMenu({
+      status: 'closed',
+      accountTimezone: 'UTC',
+      openedAt: `${TODAY_UTC}T09:00:00.000Z`,
+    });
+    await user.click(screen.getByRole('menuitem', { name: 'Reopen' }));
+
+    expect(mutate).toHaveBeenCalledWith({});
+  });
+
+  it('Add fill opens the fill dialog rather than mutating', async () => {
+    const user = await openMenu({ status: 'open' });
+    await user.click(screen.getByRole('menuitem', { name: 'Add fill' }));
+
+    expect(screen.getByTestId('fill-dialog')).toBeTruthy();
+  });
+});
+
+describe('PositionRowActions — delete confirmation', () => {
+  it('confirms before deleting, then calls the delete mutation', async () => {
+    const mutate = vi.fn();
+    vi.mocked(useDeletePosition).mockReturnValue({
+      mutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useDeletePosition>);
+
+    const user = await openMenu({ status: 'open' });
+    await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
+
+    // Menu click alone must not delete — the dialog stands between.
+    expect(mutate).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it('carries the closed-position tax warning', async () => {
+    await openMenu({
+      status: 'closed',
+      accountTimezone: 'UTC',
+      openedAt: '2020-01-01T09:00:00.000Z',
+    });
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+
+    expect(screen.getByText(/removes its realized P&L from the account balance/i)).toBeTruthy();
+    expect(screen.getByText(/including prior tax years/i)).toBeTruthy();
+    expect(screen.getByText(/wash-sale classification/i)).toBeTruthy();
+  });
+
+  it('keeps the lighter copy on a non-closed position', async () => {
+    const user = await openMenu({ status: 'open' });
+    await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
+
+    expect(screen.getByText(/Are you sure you want to delete this position\?/i)).toBeTruthy();
+    expect(screen.queryByText(/wash-sale classification/i)).toBeNull();
+  });
+});

--- a/apps/web/src/features/positions/components/PositionRowActions.tsx
+++ b/apps/web/src/features/positions/components/PositionRowActions.tsx
@@ -60,11 +60,13 @@ export function PositionRowActions({ position }: Props) {
   const isOpen = position.status === 'open';
   const isClosed = position.status === 'closed';
 
-  const canOpen = isDraft && position.totalEntryQuantity > 0;
-  const canClose =
-    isOpen &&
-    position.totalEntryQuantity > 0 &&
-    position.totalEntryQuantity === position.totalExitQuantity;
+  // R11-AC4/AC5: Open and Close are SHOWN for their status and merely disabled
+  // when the position is not yet eligible — not hidden. Reopen is different:
+  // the R11 amendment scopes it to "only when" the same-day window is open, so
+  // it stays conditionally rendered.
+  const hasEntryQuantity = position.totalEntryQuantity > 0;
+  const canOpen = hasEntryQuantity;
+  const canClose = hasEntryQuantity && position.totalEntryQuantity === position.totalExitQuantity;
   const canReopen =
     isClosed && isOpenedTodayInAccountTz(position.openedAt, position.accountTimezone, new Date());
 
@@ -101,20 +103,20 @@ export function PositionRowActions({ position }: Props) {
             </DropdownMenuItem>
           )}
 
-          {canOpen && (
+          {isDraft && (
             <DropdownMenuItem
               className="cursor-pointer"
-              disabled={isPending}
+              disabled={isPending || !canOpen}
               onClick={() => openPosition.mutate({})}
             >
               Open position
             </DropdownMenuItem>
           )}
 
-          {canClose && (
+          {isOpen && (
             <DropdownMenuItem
               className="cursor-pointer"
-              disabled={isPending}
+              disabled={isPending || !canClose}
               onClick={() => closePosition.mutate({})}
             >
               Close position
@@ -157,10 +159,11 @@ export function PositionRowActions({ position }: Props) {
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Delete position</AlertDialogTitle>
+            {/* R4 amendment: the dialog SHALL name the position. */}
             <AlertDialogDescription>
               {isClosed
-                ? "Deleting this closed position removes its realized P&L from the account balance and from tax and performance summaries — including prior tax years — and may change other positions' wash-sale classification. This cannot be undone."
-                : 'Are you sure you want to delete this position? This cannot be undone.'}
+                ? `Deleting the closed position "${position.symbol}" removes its realized P&L from the account balance and from tax and performance summaries — including prior tax years — and may change other positions' wash-sale classification. This cannot be undone.`
+                : `Are you sure you want to delete "${position.symbol}"? This cannot be undone.`}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/apps/web/src/features/positions/components/PositionRowActions.tsx
+++ b/apps/web/src/features/positions/components/PositionRowActions.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@tanstack/react-router';
+import { Check, Plus, RotateCcw, Trash2, Play, type LucideIcon } from 'lucide-react';
 import { useState } from 'react';
 
 import type { PositionListItem } from '@tradr/shared';
@@ -14,13 +14,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 import {
   useDeletePosition,
@@ -36,16 +30,74 @@ interface Props {
   position: PositionListItem;
 }
 
+interface ActionProps {
+  icon: LucideIcon;
+  /** Accessible name and tooltip label when the action is available. */
+  label: string;
+  /** Replaces `label` in the tooltip while disabled, explaining what unlocks it. */
+  disabledReason?: string;
+  disabled?: boolean;
+  destructive?: boolean;
+  onClick: () => void;
+}
+
 /**
- * Row-level action menu for a position, shared by the positions list and the
- * dashboard open-positions widget. Mirrors the lifecycle gating in
- * `PositionDetailView`'s header, but derives it from the list row: that row
- * carries no `fills` array, so "has an entry fill" comes from the aggregate
- * `totalEntryQuantity` — equivalent, since every entry fill adds to it.
+ * One icon button in the row's action strip. The label is always the button's
+ * accessible name — the icon alone is meaningless to a screen reader — and
+ * doubles as the tooltip, so the icon never has to be guessed at.
  *
- * Edit is deliberately NOT here: `PositionEditDialog` needs a full
- * `PositionDetail` (fills included), so it stays on the detail page rather than
- * making every row fetch one. "View details" is the path there.
+ * The `<span>` wrapper is required: Radix tooltips listen for pointer events,
+ * which a disabled button does not emit, so a disabled action would otherwise
+ * be the one case that never explains itself.
+ */
+function RowAction({
+  icon: Icon,
+  label,
+  disabledReason,
+  disabled = false,
+  destructive = false,
+  onClick,
+}: ActionProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span>
+          <Button
+            variant="outline"
+            size="icon-sm"
+            className={
+              destructive
+                ? 'cursor-pointer text-destructive hover:bg-destructive/10 hover:text-destructive'
+                : 'cursor-pointer'
+            }
+            aria-label={label}
+            disabled={disabled}
+            onClick={onClick}
+          >
+            <Icon aria-hidden="true" />
+          </Button>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>{disabled && disabledReason ? disabledReason : label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+/**
+ * Row-level actions for a position, shared by the positions list and the
+ * dashboard open-positions widget. Rendered as a strip of discrete icon
+ * buttons rather than a `⋯` menu: the actions are the point of the row, and
+ * burying them one click deep made them undiscoverable in a wide table.
+ *
+ * Lifecycle gating mirrors `PositionDetailView`'s header, derived from the
+ * list row: that row carries no `fills` array, so "has an entry fill" comes
+ * from the aggregate `totalEntryQuantity` — equivalent, since every entry fill
+ * adds to it.
+ *
+ * Two omissions are deliberate. **Edit** needs a full `PositionDetail` (fills
+ * included) for its option-contract branch, so it stays on the detail page.
+ * **View details** is gone with the menu — the whole row already navigates
+ * there, so an icon for it would be redundant.
  */
 export function PositionRowActions({ position }: Props) {
   const deletePosition = useDeletePosition(position.id);
@@ -78,73 +130,53 @@ export function PositionRowActions({ position }: Props) {
 
   return (
     <>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            className="cursor-pointer"
-            aria-label={`Actions for ${position.symbol}`}
-            data-testid={`position-actions-${position.id}`}
-          >
-            ⋯
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem asChild className="cursor-pointer">
-            <Link to="/positions/$positionId" params={{ positionId: position.id }}>
-              View details
-            </Link>
-          </DropdownMenuItem>
-
-          {!isClosed && (
-            <DropdownMenuItem className="cursor-pointer" onClick={() => setFillOpen(true)}>
-              Add fill
-            </DropdownMenuItem>
-          )}
-
-          {isDraft && (
-            <DropdownMenuItem
-              className="cursor-pointer"
-              disabled={isPending || !canOpen}
-              onClick={() => openPosition.mutate({})}
-            >
-              Open position
-            </DropdownMenuItem>
-          )}
-
-          {isOpen && (
-            <DropdownMenuItem
-              className="cursor-pointer"
-              disabled={isPending || !canClose}
-              onClick={() => closePosition.mutate({})}
-            >
-              Close position
-            </DropdownMenuItem>
-          )}
-
-          {canReopen && (
-            <DropdownMenuItem
-              className="cursor-pointer"
-              disabled={isPending}
-              onClick={() => reopenPosition.mutate({})}
-            >
-              Reopen
-            </DropdownMenuItem>
-          )}
-
-          <DropdownMenuSeparator />
-
-          <DropdownMenuItem
-            variant="destructive"
-            className="cursor-pointer"
+      <div className="flex items-center justify-end gap-1">
+        {!isClosed && (
+          <RowAction
+            icon={Plus}
+            label="Add fill"
             disabled={isPending}
-            onClick={() => setDeleteOpen(true)}
-          >
-            Delete
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+            onClick={() => setFillOpen(true)}
+          />
+        )}
+
+        {isDraft && (
+          <RowAction
+            icon={Play}
+            label="Open position"
+            disabledReason="Add an entry fill first"
+            disabled={isPending || !canOpen}
+            onClick={() => openPosition.mutate({})}
+          />
+        )}
+
+        {isOpen && (
+          <RowAction
+            icon={Check}
+            label="Close position"
+            disabledReason="Exit the full quantity first"
+            disabled={isPending || !canClose}
+            onClick={() => closePosition.mutate({})}
+          />
+        )}
+
+        {canReopen && (
+          <RowAction
+            icon={RotateCcw}
+            label="Reopen"
+            disabled={isPending}
+            onClick={() => reopenPosition.mutate({})}
+          />
+        )}
+
+        <RowAction
+          icon={Trash2}
+          label="Delete"
+          destructive
+          disabled={isPending}
+          onClick={() => setDeleteOpen(true)}
+        />
+      </div>
 
       <FillDialog
         open={fillOpen}

--- a/apps/web/src/features/positions/components/PositionRowActions.tsx
+++ b/apps/web/src/features/positions/components/PositionRowActions.tsx
@@ -1,0 +1,176 @@
+import { Link } from '@tanstack/react-router';
+import { useState } from 'react';
+
+import type { PositionListItem } from '@tradr/shared';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+import {
+  useDeletePosition,
+  useOpenPosition,
+  useClosePosition,
+  useReopenPosition,
+} from '../hooks/usePosition';
+import { isOpenedTodayInAccountTz } from '../utils/reopenWindow';
+
+import { FillDialog } from './FillDialog';
+
+interface Props {
+  position: PositionListItem;
+}
+
+/**
+ * Row-level action menu for a position, shared by the positions list and the
+ * dashboard open-positions widget. Mirrors the lifecycle gating in
+ * `PositionDetailView`'s header, but derives it from the list row: that row
+ * carries no `fills` array, so "has an entry fill" comes from the aggregate
+ * `totalEntryQuantity` — equivalent, since every entry fill adds to it.
+ *
+ * Edit is deliberately NOT here: `PositionEditDialog` needs a full
+ * `PositionDetail` (fills included), so it stays on the detail page rather than
+ * making every row fetch one. "View details" is the path there.
+ */
+export function PositionRowActions({ position }: Props) {
+  const deletePosition = useDeletePosition(position.id);
+  const openPosition = useOpenPosition(position.id);
+  const closePosition = useClosePosition(position.id);
+  const reopenPosition = useReopenPosition(position.id);
+
+  const [fillOpen, setFillOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const isDraft = position.status === 'draft';
+  const isOpen = position.status === 'open';
+  const isClosed = position.status === 'closed';
+
+  const canOpen = isDraft && position.totalEntryQuantity > 0;
+  const canClose =
+    isOpen &&
+    position.totalEntryQuantity > 0 &&
+    position.totalEntryQuantity === position.totalExitQuantity;
+  const canReopen =
+    isClosed && isOpenedTodayInAccountTz(position.openedAt, position.accountTimezone, new Date());
+
+  const isPending =
+    openPosition.isPending ||
+    closePosition.isPending ||
+    reopenPosition.isPending ||
+    deletePosition.isPending;
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="cursor-pointer"
+            aria-label={`Actions for ${position.symbol}`}
+            data-testid={`position-actions-${position.id}`}
+          >
+            ⋯
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem asChild className="cursor-pointer">
+            <Link to="/positions/$positionId" params={{ positionId: position.id }}>
+              View details
+            </Link>
+          </DropdownMenuItem>
+
+          {!isClosed && (
+            <DropdownMenuItem className="cursor-pointer" onClick={() => setFillOpen(true)}>
+              Add fill
+            </DropdownMenuItem>
+          )}
+
+          {canOpen && (
+            <DropdownMenuItem
+              className="cursor-pointer"
+              disabled={isPending}
+              onClick={() => openPosition.mutate({})}
+            >
+              Open position
+            </DropdownMenuItem>
+          )}
+
+          {canClose && (
+            <DropdownMenuItem
+              className="cursor-pointer"
+              disabled={isPending}
+              onClick={() => closePosition.mutate({})}
+            >
+              Close position
+            </DropdownMenuItem>
+          )}
+
+          {canReopen && (
+            <DropdownMenuItem
+              className="cursor-pointer"
+              disabled={isPending}
+              onClick={() => reopenPosition.mutate({})}
+            >
+              Reopen
+            </DropdownMenuItem>
+          )}
+
+          <DropdownMenuSeparator />
+
+          <DropdownMenuItem
+            variant="destructive"
+            className="cursor-pointer"
+            disabled={isPending}
+            onClick={() => setDeleteOpen(true)}
+          >
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <FillDialog
+        open={fillOpen}
+        onOpenChange={setFillOpen}
+        positionId={position.id}
+        positionStatus={position.status}
+      />
+
+      {/* Same closed-position tax warning as the detail page — deleting a
+          closed position reverses its ledger row. */}
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete position</AlertDialogTitle>
+            <AlertDialogDescription>
+              {isClosed
+                ? "Deleting this closed position removes its realized P&L from the account balance and from tax and performance summaries — including prior tax years — and may change other positions' wash-sale classification. This cannot be undone."
+                : 'Are you sure you want to delete this position? This cannot be undone.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
+            <AlertDialogAction className="cursor-pointer" onClick={() => deletePosition.mutate()}>
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/web/src/features/positions/components/PositionRowActions.tsx
+++ b/apps/web/src/features/positions/components/PositionRowActions.tsx
@@ -1,4 +1,4 @@
-import { Check, Minus, Plus, RotateCcw, Trash2, Play, type LucideIcon } from 'lucide-react';
+import { Minus, Plus, RotateCcw, Trash2, Play, type LucideIcon } from 'lucide-react';
 import { useState } from 'react';
 
 import type { PositionListItem } from '@tradr/shared';
@@ -16,12 +16,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
-import {
-  useDeletePosition,
-  useOpenPosition,
-  useClosePosition,
-  useReopenPosition,
-} from '../hooks/usePosition';
+import { useDeletePosition, useOpenPosition, useReopenPosition } from '../hooks/usePosition';
 import { isOpenedTodayInAccountTz } from '../utils/reopenWindow';
 
 import { FillDialog } from './FillDialog';
@@ -102,7 +97,6 @@ function RowAction({
 export function PositionRowActions({ position }: Props) {
   const deletePosition = useDeletePosition(position.id);
   const openPosition = useOpenPosition(position.id);
-  const closePosition = useClosePosition(position.id);
   const reopenPosition = useReopenPosition(position.id);
 
   const [fillType, setFillType] = useState<'entry' | 'exit' | null>(null);
@@ -112,22 +106,22 @@ export function PositionRowActions({ position }: Props) {
   const isOpen = position.status === 'open';
   const isClosed = position.status === 'closed';
 
-  // R11-AC4/AC5: Open and Close are SHOWN for their status and merely disabled
-  // when the position is not yet eligible — not hidden. Reopen is different:
-  // the R11 amendment scopes it to "only when" the same-day window is open, so
-  // it stays conditionally rendered.
+  // R11-AC4: Open is SHOWN on a draft and merely disabled until an entry fill
+  // exists — not hidden. Reopen is different: the R11 amendment scopes it to
+  // "only when" the same-day window is open, so it stays conditionally rendered.
+  //
+  // There is deliberately NO Close action here. A balancing exit auto-closes
+  // the position (R7 amendment), so "−" then All *is* the close; a separate
+  // button would sit permanently disabled except in the instant between full
+  // exit and auto-close, which no user can reach. The detail page keeps one for
+  // the residual path that does not auto-close (editing a fill up to full size).
   const openUnits = position.totalEntryQuantity - position.totalExitQuantity;
   const hasEntryQuantity = position.totalEntryQuantity > 0;
   const canOpen = hasEntryQuantity;
-  const canClose = hasEntryQuantity && position.totalEntryQuantity === position.totalExitQuantity;
   const canReopen =
     isClosed && isOpenedTodayInAccountTz(position.openedAt, position.accountTimezone, new Date());
 
-  const isPending =
-    openPosition.isPending ||
-    closePosition.isPending ||
-    reopenPosition.isPending ||
-    deletePosition.isPending;
+  const isPending = openPosition.isPending || reopenPosition.isPending || deletePosition.isPending;
 
   return (
     <>
@@ -164,16 +158,6 @@ export function PositionRowActions({ position }: Props) {
             disabledReason="Add an entry fill first"
             disabled={isPending || !canOpen}
             onClick={() => openPosition.mutate({})}
-          />
-        )}
-
-        {isOpen && (
-          <RowAction
-            icon={Check}
-            label="Close position"
-            disabledReason="Exit the full quantity first"
-            disabled={isPending || !canClose}
-            onClick={() => closePosition.mutate({})}
           />
         )}
 

--- a/apps/web/src/features/positions/components/PositionRowActions.tsx
+++ b/apps/web/src/features/positions/components/PositionRowActions.tsx
@@ -1,4 +1,4 @@
-import { Check, Plus, RotateCcw, Trash2, Play, type LucideIcon } from 'lucide-react';
+import { Check, Minus, Plus, RotateCcw, Trash2, Play, type LucideIcon } from 'lucide-react';
 import { useState } from 'react';
 
 import type { PositionListItem } from '@tradr/shared';
@@ -105,7 +105,7 @@ export function PositionRowActions({ position }: Props) {
   const closePosition = useClosePosition(position.id);
   const reopenPosition = useReopenPosition(position.id);
 
-  const [fillOpen, setFillOpen] = useState(false);
+  const [fillType, setFillType] = useState<'entry' | 'exit' | null>(null);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
   const isDraft = position.status === 'draft';
@@ -116,6 +116,7 @@ export function PositionRowActions({ position }: Props) {
   // when the position is not yet eligible — not hidden. Reopen is different:
   // the R11 amendment scopes it to "only when" the same-day window is open, so
   // it stays conditionally rendered.
+  const openUnits = position.totalEntryQuantity - position.totalExitQuantity;
   const hasEntryQuantity = position.totalEntryQuantity > 0;
   const canOpen = hasEntryQuantity;
   const canClose = hasEntryQuantity && position.totalEntryQuantity === position.totalExitQuantity;
@@ -130,13 +131,29 @@ export function PositionRowActions({ position }: Props) {
 
   return (
     <>
-      <div className="flex items-center justify-end gap-1">
+      {/* data-slot is load-bearing: rowNavigation keys off it so a click on a
+          DISABLED action (which lands on the tooltip's span wrapper, not the
+          button) does not fall through and navigate the row. */}
+      <div data-slot="row-actions" className="flex items-center justify-end gap-1">
+        {/* Single-purpose entry/exit, replacing one dual-purpose "Add fill".
+            Exit is `open`-only — R5-AC3 409s an exit fill on a draft — and is
+            dead once nothing is left open to reduce. */}
         {!isClosed && (
           <RowAction
             icon={Plus}
-            label="Add fill"
+            label="Add to position"
             disabled={isPending}
-            onClick={() => setFillOpen(true)}
+            onClick={() => setFillType('entry')}
+          />
+        )}
+
+        {isOpen && (
+          <RowAction
+            icon={Minus}
+            label="Reduce position"
+            disabledReason="Nothing open to reduce"
+            disabled={isPending || openUnits <= 0}
+            onClick={() => setFillType('exit')}
           />
         )}
 
@@ -179,10 +196,20 @@ export function PositionRowActions({ position }: Props) {
       </div>
 
       <FillDialog
-        open={fillOpen}
-        onOpenChange={setFillOpen}
+        open={fillType !== null}
+        onOpenChange={(next) => !next && setFillType(null)}
         positionId={position.id}
         positionStatus={position.status}
+        defaultType={fillType ?? undefined}
+        position={{
+          accountId: position.accountId,
+          assetType: position.assetType,
+          side: position.side,
+          openUnits,
+          avgEntryPrice: position.avgEntryPrice,
+          targetPrice: position.targetPrice,
+          stopLoss: position.stopLoss,
+        }}
       />
 
       {/* Same closed-position tax warning as the detail page — deleting a

--- a/apps/web/src/features/positions/hooks/useAccountFeeSchedule.ts
+++ b/apps/web/src/features/positions/hooks/useAccountFeeSchedule.ts
@@ -1,0 +1,24 @@
+import type { FeeSchedule } from '@tradr/shared';
+
+import { useAccounts } from '@/features/accounts/hooks/useAccounts';
+import { useBrokerages } from '@/features/brokerages/hooks/useBrokerages';
+
+/**
+ * The fee schedule that applies to a position's account, or null when there is
+ * none — the account has no brokerage, or the two cached queries have not
+ * resolved yet.
+ *
+ * Callers treat null as "fees are not brokerage-calculatable" and fall back to
+ * a manually editable fee field. Both queries are already warm elsewhere in the
+ * app (the accounts list, the brokerages page), so this adds no fetch in
+ * practice.
+ */
+export function useAccountFeeSchedule(accountId: string | undefined): FeeSchedule | null {
+  const { data: accounts } = useAccounts();
+  const { data: brokerages } = useBrokerages();
+
+  if (!accountId) return null;
+  const account = accounts?.find((a) => a.id === accountId);
+  if (!account?.brokerageId) return null;
+  return brokerages?.find((b) => b.id === account.brokerageId)?.feeSchedule ?? null;
+}

--- a/apps/web/src/features/positions/utils/fillDefaults.test.ts
+++ b/apps/web/src/features/positions/utils/fillDefaults.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { QUANTITY_PRESETS, defaultFillPrice, presetQuantity } from './fillDefaults';
+
+describe('presetQuantity', () => {
+  it('returns the exact open size for All, without rounding', () => {
+    expect(presetQuantity(100, 1, 'stock')).toBe('100');
+    expect(presetQuantity(7, 1, 'option')).toBe('7');
+  });
+
+  it('rounds fractions DOWN so an exit can never exceed the open size', () => {
+    // ⅓ of 100 is 33.33…; 33.34 would be a 400 from the server.
+    expect(presetQuantity(100, 1 / 3, 'option')).toBe('33');
+    expect(presetQuantity(10, 1 / 3, 'option')).toBe('3');
+  });
+
+  it('keeps option quantities whole', () => {
+    expect(presetQuantity(7, 1 / 2, 'option')).toBe('3');
+    expect(presetQuantity(7, 1 / 4, 'option')).toBe('1');
+  });
+
+  it('allows fractional stock quantities', () => {
+    expect(presetQuantity(7, 1 / 2, 'stock')).toBe('3.5');
+  });
+
+  it('never exceeds the open size for any preset', () => {
+    for (const openUnits of [1, 3, 7, 10, 100, 953]) {
+      for (const preset of QUANTITY_PRESETS) {
+        const qty = Number(presetQuantity(openUnits, preset.fraction, 'stock'));
+        expect(qty).toBeLessThanOrEqual(openUnits);
+      }
+    }
+  });
+
+  it('degrades to 0 when nothing is open', () => {
+    expect(presetQuantity(0, 1 / 2, 'stock')).toBe('0');
+    expect(presetQuantity(-5, 1, 'stock')).toBe('0');
+  });
+});
+
+describe('defaultFillPrice', () => {
+  const plan = { avgEntryPrice: 150, stopLoss: 140, targetPrice: 195 };
+
+  it('prefers the target on an exit', () => {
+    expect(defaultFillPrice('exit', plan)).toBe('195');
+  });
+
+  it('prefers the average entry on an entry', () => {
+    expect(defaultFillPrice('entry', plan)).toBe('150');
+  });
+
+  it('falls back through stop to entry on an exit', () => {
+    expect(defaultFillPrice('exit', { ...plan, targetPrice: null })).toBe('140');
+    expect(defaultFillPrice('exit', { ...plan, targetPrice: null, stopLoss: null })).toBe('150');
+  });
+
+  it('falls back through stop to target on an entry', () => {
+    expect(defaultFillPrice('entry', { ...plan, avgEntryPrice: null })).toBe('140');
+    expect(defaultFillPrice('entry', { ...plan, avgEntryPrice: null, stopLoss: null })).toBe('195');
+  });
+
+  it('returns empty rather than guessing when the position has no prices', () => {
+    const empty = { avgEntryPrice: null, stopLoss: null, targetPrice: null };
+    expect(defaultFillPrice('entry', empty)).toBe('');
+    expect(defaultFillPrice('exit', empty)).toBe('');
+  });
+
+  it('ignores non-positive prices', () => {
+    expect(defaultFillPrice('entry', { avgEntryPrice: 0, stopLoss: 140, targetPrice: 195 })).toBe(
+      '140',
+    );
+  });
+});

--- a/apps/web/src/features/positions/utils/fillDefaults.ts
+++ b/apps/web/src/features/positions/utils/fillDefaults.ts
@@ -1,0 +1,58 @@
+/**
+ * Prefill helpers for the add-fill dialog.
+ *
+ * Both exist so the dialog opens with useful values instead of empty inputs and
+ * a 0.00 fee, and so that behavior is testable without mounting React.
+ */
+
+/** The quantity shortcut buttons, as fractions of currently-open size. */
+export const QUANTITY_PRESETS = [
+  { label: '¼', fraction: 1 / 4 },
+  { label: '⅓', fraction: 1 / 3 },
+  { label: '½', fraction: 1 / 2 },
+  { label: '¾', fraction: 3 / 4 },
+  { label: 'All', fraction: 1 },
+] as const;
+
+/**
+ * A preset's quantity against the currently-open size.
+ *
+ * Always rounds DOWN: an exit whose quantity exceeds the open size is a 400
+ * from the server (R5-AC4), so ⅓ of 100 must land on 33, never 33.34. `All`
+ * bypasses the rounding to return the open size exactly, which is the one case
+ * that must hit the boundary rather than fall short of it. Option quantities
+ * are whole contracts; stocks may be fractional.
+ */
+export function presetQuantity(
+  openUnits: number,
+  fraction: number,
+  assetType: 'stock' | 'option',
+): string {
+  if (!Number.isFinite(openUnits) || openUnits <= 0) return '0';
+  if (fraction >= 1) return String(openUnits);
+  const raw = openUnits * fraction;
+  if (assetType === 'option') return String(Math.floor(raw));
+  return String(Math.floor(raw * 1e8) / 1e8);
+}
+
+/**
+ * The price an add-fill dialog should open with, by direction.
+ *
+ * Exit prefers the target (you exit into your target, falling back to the stop,
+ * then to what you paid). Entry prefers the average entry (a scale-in happens
+ * near your existing average, not at the target you have not reached yet).
+ * Returns '' when the position carries none of them — a draft with no fills and
+ * no trade plan has nothing meaningful to offer, and a wrong guess is worse
+ * than an empty field.
+ */
+export function defaultFillPrice(
+  type: 'entry' | 'exit',
+  plan: { avgEntryPrice: number | null; stopLoss: number | null; targetPrice: number | null },
+): string {
+  const order =
+    type === 'exit'
+      ? [plan.targetPrice, plan.stopLoss, plan.avgEntryPrice]
+      : [plan.avgEntryPrice, plan.stopLoss, plan.targetPrice];
+  const first = order.find((v) => v !== null && Number.isFinite(v) && v > 0);
+  return first === undefined ? '' : String(first);
+}

--- a/apps/web/src/features/positions/utils/fillFees.test.ts
+++ b/apps/web/src/features/positions/utils/fillFees.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FeeSchedule } from '@tradr/shared';
+
+import { computeFillFee, fillSide } from './fillFees';
+
+const schedule: FeeSchedule = {
+  stockPerShareCommission: '0.005',
+  stockMinPerFill: '1',
+  stockMaxPerFill: '0',
+  optionsPerContractCommission: '0.65',
+  optionsPerContractExchangeFee: '0',
+  optionsMinPerFill: '0',
+  optionsMaxPerFill: '0',
+};
+
+describe('fillSide', () => {
+  it('maps an entry to the direction that opens the position', () => {
+    expect(fillSide('long', 'entry')).toBe('buy');
+    expect(fillSide('short', 'entry')).toBe('sell');
+  });
+
+  it('maps an exit to the direction that closes it', () => {
+    expect(fillSide('long', 'exit')).toBe('sell');
+    expect(fillSide('short', 'exit')).toBe('buy');
+  });
+});
+
+describe('computeFillFee', () => {
+  const base = {
+    schedule,
+    assetType: 'stock' as const,
+    positionSide: 'long' as const,
+    type: 'entry' as const,
+  };
+
+  it('prices a stock fill through the shared calculator', () => {
+    // 1000 shares × 0.005 = 5.00, above the 1.00 minimum.
+    expect(computeFillFee({ ...base, price: '10', quantity: '1000' })).toBe('5');
+  });
+
+  it('applies the per-fill minimum on small fills', () => {
+    expect(computeFillFee({ ...base, price: '10', quantity: '10' })).toBe('1');
+  });
+
+  it('prices options per contract', () => {
+    const fee = computeFillFee({
+      ...base,
+      assetType: 'option',
+      price: '2.50',
+      quantity: '10',
+    });
+    expect(fee).toBe('6.5');
+  });
+
+  // A half-typed form must not render a confident 0.00.
+  it('returns null until price and quantity are usable', () => {
+    expect(computeFillFee({ ...base, price: '', quantity: '' })).toBeNull();
+    expect(computeFillFee({ ...base, price: '10', quantity: '' })).toBeNull();
+    expect(computeFillFee({ ...base, price: '0', quantity: '100' })).toBeNull();
+    expect(computeFillFee({ ...base, price: 'abc', quantity: '100' })).toBeNull();
+    expect(computeFillFee({ ...base, price: '10', quantity: '-5' })).toBeNull();
+  });
+});

--- a/apps/web/src/features/positions/utils/fillFees.ts
+++ b/apps/web/src/features/positions/utils/fillFees.ts
@@ -1,0 +1,48 @@
+import { calculateFees, type FeeSchedule } from '@tradr/shared';
+
+/**
+ * A fill's buy/sell side, which is the position side crossed with the fill
+ * direction: exiting a long is a sell, exiting a short is a buy. Mirrors the
+ * mapping `listPositions` uses server-side so the preview and the server's
+ * own `brokerageFees` agree.
+ */
+export function fillSide(positionSide: 'long' | 'short', type: 'entry' | 'exit'): 'buy' | 'sell' {
+  if (type === 'entry') return positionSide === 'long' ? 'buy' : 'sell';
+  return positionSide === 'long' ? 'sell' : 'buy';
+}
+
+/**
+ * What the account's brokerage will charge for a prospective fill, using the
+ * same shared `calculateFees` the API applies — so the number shown while
+ * typing is the number the position will later report.
+ *
+ * Returns null when price or quantity is not yet a usable positive number,
+ * which is the normal state of a half-typed form; callers render a placeholder
+ * rather than a misleading 0.00.
+ */
+export function computeFillFee(args: {
+  schedule: FeeSchedule;
+  assetType: 'stock' | 'option';
+  positionSide: 'long' | 'short';
+  type: 'entry' | 'exit';
+  price: string;
+  quantity: string;
+}): string | null {
+  const price = Number(args.price);
+  const quantity = Number(args.quantity);
+  if (!Number.isFinite(price) || !Number.isFinite(quantity)) return null;
+  if (price <= 0 || quantity <= 0) return null;
+
+  const { totalFees } = calculateFees(
+    [
+      {
+        quantity: args.quantity,
+        price: args.price,
+        type: args.assetType,
+        side: fillSide(args.positionSide, args.type),
+      },
+    ],
+    args.schedule,
+  );
+  return totalFees;
+}

--- a/apps/web/src/features/positions/utils/reopenWindow.ts
+++ b/apps/web/src/features/positions/utils/reopenWindow.ts
@@ -1,0 +1,27 @@
+/**
+ * R13 same-day reopen visibility: a closed position may be reopened only while
+ * its openedAt still falls on the current trading day in the ACCOUNT's timezone
+ * (never UTC — a US-Eastern evening session crosses UTC midnight but stays one
+ * trading day). Compares the zone-local YYYY-MM-DD keys of openedAt and now via
+ * Intl 'en-CA' (ISO order), mirroring the server's authoritative zonedDateKey.
+ * Fallback: if the account timezone is somehow unavailable, show the action and
+ * let the server's 409 surface as a toast rather than hiding a valid action.
+ *
+ * Shared by the detail header and the row action menus — the server stays
+ * authoritative either way; this only governs whether the action is offered.
+ */
+export function isOpenedTodayInAccountTz(
+  openedAt: string | null,
+  accountTimezone: string | undefined,
+  now: Date,
+): boolean {
+  if (!accountTimezone) return true;
+  if (openedAt === null) return false;
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: accountTimezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  return fmt.format(new Date(openedAt)) === fmt.format(now);
+}

--- a/apps/web/src/features/positions/utils/rowNavigation.test.ts
+++ b/apps/web/src/features/positions/utils/rowNavigation.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+
+import { shouldNavigateFromRowClick } from './rowNavigation';
+
+type ClickLike = Parameters<typeof shouldNavigateFromRowClick>[0];
+
+/** Minimal stand-in for the React synthetic click the row handler receives. */
+function clickOn(target: HTMLElement, overrides: Partial<ClickLike> = {}): ClickLike {
+  return {
+    defaultPrevented: false,
+    button: 0,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    target,
+    ...overrides,
+  } as ClickLike;
+}
+
+function cellWith(innerHtml: string): { cell: HTMLElement; child: HTMLElement } {
+  const cell = document.createElement('td');
+  cell.innerHTML = innerHtml;
+  return { cell, child: cell.firstElementChild as HTMLElement };
+}
+
+describe('shouldNavigateFromRowClick', () => {
+  it('navigates on a plain primary click on inert row content', () => {
+    const { child } = cellWith('<span>AAPL</span>');
+    expect(shouldNavigateFromRowClick(clickOn(child))).toBe(true);
+  });
+
+  it('defers to the symbol link so a click is not handled twice', () => {
+    const { child } = cellWith('<a href="/positions/1">AAPL</a>');
+    expect(shouldNavigateFromRowClick(clickOn(child))).toBe(false);
+  });
+
+  it('defers to the actions menu trigger', () => {
+    const { child } = cellWith('<button type="button">⋯</button>');
+    expect(shouldNavigateFromRowClick(clickOn(child))).toBe(false);
+  });
+
+  it('defers when the click lands on an element nested inside a button', () => {
+    const { cell } = cellWith('<button type="button"><span id="glyph">⋯</span></button>');
+    const glyph = cell.querySelector('#glyph') as HTMLElement;
+    expect(shouldNavigateFromRowClick(clickOn(glyph))).toBe(false);
+  });
+
+  it.each([
+    ['meta', { metaKey: true }],
+    ['ctrl', { ctrlKey: true }],
+    ['shift', { shiftKey: true }],
+    ['alt', { altKey: true }],
+  ])('leaves a %s-modified click to the browser (new tab/window)', (_label, mods) => {
+    const { child } = cellWith('<span>AAPL</span>');
+    expect(shouldNavigateFromRowClick(clickOn(child, mods))).toBe(false);
+  });
+
+  it('ignores non-primary buttons (middle-click opens a background tab)', () => {
+    const { child } = cellWith('<span>AAPL</span>');
+    expect(shouldNavigateFromRowClick(clickOn(child, { button: 1 }))).toBe(false);
+  });
+
+  it('ignores a click something else already handled', () => {
+    const { child } = cellWith('<span>AAPL</span>');
+    expect(shouldNavigateFromRowClick(clickOn(child, { defaultPrevented: true }))).toBe(false);
+  });
+});

--- a/apps/web/src/features/positions/utils/rowNavigation.test.ts
+++ b/apps/web/src/features/positions/utils/rowNavigation.test.ts
@@ -7,6 +7,9 @@ type ClickLike = Parameters<typeof shouldNavigateFromRowClick>[0];
 
 /** Minimal stand-in for the React synthetic click the row handler receives. */
 function clickOn(target: HTMLElement, overrides: Partial<ClickLike> = {}): ClickLike {
+  // `currentTarget` defaults to an ancestor that contains the target, matching
+  // a real bubble; the portal test overrides it with a detached row.
+  const row = target.closest('tr') ?? target.parentElement ?? target;
   return {
     defaultPrevented: false,
     button: 0,
@@ -15,13 +18,16 @@ function clickOn(target: HTMLElement, overrides: Partial<ClickLike> = {}): Click
     shiftKey: false,
     altKey: false,
     target,
+    currentTarget: row,
     ...overrides,
   } as ClickLike;
 }
 
 function cellWith(innerHtml: string): { cell: HTMLElement; child: HTMLElement } {
+  const row = document.createElement('tr');
   const cell = document.createElement('td');
   cell.innerHTML = innerHtml;
+  row.appendChild(cell);
   return { cell, child: cell.firstElementChild as HTMLElement };
 }
 
@@ -39,6 +45,23 @@ describe('shouldNavigateFromRowClick', () => {
   it('defers to the actions menu trigger', () => {
     const { child } = cellWith('<button type="button">⋯</button>');
     expect(shouldNavigateFromRowClick(clickOn(child))).toBe(false);
+  });
+
+  // Regression: a disabled button emits no pointer events, so the click lands
+  // on the tooltip's span wrapper — the button's PARENT — and closest('button')
+  // finds nothing. Matching the action strip is what stops the fall-through.
+  it('defers when the click lands on the wrapper around a disabled button', () => {
+    const { cell } = cellWith(
+      '<div data-slot="row-actions"><span id="wrap"><button type="button" disabled>x</button></span></div>',
+    );
+    const wrapper = cell.querySelector('#wrap') as HTMLElement;
+    expect(shouldNavigateFromRowClick(clickOn(wrapper))).toBe(false);
+  });
+
+  it('defers on the gaps between action buttons', () => {
+    const { cell } = cellWith('<div data-slot="row-actions" id="strip"></div>');
+    const strip = cell.querySelector('#strip') as HTMLElement;
+    expect(shouldNavigateFromRowClick(clickOn(strip))).toBe(false);
   });
 
   it('defers when the click lands on an element nested inside a button', () => {
@@ -65,5 +88,22 @@ describe('shouldNavigateFromRowClick', () => {
   it('ignores a click something else already handled', () => {
     const { child } = cellWith('<span>AAPL</span>');
     expect(shouldNavigateFromRowClick(clickOn(child, { defaultPrevented: true }))).toBe(false);
+  });
+
+  // Regression: the row's dialogs are portalled to document.body, but a React
+  // portal keeps the React tree intact, so clicks inside them bubbled to the
+  // row handler and navigated away from the open dialog.
+  it('ignores clicks from portalled content outside the row subtree', () => {
+    const row = document.createElement('tr');
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    dialog.innerHTML = '<label>Quantity</label>';
+    document.body.append(row, dialog);
+
+    const label = dialog.querySelector('label') as HTMLElement;
+    expect(shouldNavigateFromRowClick(clickOn(label, { currentTarget: row }))).toBe(false);
+
+    row.remove();
+    dialog.remove();
   });
 });

--- a/apps/web/src/features/positions/utils/rowNavigation.ts
+++ b/apps/web/src/features/positions/utils/rowNavigation.ts
@@ -10,8 +10,23 @@ import type { MouseEvent } from 'react';
  *
  * - a modified or non-primary click (open in a new tab / window / background)
  * - a click that landed on a genuinely interactive element inside the row: the
- *   symbol link, or the actions menu trigger, both of which handle themselves
+ *   symbol link, or an action button, both of which handle themselves
+ * - a click anywhere in the action strip (`[data-slot="row-actions"]`). Testing
+ *   for an ancestor `button` is not enough: a DISABLED button emits no pointer
+ *   events, so the event target becomes the tooltip's `<span>` wrapper — the
+ *   button's parent, not its ancestor — and the click sails through to navigate.
+ *   Matching the strip catches the wrappers and the gaps between buttons too.
  * - a click something else already handled (`preventDefault`)
+ * - a click that never happened in the row's DOM subtree at all — see below
+ *
+ * The last case is the important one. The row renders dialogs (fill, delete
+ * confirmation) and tooltips that Radix *portals* to document.body. A React
+ * portal relocates the DOM node but NOT the React tree, so events raised inside
+ * it still bubble to this handler as though they came from the row. Testing DOM
+ * containment against `currentTarget` rejects every portalled surface at once —
+ * dialogs, tooltips, toasts, select popovers — instead of chasing them
+ * individually in the selector list. Without it, clicking anywhere non-
+ * interactive inside an open dialog navigates away from it.
  *
  * Shared by the positions list and the dashboard open-positions widget.
  */
@@ -19,5 +34,7 @@ export function shouldNavigateFromRowClick(e: MouseEvent<HTMLElement>): boolean 
   if (e.defaultPrevented) return false;
   if (e.button !== 0) return false;
   if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return false;
-  return !(e.target as HTMLElement).closest('a, button, input, [role="menuitem"]');
+  const target = e.target as HTMLElement;
+  if (!e.currentTarget.contains(target)) return false;
+  return !target.closest('a, button, input, [role="menuitem"], [data-slot="row-actions"]');
 }

--- a/apps/web/src/features/positions/utils/rowNavigation.ts
+++ b/apps/web/src/features/positions/utils/rowNavigation.ts
@@ -1,0 +1,23 @@
+import type { MouseEvent } from 'react';
+
+/**
+ * Whether a click on a position table row should navigate to the detail page.
+ *
+ * Whole-row navigation is a mouse convenience layered over the symbol link —
+ * that link stays the keyboard and accessibility path, so the row itself is not
+ * focusable. Bail out whenever the browser is already going to do something
+ * better with the click:
+ *
+ * - a modified or non-primary click (open in a new tab / window / background)
+ * - a click that landed on a genuinely interactive element inside the row: the
+ *   symbol link, or the actions menu trigger, both of which handle themselves
+ * - a click something else already handled (`preventDefault`)
+ *
+ * Shared by the positions list and the dashboard open-positions widget.
+ */
+export function shouldNavigateFromRowClick(e: MouseEvent<HTMLElement>): boolean {
+  if (e.defaultPrevented) return false;
+  if (e.button !== 0) return false;
+  if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return false;
+  return !(e.target as HTMLElement).closest('a, button, input, [role="menuitem"]');
+}

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -17,3 +17,16 @@ if (typeof window !== 'undefined') {
     dispatchEvent: vi.fn(),
   });
 }
+
+// jsdom does not implement ResizeObserver either, and several Radix primitives
+// (Switch, Select, Popover) construct one on mount — without this any test
+// rendering them dies with "ResizeObserver is not defined". A no-op observer is
+// enough: nothing under test asserts on resize callbacks. `DashboardGrid.test`
+// installs its own instrumented double over the top and restores this one.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}

--- a/e2e/tests/dashboard-event-bus.spec.ts
+++ b/e2e/tests/dashboard-event-bus.spec.ts
@@ -212,10 +212,13 @@ test.describe('Dashboard — cross-tab close-position event bus', () => {
       },
     });
     expect(closeRes.status(), 'POST exit fill').toBe(201);
-    const finalCloseRes = await tabA.request.post(`/api/positions/${positionId}/close`, {
-      data: { closedAt: '2026-05-02T15:00:00.000Z' },
-    });
-    expect(finalCloseRes.status(), 'POST /positions/:id/close').toBe(200);
+
+    // The balancing exit closes the position by itself — no separate close
+    // call, which would 409. This still exercises what the test is about: the
+    // close-hook writes its ledger row, so Tab B's balances go stale.
+    const detailRes = await tabA.request.get(`/api/positions/${positionId}`);
+    expect(detailRes.status(), 'GET /positions/:id').toBe(200);
+    expect((await detailRes.json()).status, 'auto-closed by the balancing exit').toBe('closed');
 
     // --- Switch focus to Tab B → refetchOnWindowFocus fires ---
     // The cross-tab refresh rides TanStack Query's refetchOnWindowFocus, not the

--- a/e2e/tests/expenses-tax.spec.ts
+++ b/e2e/tests/expenses-tax.spec.ts
@@ -207,11 +207,20 @@ async function createClosedPosition(
   });
   expect(exitRes.status(), 'POST exit fill').toBe(201);
 
-  // 5. Close (fires the ledger close-hook → realised P&L → wash-sale check)
-  const closeRes = await req.post(`/api/positions/${position.id}/close`, {
-    data: { closedAt: input.exitAt },
-  });
-  expect(closeRes.status(), 'POST /positions/:id/close').toBe(200);
+  // 5. The balancing exit above auto-closes the position, which is what fires
+  //    the ledger close-hook → realised P&L → wash-sale check. There is no
+  //    separate close step: the route would 409 against an already-closed
+  //    position. Assert the resulting state instead — these fixtures key off
+  //    the exact closedAt for tax-year and wash-sale windows, so a drift
+  //    between the final exit and the close must fail loudly rather than
+  //    silently move a position into another period.
+  const detailRes = await req.get(`/api/positions/${position.id}`);
+  expect(detailRes.status(), 'GET /positions/:id').toBe(200);
+  const detail = await detailRes.json();
+  expect(detail.status, 'auto-closed by the balancing exit').toBe('closed');
+  expect(new Date(detail.closedAt).toISOString(), 'closedAt == final exit fill').toBe(
+    new Date(input.exitAt).toISOString(),
+  );
 
   return { positionId: position.id };
 }

--- a/packages/shared/src/schemas/position.ts
+++ b/packages/shared/src/schemas/position.ts
@@ -155,6 +155,10 @@ export const PositionListItemSchema = z.object({
   updatedAt: z.string(),
   accountName: z.string(),
   accountCurrency: z.string(),
+  // Account IANA timezone — same role as on the detail: it defines the trading
+  // day for R13's same-day reopen rule, so a list row can decide whether to
+  // offer Reopen without refetching the detail.
+  accountTimezone: z.string(),
   realizedPnl: z.number().nullable(),
   returnPercentage: z.number().nullable(),
   avgEntryPrice: z.number().nullable(),


### PR DESCRIPTION
Position rows were pure data: every lifecycle action lived only on the detail page, so the listing read as inert. This adds per-row actions to the positions list and the dashboard widget, and fixes what surfaced while building them.

## Row actions

Each row ends in a strip of discrete icon buttons — not a `⋯` overflow menu. The first cut followed the account-row precedent, but a transparent glyph trigger at the far-right edge of a thirteen-column table is not findable, and these actions are the point of the row rather than an overflow afterthought.

| Status | Actions |
| --- | --- |
| draft | Add to position · Open position *(disabled until an entry fill exists)* · Delete |
| open | Add to position · Reduce position *(disabled once nothing is open)* · Delete |
| closed | Reopen *(only inside the R13 same-day window)* · Delete |

Add/Reduce are single-purpose entry and exit buttons; the direction is the decision, so making the user open a dialog to state it buried the only thing the button was for. Every button carries a text accessible name and a tooltip; a disabled one swaps the tooltip for what would unlock it.

The whole row now navigates to the detail page — already required by R10-AC3, but only the symbol cell ever implemented it. The guard leaves modified and middle clicks to the browser so ctrl-click still opens a new tab.

## Auto-close on a balancing exit

"Fully exited but still open" was a state with no decision left in it, and it made the Close control permanently disabled except in the instant between the final exit and the close — an affordance no user could reach.

An exit that balances entry quantity now closes the position inside the same transaction as the fill insert, reusing `closePositionTx` so the reconcile guard, the reopen guard and the ledger hook stay in one place.

- **Scoped to the interactive `addFill`, not `addFillTx`.** `csv-import` and the demo seed call `addFillTx` directly and drive their own `closePositionTx`, which would 409 against an already-closed position. Same split as `closePosition`/`closePositionTx`.
- **`closedAt` is the final exit's own timestamp, clamped up to `openedAt`.** It feeds tax and performance summaries, so stamping "now" onto a trade journalled after the fact misreports the period. The clamp is load-bearing: `POST /open` with no body sets `openedAt` to now, so historical fills are routinely older than the open — unclamped, the close-date guard rejected the request and the fill itself was lost.
- **Atomic.** A close hook that throws rolls back the triggering fill too; a saved exit whose close never landed is the exact inconsistency this removes.

`POST /:id/close` survives for the residual path that does not auto-close — a fill edited up to full size — and for the importers.

## Two pre-existing bugs fixed

**The add-fill dialog could never submit.** The form validated the raw `datetime-local` value (`YYYY-MM-DDTHH:mm`) against `CreateFillSchema`, whose `.datetime()` rule demands a full ISO instant. Validation failed, `handleSubmit` never reached the mutation, and nothing rendered the error — clicking Add silently did nothing. Now validated against the widget's own format, still converted to ISO before the request, with field errors rendered so a rejected submit can't look like a dead button.

**The delete confirmation did not name the position**, which the R4 amendment requires. With a row of identical trash icons the dialog is the only confirmation of *which* position is about to be destroyed.

## Fill dialog

- Quantity presets (¼ ⅓ ½ ¾ All) as fractions of currently-open size, exit-only, always rounded **down** so an exit cannot exceed the open size; `All` returns it exactly, and options floor to whole contracts.
- Price prefilled by direction: entry from average entry, exit from target.
- Fees shown as a live read-only preview computed from the account's brokerage schedule via the shared `calculateFees`, and **submitted as `0`** — manual fill fees and the server's `brokerageFees` are additive, so writing the previewed value would bill it twice. An Override switch restores manual entry.

## Also

Open and Close are now rendered-and-disabled rather than hidden, per R11-AC4/AC5, with the reason on a tooltip. `accountTimezone` added to `PositionListItemSchema` so a list row can evaluate the same-day reopen window without refetching the detail. `ResizeObserver` shimmed in the web test setup alongside the existing `matchMedia` shim.

## Verification

Full API suite (1828), full web + shared suites (1285), `check-types`, eslint, build, and the per-widget bundle gate all pass. The dashboard widget's lazy chunk measures 756 bytes against its 20 KB budget.
