### PR TITLE
fix(advisor): restore markdown hierarchy in assistant messages

### DIFF
--- a/apps/web/src/features/advisor/components/MarkdownRenderer.tsx
+++ b/apps/web/src/features/advisor/components/MarkdownRenderer.tsx
@@ -11,6 +11,18 @@
 //
 // This renderer is used ONLY for assistant messages. User messages are plain
 // text (Transcript renders them without Markdown).
+//
+// TYPOGRAPHY — an explicit `components` map, NOT @tailwindcss/typography. That
+// plugin is not a dependency and index.css never loads it, so the
+// `prose prose-sm dark:prose-invert` classes this file used to carry emitted
+// nothing: under Preflight's reset, model output lost its heading tier, ALL
+// list markers (ordered numbering included), table rules, and every block
+// margin, and links rendered in the body text colour — indistinguishable from
+// prose. The changelog's ReleaseMarkdown carries the same treatment for the
+// same reason; the two stay siblings rather than a shared module because they
+// style different content at different scales (this one keeps the transcript's
+// inherited body size so assistant text matches user text, and owns the shiki
+// path; the changelog runs at text-sm and owns its own link handling).
 
 import { Suspense, lazy, type ReactNode } from 'react';
 import Markdown, { type Components } from 'react-markdown';
@@ -26,14 +38,62 @@ function extractText(children: ReactNode): string {
   return '';
 }
 
