### PR TITLE
feat(positions): make play the whole draft workflow

### DIFF
--- a/apps/web/src/features/positions/components/FillDialog.test.tsx
+++ b/apps/web/src/features/positions/components/FillDialog.test.tsx
@@ -194,6 +194,34 @@ describe('FillDialog — submitted fees avoid double-counting', () => {
   });
 });
 
+// The row chains "open the position" off a successful add, and cancels that
+// intent from onOpenChange — so the ordering here is load-bearing.
+describe('FillDialog — onAdded', () => {
+  it('fires on a successful add, before the dialog closes', async () => {
+    const calls: string[] = [];
+    renderDialog({
+      defaultType: 'entry',
+      onAdded: () => calls.push('added'),
+      onOpenChange: (open: boolean) => calls.push(open ? 'open' : 'close'),
+    });
+
+    fireEvent.change(field('Quantity'), { target: { value: '10' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    await waitFor(() => expect(calls).toContain('added'));
+    expect(calls).toEqual(['added', 'close']);
+  });
+
+  it('does not fire when the dialog is cancelled', () => {
+    const onAdded = vi.fn();
+    renderDialog({ defaultType: 'entry', onAdded });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onAdded).not.toHaveBeenCalled();
+  });
+});
+
 describe('FillDialog — single-purpose type', () => {
   it('hides the type picker when the caller fixed the direction', () => {
     renderDialog({ defaultType: 'exit' });

--- a/apps/web/src/features/positions/components/FillDialog.tsx
+++ b/apps/web/src/features/positions/components/FillDialog.tsx
@@ -76,6 +76,13 @@ interface Props {
    * none of those apply and the recorded fee must stay editable.
    */
   position?: FillPositionContext;
+  /**
+   * Fired after a fill is successfully ADDED (never on edit, never on cancel),
+   * and deliberately BEFORE `onOpenChange(false)` — callers that chain a
+   * follow-up action off the save use `onOpenChange` to cancel that intent, so
+   * the close must not run first and clear it.
+   */
+  onAdded?: () => void;
 }
 
 export function FillDialog({
@@ -87,6 +94,7 @@ export function FillDialog({
   fill,
   defaultType,
   position,
+  onAdded,
 }: Props) {
   const isEdit = !!fill;
   const addFill = useAddFill(positionId);
@@ -180,6 +188,8 @@ export function FillDialog({
       // number here would have the position count it twice.
       const fees = feeIsCalculable && !feeOverride ? '0' : data.fees;
       await addFill.mutateAsync({ ...data, fees, filledAt });
+      // Before the close, per onAdded's contract.
+      onAdded?.();
     }
     onOpenChange(false);
     form.reset();

--- a/apps/web/src/features/positions/components/PositionRowActions.test.tsx
+++ b/apps/web/src/features/positions/components/PositionRowActions.test.tsx
@@ -17,8 +17,35 @@ vi.mock('../hooks/usePosition', () => ({
   useReopenPosition: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
+// Stub exposes the two outcomes the row chains off: a successful add (onAdded
+// fires BEFORE the close, per its contract) and a cancel (close only).
 vi.mock('./FillDialog', () => ({
-  FillDialog: ({ open }: { open: boolean }) => (open ? <div data-testid="fill-dialog" /> : null),
+  FillDialog: ({
+    open,
+    onAdded,
+    onOpenChange,
+  }: {
+    open: boolean;
+    onAdded?: () => void;
+    onOpenChange: (open: boolean) => void;
+  }) =>
+    open ? (
+      <div data-testid="fill-dialog">
+        <button
+          type="button"
+          data-testid="fill-dialog-added"
+          onClick={() => {
+            onAdded?.();
+            onOpenChange(false);
+          }}
+        />
+        <button
+          type="button"
+          data-testid="fill-dialog-cancel"
+          onClick={() => onOpenChange(false)}
+        />
+      </div>
+    ) : null,
 }));
 
 import { PositionRowActions } from './PositionRowActions';
@@ -70,17 +97,27 @@ describe('PositionRowActions — actions are inline buttons, not a menu', () => 
     }
   });
 
-  it('offers Add to position on draft and open, but not on closed', () => {
-    renderActions({ status: 'draft' });
-    expect(action('Add to position')).toBeTruthy();
-    cleanup();
-
+  // A draft is a plan with no units, so there is nothing to add to or reduce.
+  it('offers Add to position only on an open position', () => {
     renderActions({ status: 'open' });
     expect(action('Add to position')).toBeTruthy();
     cleanup();
 
+    renderActions({ status: 'draft' });
+    expect(screen.queryByRole('button', { name: 'Add to position' })).toBeNull();
+    cleanup();
+
     renderActions({ status: 'closed', closedAt: `${TODAY_UTC}T13:00:00.000Z` });
     expect(screen.queryByRole('button', { name: 'Add to position' })).toBeNull();
+  });
+
+  it('leaves a draft row with only Open position and Delete', () => {
+    renderActions({ status: 'draft', totalEntryQuantity: 0, totalExitQuantity: 0 });
+    const labels = screen
+      .getAllByRole('button')
+      .map((b) => b.getAttribute('aria-label'))
+      .filter(Boolean);
+    expect(labels).toEqual(['Open position', 'Delete']);
   });
 
   // Exit fills 409 on a draft (R5-AC3), so the "−" button is open-only.
@@ -105,14 +142,16 @@ describe('PositionRowActions — actions are inline buttons, not a menu', () => 
 
 // R11-AC4: Open is shown-and-disabled on a draft, never hidden.
 describe('PositionRowActions — lifecycle gating', () => {
+  // Play is never disabled on a draft — with no entry fill it collects one
+  // first, so a freshly created draft is never stranded in the list.
   it('enables Open position on a draft that has an entry fill', () => {
     renderActions({ status: 'draft', totalEntryQuantity: 100, totalExitQuantity: 0 });
     expect(action('Open position').disabled).toBe(false);
   });
 
-  it('shows Open position disabled on a draft with no fills yet', () => {
+  it('enables Open position on a draft with no fills yet', () => {
     renderActions({ status: 'draft', totalEntryQuantity: 0, totalExitQuantity: 0 });
-    expect(action('Open position').disabled).toBe(true);
+    expect(action('Open position').disabled).toBe(false);
   });
 
   it('does not offer Open position on a non-draft position', () => {
@@ -140,7 +179,7 @@ describe('PositionRowActions — lifecycle gating', () => {
 });
 
 describe('PositionRowActions — actions fire the right mutation', () => {
-  it('Open position calls the open mutation', () => {
+  it('Open position calls the open mutation when an entry fill already exists', () => {
     const mutate = vi.fn();
     vi.mocked(useOpenPosition).mockReturnValue({
       mutate,
@@ -151,6 +190,67 @@ describe('PositionRowActions — actions fire the right mutation', () => {
     fireEvent.click(action('Open position'));
 
     expect(mutate).toHaveBeenCalledWith({});
+    expect(screen.queryByTestId('fill-dialog')).toBeNull();
+  });
+
+  // The server rejects an open with no entry fill, so play collects one first
+  // rather than sitting disabled.
+  it('Open position on an empty draft collects the entry instead of mutating', () => {
+    const mutate = vi.fn();
+    vi.mocked(useOpenPosition).mockReturnValue({
+      mutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useOpenPosition>);
+
+    renderActions({ status: 'draft', totalEntryQuantity: 0 });
+    fireEvent.click(action('Open position'));
+
+    expect(screen.getByTestId('fill-dialog')).toBeTruthy();
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it('opens the position once that entry fill saves', () => {
+    const mutate = vi.fn();
+    vi.mocked(useOpenPosition).mockReturnValue({
+      mutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useOpenPosition>);
+
+    renderActions({ status: 'draft', totalEntryQuantity: 0 });
+    fireEvent.click(action('Open position'));
+    fireEvent.click(screen.getByTestId('fill-dialog-added'));
+
+    expect(mutate).toHaveBeenCalledWith({});
+  });
+
+  it('does not open the position if the entry dialog is cancelled', () => {
+    const mutate = vi.fn();
+    vi.mocked(useOpenPosition).mockReturnValue({
+      mutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useOpenPosition>);
+
+    renderActions({ status: 'draft', totalEntryQuantity: 0 });
+    fireEvent.click(action('Open position'));
+    fireEvent.click(screen.getByTestId('fill-dialog-cancel'));
+
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  // "+" on an open position must not chain an open — that intent belongs to
+  // play alone, and an open position has nothing to transition to.
+  it('does not open the position when a fill is added via "+"', () => {
+    const mutate = vi.fn();
+    vi.mocked(useOpenPosition).mockReturnValue({
+      mutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useOpenPosition>);
+
+    renderActions({ status: 'open', totalEntryQuantity: 100 });
+    fireEvent.click(action('Add to position'));
+    fireEvent.click(screen.getByTestId('fill-dialog-added'));
+
+    expect(mutate).not.toHaveBeenCalled();
   });
 
   it('Reopen calls the reopen mutation', () => {

--- a/apps/web/src/features/positions/components/PositionRowActions.tsx
+++ b/apps/web/src/features/positions/components/PositionRowActions.tsx
@@ -100,15 +100,20 @@ export function PositionRowActions({ position }: Props) {
   const reopenPosition = useReopenPosition(position.id);
 
   const [fillType, setFillType] = useState<'entry' | 'exit' | null>(null);
+  /** Play opened the fill dialog to collect a draft's entry — open once it saves. */
+  const [openAfterFill, setOpenAfterFill] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
   const isDraft = position.status === 'draft';
   const isOpen = position.status === 'open';
   const isClosed = position.status === 'closed';
 
-  // R11-AC4: Open is SHOWN on a draft and merely disabled until an entry fill
-  // exists — not hidden. Reopen is different: the R11 amendment scopes it to
-  // "only when" the same-day window is open, so it stays conditionally rendered.
+  // A draft is a PLAN, not a position holding units, so there is nothing to
+  // "add to" — "+" is open-only. Play is the whole draft workflow instead: on a
+  // draft that has no entry fill yet it collects the entry first (the server
+  // rejects an open without one), then performs the transition. One button, one
+  // meaning — "start this trade" — and never disabled, so a fresh draft is never
+  // stranded in the list.
   //
   // There is deliberately NO Close action here. A balancing exit auto-closes
   // the position (R7 amendment), so "−" then All *is* the close; a separate
@@ -117,7 +122,6 @@ export function PositionRowActions({ position }: Props) {
   // the residual path that does not auto-close (editing a fill up to full size).
   const openUnits = position.totalEntryQuantity - position.totalExitQuantity;
   const hasEntryQuantity = position.totalEntryQuantity > 0;
-  const canOpen = hasEntryQuantity;
   const canReopen =
     isClosed && isOpenedTodayInAccountTz(position.openedAt, position.accountTimezone, new Date());
 
@@ -129,10 +133,9 @@ export function PositionRowActions({ position }: Props) {
           DISABLED action (which lands on the tooltip's span wrapper, not the
           button) does not fall through and navigate the row. */}
       <div data-slot="row-actions" className="flex items-center justify-end gap-1">
-        {/* Single-purpose entry/exit, replacing one dual-purpose "Add fill".
-            Exit is `open`-only — R5-AC3 409s an exit fill on a draft — and is
-            dead once nothing is left open to reduce. */}
-        {!isClosed && (
+        {/* Single-purpose entry/exit. Both are `open`-only: a draft has no
+            units to add to or reduce, and R5-AC3 409s an exit on a draft. */}
+        {isOpen && (
           <RowAction
             icon={Plus}
             label="Add to position"
@@ -155,9 +158,16 @@ export function PositionRowActions({ position }: Props) {
           <RowAction
             icon={Play}
             label="Open position"
-            disabledReason="Add an entry fill first"
-            disabled={isPending || !canOpen}
-            onClick={() => openPosition.mutate({})}
+            disabled={isPending}
+            onClick={() => {
+              if (hasEntryQuantity) {
+                openPosition.mutate({});
+                return;
+              }
+              // No entry fill yet: collect it, then open once it saves.
+              setOpenAfterFill(true);
+              setFillType('entry');
+            }}
           />
         )}
 
@@ -181,7 +191,17 @@ export function PositionRowActions({ position }: Props) {
 
       <FillDialog
         open={fillType !== null}
-        onOpenChange={(next) => !next && setFillType(null)}
+        onOpenChange={(next) => {
+          if (next) return;
+          setFillType(null);
+          // Cancelled rather than saved — drop the pending open.
+          setOpenAfterFill(false);
+        }}
+        onAdded={() => {
+          if (!openAfterFill) return;
+          setOpenAfterFill(false);
+          openPosition.mutate({});
+        }}
         positionId={position.id}
         positionStatus={position.status}
         defaultType={fillType ?? undefined}


### PR DESCRIPTION
Follow-up to #3.

"Add to position" made no sense on a draft. A draft is a plan, not a position holding units — there is nothing to add *to*. `+` and `−` are now open-only.

## The part that needed care

Removing `+` alone would strand a freshly created draft. `POST /open` rejects an open with no entry fill (`positions.service.ts:679`, *"Position must have at least one entry fill to open"*), so play would sit permanently disabled with the only remedy on another page — the same dead-button problem the `⋯` menu and the old Close button had.

So play now covers the whole draft workflow rather than being a bare state transition:

| Draft state | ▶ does |
| --- | --- |
| no entry fill | opens the entry dialog, then opens the position once it saves |
| has an entry fill | opens the position directly |

One button, one meaning — "start this trade" — and never disabled.

## Row contents now

| Status | Actions |
| --- | --- |
| draft | ▶ Open position · 🗑 Delete |
| open | ＋ Add to position · − Reduce position · 🗑 Delete |
| closed | ↺ Reopen *(same-day only)* · 🗑 Delete |

## Implementation note

`FillDialog` gains `onAdded`, fired **only** on a successful add and deliberately **before** `onOpenChange(false)`. The row cancels its pending-open intent from `onOpenChange`, so a close that ran first would clear the very intent the save is meant to trigger. That ordering is covered by tests at both ends — the dialog's own contract, and the row's chaining — including that `+` on an open position never chains an open.

## Verification

159 positions tests, 1024 across web + API positions, `check-types`, eslint, build, and the per-widget bundle gate all pass.