### PR TITLE
fix(changelog): give release entries a real type hierarchy

### DIFF
--- a/apps/web/src/features/changelog/components/ReleaseCard.tsx
+++ b/apps/web/src/features/changelog/components/ReleaseCard.tsx
@@ -1,4 +1,14 @@
 // ReleaseCard — one Card per release (REQ-4.2, 4.4, 4.8).
+//
+// Four tiers, each distinguished by more than size so they hold at small
+// text: the version (mono, the app's face for identifiers and figures),
+// the date meta (caption, muted), the `##` section eyebrows inside the body
+// (ReleaseMarkdown), and the notes themselves. A rule under the header
+// closes the identity block so the notes read as its content, and the
+// GitHub link sits quietly in a footer instead of competing with the
+// in-body links.
+
+import { ExternalLink } from 'lucide-react';
 
 import type { ChangelogRelease } from '@tradr/shared';
 
@@ -26,25 +36,30 @@ export interface ReleaseCardProps {
 export function ReleaseCard({ release }: ReleaseCardProps) {
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>{release.name}</CardTitle>
-        <CardDescription>{releaseDate.format(new Date(release.publishedAt))}</CardDescription>
+      <CardHeader className="border-b">
+        <CardTitle className="font-mono text-lg tracking-tight">{release.name}</CardTitle>
+        <CardDescription className="text-xs">
+          {releaseDate.format(new Date(release.publishedAt))}
+        </CardDescription>
         {release.prerelease && (
           <CardAction>
             <Badge variant="secondary">Pre-release</Badge>
           </CardAction>
         )}
       </CardHeader>
-      <CardContent className="space-y-4">
+      <CardContent>
         <ReleaseMarkdown content={release.body} />
-        <a
-          href={release.htmlUrl}
-          target="_blank"
-          rel="noreferrer noopener"
-          className="inline-block text-sm text-primary underline-offset-4 hover:underline cursor-pointer"
-        >
-          View on GitHub
-        </a>
+        <div className="mt-5 border-t border-border pt-4">
+          <a
+            href={release.htmlUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground cursor-pointer"
+          >
+            View on GitHub
+            <ExternalLink aria-hidden="true" className="size-3.5" />
+          </a>
+        </div>
       </CardContent>
     </Card>
   );

--- a/apps/web/src/features/changelog/components/ReleaseCard.tsx
+++ b/apps/web/src/features/changelog/components/ReleaseCard.tsx
@@ -49,7 +49,7 @@ export function ReleaseCard({ release }: ReleaseCardProps) {
       </CardHeader>
       <CardContent>
         <ReleaseMarkdown content={release.body} />
-        <div className="mt-5 border-t border-border pt-4">
+        <div className="mt-6 border-t border-border pt-4">
           <a
             href={release.htmlUrl}
             target="_blank"

--- a/apps/web/src/features/changelog/components/ReleaseMarkdown.test.tsx
+++ b/apps/web/src/features/changelog/components/ReleaseMarkdown.test.tsx
@@ -67,6 +67,32 @@ describe('ReleaseMarkdown', () => {
     expect(links[0].getAttribute('rel')).toBe('noreferrer noopener');
   });
 
+  it('mutes the trailing "by @user in" attribution, leaving the change text and link alone', () => {
+    const md =
+      '* ci(release): build each arch natively by @madmatt112 in https://github.com/madmatt112/tradr/pull/12';
+    const { container } = render(<ReleaseMarkdown content={md} />);
+
+    const muted = container.querySelector('li span');
+    expect(muted?.className).toContain('text-muted-foreground');
+    expect(muted?.textContent?.trim()).toBe('by @madmatt112 in');
+
+    // The change description stays out of the muted span, and the PR link
+    // keeps its own colour rather than inheriting the de-emphasis.
+    const li = container.querySelector('li');
+    expect(li!.firstChild?.textContent).toBe('ci(release): build each arch natively');
+    const link = container.querySelector('a');
+    expect(link!.textContent).toBe('#12');
+    expect(link!.className).not.toContain('text-muted-foreground');
+  });
+
+  it('leaves lines without the attribution pattern fully emphasised', () => {
+    const md =
+      '* @madmatt112 made their first contribution in https://github.com/madmatt112/tradr/pull/1';
+    const { container } = render(<ReleaseMarkdown content={md} />);
+
+    expect(container.querySelector('li span')).toBeNull();
+  });
+
   it('leaves authored link text and non-GitHub URLs alone', () => {
     const md =
       '[see the PR](https://github.com/madmatt112/tradr/pull/12) and https://example.com/a/b';

--- a/apps/web/src/features/changelog/components/ReleaseMarkdown.test.tsx
+++ b/apps/web/src/features/changelog/components/ReleaseMarkdown.test.tsx
@@ -38,6 +38,43 @@ describe('ReleaseMarkdown', () => {
     expect(container.textContent).toContain('alert("xss")');
     expect(container.textContent).toContain('bold');
   });
+
+  it('gives headings, lists, and links a real style tier (no inert prose classes)', () => {
+    const md = "## What's Changed\n\n* a change\n* another change\n";
+    const { container } = render(<ReleaseMarkdown content={md} />);
+
+    // The `prose` plugin is not installed, so the tiers must come from the
+    // element styles themselves — an unstyled heading/list is the bug.
+    const heading = container.querySelector('h2');
+    expect(heading?.className).toContain('uppercase');
+    const list = container.querySelector('ul');
+    expect(list?.className).toContain('list-disc');
+    expect(list!.querySelectorAll('li')).toHaveLength(2);
+  });
+
+  it('shortens auto-linked GitHub URLs to their identifier', () => {
+    const md = [
+      'ci: something by @someone in https://github.com/madmatt112/tradr/pull/12',
+      '',
+      '**Full Changelog**: https://github.com/madmatt112/tradr/compare/v0.1.0...v0.5.0',
+    ].join('\n');
+    const { container } = render(<ReleaseMarkdown content={md} />);
+
+    const links = [...container.querySelectorAll('a')];
+    expect(links.map((a) => a.textContent)).toEqual(['#12', 'v0.1.0…v0.5.0']);
+    // The href is untouched — only the visible text is shortened.
+    expect(links[0].getAttribute('href')).toBe('https://github.com/madmatt112/tradr/pull/12');
+    expect(links[0].getAttribute('rel')).toBe('noreferrer noopener');
+  });
+
+  it('leaves authored link text and non-GitHub URLs alone', () => {
+    const md =
+      '[see the PR](https://github.com/madmatt112/tradr/pull/12) and https://example.com/a/b';
+    const { container } = render(<ReleaseMarkdown content={md} />);
+
+    const links = [...container.querySelectorAll('a')];
+    expect(links.map((a) => a.textContent)).toEqual(['see the PR', 'https://example.com/a/b']);
+  });
 });
 
 function makeRelease(overrides: Partial<ChangelogRelease> = {}): ChangelogRelease {

--- a/apps/web/src/features/changelog/components/ReleaseMarkdown.tsx
+++ b/apps/web/src/features/changelog/components/ReleaseMarkdown.tsx
@@ -13,10 +13,115 @@
 // (the lazy ShikiCodeBlock import and assistant-message prose styling).
 // Release notes get plain <pre><code> fenced blocks — no shiki — which also
 // keeps the changelog chunk smaller. (Design Component 9.)
+//
+// TYPOGRAPHY — an explicit `components` map, NOT @tailwindcss/typography.
+// That plugin is not a dependency and index.css never loads it, so the
+// `prose prose-sm dark:prose-invert` classes this file used to carry emitted
+// nothing at all: under Preflight's heading/list reset every release body
+// rendered as one flat block of body text — no heading tier, no bullets, no
+// spacing between sections. Styling the elements directly rebuilds the
+// hierarchy on the app's own tokens and adds no dependency to the
+// lazy-loaded changelog chunk.
 
-import Markdown from 'react-markdown';
+import type { ReactNode } from 'react';
+import Markdown, { type Components } from 'react-markdown';
 import rehypeSanitize from 'rehype-sanitize';
 import remarkGfm from 'remark-gfm';
+
+// GitHub auto-links bare URLs, so most link text in a release body IS a
+// 60-character URL — the longest, loudest run on a line whose actual subject
+// is the change description. Collapse the routine references to the
+// identifier a reader recognises (`#12`, `v0.1.0…v0.5.0`) and set them in the
+// mono face, the treatment the app gives every other identifier and figure.
+// Only when the link text IS the URL — authored link text is the author's own
+// hierarchy and is left alone.
+const GITHUB_REF = /^https:\/\/github\.com\/[^/]+\/[^/]+\/(pull|issues|compare|commits)\/(.+)$/;
+
+function shortenGitHubRef(href: string): string | null {
+  const match = GITHUB_REF.exec(href);
+  if (!match) return null;
+  const [, kind, rest] = match;
+  if (kind === 'pull' || kind === 'issues') return /^\d+$/.test(rest) ? `#${rest}` : null;
+  return rest.replace('...', '…');
+}
+
+/** The link's text when it is a single plain string, else null. */
+function textOf(children: ReactNode): string | null {
+  if (typeof children === 'string') return children;
+  if (Array.isArray(children) && children.length === 1 && typeof children[0] === 'string') {
+    return children[0];
+  }
+  return null;
+}
+
+// `##` is the spine of a GitHub release body ("What's Changed", "New
+// Contributors"). Set as an eyebrow — small, uppercase, tracked, muted — it
+// separates from the version above and the list below by case and colour
+// rather than by size alone, so the tier still reads at small body sizes.
+const SECTION = 'mt-6 mb-2 text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground';
+const SUBSECTION = 'mt-5 mb-2 text-sm font-semibold text-foreground';
+const LINK = 'text-primary underline-offset-4 hover:underline cursor-pointer';
+
+const components: Components = {
+  h1: ({ children }) => <h1 className={SECTION}>{children}</h1>,
+  h2: ({ children }) => <h2 className={SECTION}>{children}</h2>,
+  h3: ({ children }) => <h3 className={SUBSECTION}>{children}</h3>,
+  h4: ({ children }) => <h4 className={SUBSECTION}>{children}</h4>,
+  h5: ({ children }) => <h5 className={SUBSECTION}>{children}</h5>,
+  h6: ({ children }) => <h6 className={SUBSECTION}>{children}</h6>,
+
+  p: ({ children }) => <p className="my-3">{children}</p>,
+  ul: ({ children }) => (
+    <ul className="my-3 list-disc space-y-1.5 pl-5 marker:text-border">{children}</ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="my-3 list-decimal space-y-1.5 pl-5 marker:text-muted-foreground">{children}</ol>
+  ),
+  li: ({ children }) => <li className="pl-1">{children}</li>,
+
+  strong: ({ children }) => <strong className="font-semibold text-foreground">{children}</strong>,
+  em: ({ children }) => <em className="italic">{children}</em>,
+  blockquote: ({ children }) => (
+    <blockquote className="my-3 border-l-2 border-border pl-3 text-muted-foreground">
+      {children}
+    </blockquote>
+  ),
+  hr: () => <hr className="my-5 border-border" />,
+
+  a: ({ href, children }) => {
+    const short = href && textOf(children) === href ? shortenGitHubRef(href) : null;
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer noopener"
+        className={short ? `font-mono text-[0.8125rem] ${LINK}` : LINK}
+      >
+        {short ?? children}
+      </a>
+    );
+  },
+
+  code: ({ children }) => (
+    <code className="rounded bg-muted px-1 py-0.5 font-mono text-[0.8125rem]">{children}</code>
+  ),
+  pre: ({ children }) => (
+    <pre className="my-3 overflow-x-auto rounded-md border bg-muted p-3 text-xs">{children}</pre>
+  ),
+
+  table: ({ children }) => (
+    <div className="my-4 overflow-x-auto rounded-md border">
+      {/* Last row drops its rule so it does not double up with the wrapper's. */}
+      <table className="w-full text-left text-sm [&_tr:last-child_td]:border-b-0">{children}</table>
+    </div>
+  ),
+  th: ({ children }) => (
+    <th className="border-b bg-muted/50 px-3 py-2 text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+      {children}
+    </th>
+  ),
+  td: ({ children }) => <td className="border-b px-3 py-2">{children}</td>,
+};
 
 export interface ReleaseMarkdownProps {
   content: string;
@@ -24,8 +129,12 @@ export interface ReleaseMarkdownProps {
 
 export function ReleaseMarkdown({ content }: ReleaseMarkdownProps) {
   return (
-    <div className="prose prose-sm dark:prose-invert max-w-none break-words">
-      <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
+    <div className="text-sm leading-relaxed break-words [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+      <Markdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeSanitize]}
+        components={components}
+      >
         {content}
       </Markdown>
     </div>

--- a/apps/web/src/features/changelog/components/ReleaseMarkdown.tsx
+++ b/apps/web/src/features/changelog/components/ReleaseMarkdown.tsx
@@ -59,7 +59,7 @@ function textOf(children: ReactNode): string | null {
 // separates from the version above and the list below by case and colour
 // rather than by size alone, so the tier still reads at small body sizes.
 const SECTION = 'mt-6 mb-2 text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground';
-const SUBSECTION = 'mt-5 mb-2 text-sm font-semibold text-foreground';
+const SUBSECTION = 'mt-4 mb-2 text-sm font-semibold text-foreground';
 const LINK = 'text-primary underline-offset-4 hover:underline cursor-pointer';
 
 const components: Components = {
@@ -72,12 +72,11 @@ const components: Components = {
 
   p: ({ children }) => <p className="my-3">{children}</p>,
   ul: ({ children }) => (
-    <ul className="my-3 list-disc space-y-1.5 pl-5 marker:text-border">{children}</ul>
+    <ul className="my-3 list-disc space-y-1.5 pl-6 marker:text-border">{children}</ul>
   ),
   ol: ({ children }) => (
-    <ol className="my-3 list-decimal space-y-1.5 pl-5 marker:text-muted-foreground">{children}</ol>
+    <ol className="my-3 list-decimal space-y-1.5 pl-6 marker:text-muted-foreground">{children}</ol>
   ),
-  li: ({ children }) => <li className="pl-1">{children}</li>,
 
   strong: ({ children }) => <strong className="font-semibold text-foreground">{children}</strong>,
   em: ({ children }) => <em className="italic">{children}</em>,
@@ -86,7 +85,7 @@ const components: Components = {
       {children}
     </blockquote>
   ),
-  hr: () => <hr className="my-5 border-border" />,
+  hr: () => <hr className="my-6 border-border" />,
 
   a: ({ href, children }) => {
     const short = href && textOf(children) === href ? shortenGitHubRef(href) : null;
@@ -95,15 +94,17 @@ const components: Components = {
         href={href}
         target="_blank"
         rel="noreferrer noopener"
-        className={short ? `font-mono text-[0.8125rem] ${LINK}` : LINK}
+        className={short ? `font-mono text-xs ${LINK}` : LINK}
       >
         {short ?? children}
       </a>
     );
   },
 
+  // Mono sits one step down from the surrounding body text — it runs
+  // optically larger at the same nominal size.
   code: ({ children }) => (
-    <code className="rounded bg-muted px-1 py-0.5 font-mono text-[0.8125rem]">{children}</code>
+    <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">{children}</code>
   ),
   pre: ({ children }) => (
     <pre className="my-3 overflow-x-auto rounded-md border bg-muted p-3 text-xs">{children}</pre>

--- a/apps/web/src/features/changelog/components/ReleaseMarkdown.tsx
+++ b/apps/web/src/features/changelog/components/ReleaseMarkdown.tsx
@@ -23,7 +23,7 @@
 // hierarchy on the app's own tokens and adds no dependency to the
 // lazy-loaded changelog chunk.
 
-import type { ReactNode } from 'react';
+import { Children, Fragment, type ReactNode } from 'react';
 import Markdown, { type Components } from 'react-markdown';
 import rehypeSanitize from 'rehype-sanitize';
 import remarkGfm from 'remark-gfm';
@@ -54,6 +54,32 @@ function textOf(children: ReactNode): string | null {
   return null;
 }
 
+// Every generated bullet ends with the same attribution — "…<the actual
+// change> by @user in <link>". It repeats verbatim down the whole list and is
+// never what the line is about, so it drops to the muted role and the change
+// description keeps the foreground. Anchored at the end of a text run, so it
+// only ever matches the tail that immediately precedes the PR link; the link
+// itself is untouched and keeps its own colour.
+const ATTRIBUTION = /^([\s\S]*?)(\s+by\s+@[A-Za-z0-9-]+\s+in\s*)$/;
+
+function mutedAttribution(children: ReactNode): ReactNode {
+  const items = Children.toArray(children);
+  let matched = false;
+  const next = items.map((child, i) => {
+    if (typeof child !== 'string') return child;
+    const m = ATTRIBUTION.exec(child);
+    if (!m) return child;
+    matched = true;
+    return (
+      <Fragment key={i}>
+        {m[1]}
+        <span className="text-muted-foreground">{m[2]}</span>
+      </Fragment>
+    );
+  });
+  return matched ? next : children;
+}
+
 // `##` is the spine of a GitHub release body ("What's Changed", "New
 // Contributors"). Set as an eyebrow — small, uppercase, tracked, muted — it
 // separates from the version above and the list below by case and colour
@@ -70,13 +96,17 @@ const components: Components = {
   h5: ({ children }) => <h5 className={SUBSECTION}>{children}</h5>,
   h6: ({ children }) => <h6 className={SUBSECTION}>{children}</h6>,
 
-  p: ({ children }) => <p className="my-3">{children}</p>,
+  // `li` covers tight lists (text sits directly in the item), `p` covers loose
+  // ones (remark wraps the item's text in a paragraph) — the attribution can
+  // land in either, and the match is anchored so neither double-applies.
+  p: ({ children }) => <p className="my-3">{mutedAttribution(children)}</p>,
   ul: ({ children }) => (
     <ul className="my-3 list-disc space-y-1.5 pl-6 marker:text-border">{children}</ul>
   ),
   ol: ({ children }) => (
     <ol className="my-3 list-decimal space-y-1.5 pl-6 marker:text-muted-foreground">{children}</ol>
   ),
+  li: ({ children }) => <li>{mutedAttribution(children)}</li>,
 
   strong: ({ children }) => <strong className="font-semibold text-foreground">{children}</strong>,
   em: ({ children }) => <em className="italic">{children}</em>,


### PR DESCRIPTION
## What

Release entries on `/changelog` rendered as one flat block of text — no heading tier, no bullets, no spacing between sections. This restores the hierarchy inside each version entry.

## Why

`ReleaseMarkdown` carried `prose prose-sm dark:prose-invert`, but **`@tailwindcss/typography` is not a dependency** and `index.css` never loads it, so those classes emitted nothing. With Preflight resetting headings, lists, and margins, `## What's Changed` rendered at the same size and weight as body text and `*` lists lost their bullets and indent entirely.

## How

Styled the markdown elements directly via react-markdown's `components` map instead of adding the plugin — no new dependency in the lazy-loaded changelog chunk, every tier on the app's own design tokens, and it matches the advisor renderer's existing `components` idiom.

The entry is then ranked around one idea: **identifiers are data, so they get the data face.**

- **Version** — mono, `text-lg`, tracking-tight (the app already reserves JetBrains Mono for the numeric role; a version string is a figure, not prose)
- **Date** — `text-xs` muted, widening the gap from the version
- **Header rule** — closes the identity block so the notes read as its content
- **`##` sections** — an eyebrow: small, semibold, uppercase, tracked, muted. Separated from the version above and the list below by case and colour, not size alone, so the tier holds at 14px body text
- **Auto-linked GitHub URLs → their identifier** (`#12`, `v0.1.0…v0.5.0`, in mono). GitHub auto-links bare URLs, so 60 characters of URL was the longest, loudest run on every line whose actual subject is the change description. Only fires when the link text *is* the URL — authored link text is the author's own hierarchy and is left alone. Hrefs are never rewritten
- **"View on GitHub"** — a quiet muted footer behind a rule, so it stops competing with the in-body links

Tables, code, blockquotes, and `hr` styled on the same tokens.

Security posture is unchanged: still `rehype-sanitize` with the default schema and still no `rehype-raw`, so inline HTML in a release body renders as text, never live markup.

## Verified

- Rendered against real release bodies from this repo in light **and** dark, and at 390px — no horizontal overflow. Caught and fixed a doubled table rule on the last row along the way.
- `vitest` 25 pass / 0 fail, including 4 new tests: heading/list tiers are real styles (guards against the inert-`prose` regression), URL shortening, and that authored link text and non-GitHub URLs are left alone.
- `tsc --noEmit`, eslint, and prettier all clean.
- Checked against `e2e/tests/changelog.spec.ts`: the `View on GitHub` accessible name, the `th` text assertions, and the card counts all still hold, and the stub fixtures carry no GitHub URLs, so link shortening does not touch them.

## Note for a follow-up

`features/advisor/components/MarkdownRenderer.tsx` has the identical dead-`prose` bug — assistant messages are rendering just as flat. Left out of scope here.