+// Three heading tiers. Models reach for `##` and `###` constantly, so those two
+// have to be told apart at a glance: `##` by weight and size, `###` by dropping
+// to a tracked, muted label. Kept modest — this is a chat reply, not a document.
+const H1 = 'mt-6 mb-2 text-lg font-semibold';
+const H2 = 'mt-6 mb-2 text-base font-semibold';
+const H3 = 'mt-4 mb-1 text-sm font-semibold uppercase tracking-[0.08em] text-muted-foreground';
+
 const components: Components = {
+  h1: ({ children }) => <h1 className={H1}>{children}</h1>,
+  h2: ({ children }) => <h2 className={H2}>{children}</h2>,
+  h3: ({ children }) => <h3 className={H3}>{children}</h3>,
+  h4: ({ children }) => <h4 className={H3}>{children}</h4>,
+  h5: ({ children }) => <h5 className={H3}>{children}</h5>,
+  h6: ({ children }) => <h6 className={H3}>{children}</h6>,
+
+  p: ({ children }) => <p className="my-3">{children}</p>,
+  // Markers carry real information in model output — an unnumbered "1. 2. 3."
+  // is a lost sequence, and a flattened sub-list is a lost relationship.
+  ul: ({ children }) => (
+    <ul className="my-3 list-disc space-y-1 pl-6 marker:text-muted-foreground">{children}</ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="my-3 list-decimal space-y-1 pl-6 marker:text-muted-foreground">{children}</ol>
+  ),
+
+  strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+  em: ({ children }) => <em className="italic">{children}</em>,
+  blockquote: ({ children }) => (
+    <blockquote className="my-3 border-l-2 border-border pl-3 text-muted-foreground">
+      {children}
+    </blockquote>
+  ),
+  hr: () => <hr className="my-6 border-border" />,
+
+  // Model output embeds links mid-sentence, where colour alone is easy to miss,
+  // so these stay underlined rather than revealing the underline on hover.
+  // External by construction — the sanitiser's default schema already bounds
+  // the protocol, and noreferrer/noopener bounds the new tab.
+  a: ({ href, children }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer noopener"
+      className="cursor-pointer text-primary underline underline-offset-4"
+    >
+      {children}
+    </a>
+  ),
+
   code({ className, children, ...props }) {
     const match = /language-(\w+)/.exec(className ?? '');
     const raw = extractText(children);
     // Inline code (no language- class and no newline) stays a simple <code>.
     if (!match && !raw.includes('\n')) {
       return (
-        <code className="rounded bg-muted px-1 py-0.5 text-sm" {...props}>
+        <code className="rounded bg-muted px-1 py-0.5 font-mono text-sm" {...props}>
           {children}
         </code>
       );
@@ -50,6 +110,24 @@ const components: Components = {
       </Suspense>
     );
   },
+  // A fenced block's `code` handler above returns its OWN block wrapper (the
+  // shiki <div> or the fallback <pre>), so react-markdown's default <pre> would
+  // wrap a block element in a <pre> — invalid, and it double-boxed the shiki
+  // output. Pass the child through and let the handler own the block.
+  pre: ({ children }) => <>{children}</>,
+
+  table: ({ children }) => (
+    <div className="my-4 overflow-x-auto rounded-md border">
+      {/* Last row drops its rule so it does not double up with the wrapper's. */}
+      <table className="w-full text-left text-sm [&_tr:last-child_td]:border-b-0">{children}</table>
+    </div>
+  ),
+  th: ({ children }) => (
+    <th className="border-b bg-muted/50 px-3 py-2 text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+      {children}
+    </th>
+  ),
+  td: ({ children }) => <td className="border-b px-3 py-2">{children}</td>,
 };
 
 export interface MarkdownRendererProps {
@@ -58,7 +136,7 @@ export interface MarkdownRendererProps {
 
 export function MarkdownRenderer({ content }: MarkdownRendererProps) {
   return (
-    <div className="prose prose-sm dark:prose-invert max-w-none break-words">
+    <div className="break-words [&_li_ol]:my-1 [&_li_ul]:my-1 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
       <Markdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeSanitize]}

--- a/apps/web/src/features/advisor/components/__tests__/MarkdownRenderer.test.tsx
+++ b/apps/web/src/features/advisor/components/__tests__/MarkdownRenderer.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+// MarkdownRenderer typography (REQ-1.13).
+//
+// These pin the properties that were silently broken while the component
+// carried `prose` classes with no @tailwindcss/typography installed: under
+// Preflight's reset the headings, list markers, table rules and block margins
+// all resolved to nothing, and links rendered in the body text colour. The
+// assertions are on the emitted classes rather than computed style because
+// jsdom does not run Tailwind — a class-less heading or list is the bug.
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { MarkdownRenderer } from '../MarkdownRenderer';
+
+afterEach(cleanup);
+
+describe('MarkdownRenderer typography', () => {
+  it('gives h1/h2/h3 distinct tiers instead of body text', () => {
+    const { container } = render(<MarkdownRenderer content={'# One\n\n## Two\n\n### Three\n'} />);
+
+    const h1 = container.querySelector('h1')!;
+    const h2 = container.querySelector('h2')!;
+    const h3 = container.querySelector('h3')!;
+    for (const h of [h1, h2, h3]) expect(h.className).not.toBe('');
+    // Each tier is told apart by something — size, then weight, then case.
+    expect(h1.className).toContain('text-lg');
+    expect(h2.className).toContain('font-semibold');
+    expect(h3.className).toContain('uppercase');
+    expect(h1.className).not.toBe(h2.className);
+    expect(h2.className).not.toBe(h3.className);
+  });
+
+  it('keeps list markers, including ordered numbering and nesting', () => {
+    const md = '- a\n- b\n  - nested\n\n1. first\n2. second\n';
+    const { container } = render(<MarkdownRenderer content={md} />);
+
+    const ul = container.querySelector('ul')!;
+    const ol = container.querySelector('ol')!;
+    // An unnumbered ordered list is lost information, not just lost styling.
+    expect(ul.className).toContain('list-disc');
+    expect(ol.className).toContain('list-decimal');
+    expect(ul.className).toContain('pl-6');
+    // The sub-list survives as a real nested list rather than being flattened.
+    expect(container.querySelector('li ul')).not.toBeNull();
+  });
+
+  it('renders links visibly distinct from prose, and safe for a new tab', () => {
+    const { container } = render(<MarkdownRenderer content="see [docs](https://example.com/x)" />);
+
+    const link = container.querySelector('a')!;
+    expect(link.getAttribute('href')).toBe('https://example.com/x');
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toBe('noreferrer noopener');
+    // Colour alone is easy to miss mid-sentence, so the underline is not
+    // hover-only — and the link must not inherit plain body styling.
+    expect(link.className).toContain('text-primary');
+    expect(link.className).toContain('underline');
+  });
+
+  it('does not wrap a fenced code block in a redundant outer <pre>', () => {
+    const { container } = render(<MarkdownRenderer content={'```ts\nconst a = 1;\n```\n'} />);
+
+    // The `code` handler emits its own block wrapper (shiki, or this Suspense
+    // fallback), so react-markdown's default <pre> would nest one inside it.
+    expect(container.querySelector('pre')).not.toBeNull();
+    expect(container.querySelector('pre pre')).toBeNull();
+  });
+
+  it('styles GFM tables with real rules', () => {
+    const md = '| Metric | Value |\n| ------ | ----- |\n| Stop | 4.20 |';
+    const { container } = render(<MarkdownRenderer content={md} />);
+
+    const table = container.querySelector('table')!;
+    expect(table.querySelectorAll('th')).toHaveLength(2);
+    expect(container.querySelector('th')!.className).not.toBe('');
+    expect(container.querySelector('td')!.className).toContain('border-b');
+  });
+
+  it('still renders inline HTML as text, never live markup (sanitize property)', () => {
+    const md = 'before <script>alert("xss")</script> after <b>bold</b>';
+    const { container } = render(<MarkdownRenderer content={md} />);
+
+    // The typography change must not have loosened the sanitiser: no
+    // rehype-raw, default schema, so tags never become live DOM elements.
+    expect(container.querySelector('script')).toBeNull();
+    expect(container.querySelector('b')).toBeNull();
+    expect(container.textContent).toContain('alert("xss")');
+    expect(container.textContent).toContain('bold');
+  });
+});


### PR DESCRIPTION
Closed by a branch rename — superseded by #8, which carries this commit unchanged plus the chat-bubble work.