### PR TITLE
feat(advisor): chat bubbles, plus a markdown hierarchy fix

### DIFF
--- a/apps/web/src/features/advisor/components/MarkdownRenderer.tsx
+++ b/apps/web/src/features/advisor/components/MarkdownRenderer.tsx
@@ -11,6 +11,18 @@
 //
 // This renderer is used ONLY for assistant messages. User messages are plain
 // text (Transcript renders them without Markdown).
+//
+// TYPOGRAPHY — an explicit `components` map, NOT @tailwindcss/typography. That
+// plugin is not a dependency and index.css never loads it, so the
+// `prose prose-sm dark:prose-invert` classes this file used to carry emitted
+// nothing: under Preflight's reset, model output lost its heading tier, ALL
+// list markers (ordered numbering included), table rules, and every block
+// margin, and links rendered in the body text colour — indistinguishable from
+// prose. The changelog's ReleaseMarkdown carries the same treatment for the
+// same reason; the two stay siblings rather than a shared module because they
+// style different content at different scales (this one keeps the transcript's
+// inherited body size so assistant text matches user text, and owns the shiki
+// path; the changelog runs at text-sm and owns its own link handling).
 
 import { Suspense, lazy, type ReactNode } from 'react';
 import Markdown, { type Components } from 'react-markdown';
@@ -26,14 +38,62 @@ function extractText(children: ReactNode): string {
   return '';
 }
 
+// Three heading tiers. Models reach for `##` and `###` constantly, so those two
+// have to be told apart at a glance: `##` by weight and size, `###` by dropping
+// to a tracked, muted label. Kept modest — this is a chat reply, not a document.
+const H1 = 'mt-6 mb-2 text-lg font-semibold';
+const H2 = 'mt-6 mb-2 text-base font-semibold';
+const H3 = 'mt-4 mb-1 text-sm font-semibold uppercase tracking-[0.08em] text-muted-foreground';
+
 const components: Components = {
+  h1: ({ children }) => <h1 className={H1}>{children}</h1>,
+  h2: ({ children }) => <h2 className={H2}>{children}</h2>,
+  h3: ({ children }) => <h3 className={H3}>{children}</h3>,
+  h4: ({ children }) => <h4 className={H3}>{children}</h4>,
+  h5: ({ children }) => <h5 className={H3}>{children}</h5>,
+  h6: ({ children }) => <h6 className={H3}>{children}</h6>,
+
+  p: ({ children }) => <p className="my-3">{children}</p>,
+  // Markers carry real information in model output — an unnumbered "1. 2. 3."
+  // is a lost sequence, and a flattened sub-list is a lost relationship.
+  ul: ({ children }) => (
+    <ul className="my-3 list-disc space-y-1 pl-6 marker:text-muted-foreground">{children}</ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="my-3 list-decimal space-y-1 pl-6 marker:text-muted-foreground">{children}</ol>
+  ),
+
+  strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+  em: ({ children }) => <em className="italic">{children}</em>,
+  blockquote: ({ children }) => (
+    <blockquote className="my-3 border-l-2 border-border pl-3 text-muted-foreground">
+      {children}
+    </blockquote>
+  ),
+  hr: () => <hr className="my-6 border-border" />,
+
+  // Model output embeds links mid-sentence, where colour alone is easy to miss,
+  // so these stay underlined rather than revealing the underline on hover.
+  // External by construction — the sanitiser's default schema already bounds
+  // the protocol, and noreferrer/noopener bounds the new tab.
+  a: ({ href, children }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer noopener"
+      className="cursor-pointer text-primary underline underline-offset-4"
+    >
+      {children}
+    </a>
+  ),
+
   code({ className, children, ...props }) {
     const match = /language-(\w+)/.exec(className ?? '');
     const raw = extractText(children);
     // Inline code (no language- class and no newline) stays a simple <code>.
     if (!match && !raw.includes('\n')) {
       return (
-        <code className="rounded bg-muted px-1 py-0.5 text-sm" {...props}>
+        <code className="rounded bg-muted px-1 py-0.5 font-mono text-sm" {...props}>
           {children}
         </code>
       );
@@ -50,6 +110,24 @@ const components: Components = {
       </Suspense>
     );
   },
+  // A fenced block's `code` handler above returns its OWN block wrapper (the
+  // shiki <div> or the fallback <pre>), so react-markdown's default <pre> would
+  // wrap a block element in a <pre> — invalid, and it double-boxed the shiki
+  // output. Pass the child through and let the handler own the block.
+  pre: ({ children }) => <>{children}</>,
+
+  table: ({ children }) => (
+    <div className="my-4 overflow-x-auto rounded-md border">
+      {/* Last row drops its rule so it does not double up with the wrapper's. */}
+      <table className="w-full text-left text-sm [&_tr:last-child_td]:border-b-0">{children}</table>
+    </div>
+  ),
+  th: ({ children }) => (
+    <th className="border-b bg-muted/50 px-3 py-2 text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+      {children}
+    </th>
+  ),
+  td: ({ children }) => <td className="border-b px-3 py-2">{children}</td>,
 };
 
 export interface MarkdownRendererProps {
@@ -58,7 +136,7 @@ export interface MarkdownRendererProps {
 
 export function MarkdownRenderer({ content }: MarkdownRendererProps) {
   return (
-    <div className="prose prose-sm dark:prose-invert max-w-none break-words">
+    <div className="break-words [&_li_ol]:my-1 [&_li_ul]:my-1 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
       <Markdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeSanitize]}

--- a/apps/web/src/features/advisor/components/Transcript.tsx
+++ b/apps/web/src/features/advisor/components/Transcript.tsx
@@ -49,6 +49,23 @@ export interface TranscriptProps {
 
 const IDLE: StreamState = { kind: 'idle' };
 
+// Chat bubbles. The row owns the side (the BUBBLE is justified, never the text
+// inside it) and the bubble owns the fill, so the two speakers are told apart
+// twice over — by position and by colour.
+//
+// `min-w-0` matters: the bubble is a flex item, whose default `min-width: auto`
+// would refuse to shrink below its content and let a wide table or code block
+// push the whole transcript sideways. With it, those keep their own
+// `overflow-x-auto` and scroll inside the bubble.
+const ROW_USER = 'flex justify-end';
+const ROW_ASSISTANT = 'flex justify-start';
+const BUBBLE = 'min-w-0 max-w-[85%] rounded-xl px-4 py-3 break-words';
+const BUBBLE_USER = 'bg-primary text-primary-foreground';
+// Deliberately a bordered card, NOT a grey fill: `muted` and `secondary` hold
+// the same value in both themes, and MarkdownRenderer's inline code and code
+// fallback are `bg-muted` — on a muted bubble they would vanish into it.
+const BUBBLE_ASSISTANT = 'border border-border bg-card';
+
 function userText(message: Message): string {
   return message.contentParts
     .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
@@ -243,49 +260,59 @@ export function Transcript({ conversationId, onRetry }: TranscriptProps) {
     <div data-testid="transcript" className="flex flex-col gap-4 p-4">
       {messages.map((message) =>
         message.role === 'user' ? (
-          <div key={message.id} data-role="user" className="whitespace-pre-wrap break-words">
-            {userText(message)}
-            {renderImageParts(message, conversationId)}
+          <div key={message.id} className={ROW_USER}>
+            <div data-role="user" className={`${BUBBLE} ${BUBBLE_USER} whitespace-pre-wrap`}>
+              {userText(message)}
+              {renderImageParts(message, conversationId)}
+            </div>
           </div>
         ) : (
-          <div key={message.id} data-role="assistant">
-            {renderAssistantParts(message, conversationId)}
+          <div key={message.id} className={ROW_ASSISTANT}>
+            <div data-role="assistant" className={`${BUBBLE} ${BUBBLE_ASSISTANT}`}>
+              {renderAssistantParts(message, conversationId)}
+            </div>
           </div>
         ),
       )}
 
       {showStreamEntry && (
-        <div data-role="assistant" data-testid="stream-entry">
-          {billingMode && (
-            <div data-testid="billing-mode" className="mb-1 text-xs text-muted-foreground">
-              {billingMode.mode === 'platform'
-                ? billingMode.fellThrough
-                  ? 'Billed with platform credits (no key for this provider).'
-                  : 'Billed with platform credits.'
-                : 'Using your own provider key (no credits charged).'}
-            </div>
-          )}
+        <div className={ROW_ASSISTANT}>
+          <div
+            data-role="assistant"
+            data-testid="stream-entry"
+            className={`${BUBBLE} ${BUBBLE_ASSISTANT}`}
+          >
+            {billingMode && (
+              <div data-testid="billing-mode" className="mb-1 text-xs text-muted-foreground">
+                {billingMode.mode === 'platform'
+                  ? billingMode.fellThrough
+                    ? 'Billed with platform credits (no key for this provider).'
+                    : 'Billed with platform credits.'
+                  : 'Using your own provider key (no credits charged).'}
+              </div>
+            )}
 
-          {tools.map((t) => (
-            <StreamingToolAffordance key={t.id} tool={t} />
-          ))}
+            {tools.map((t) => (
+              <StreamingToolAffordance key={t.id} tool={t} />
+            ))}
 
-          {stream.text.length > 0 && <MarkdownRenderer content={stream.text} />}
+            {stream.text.length > 0 && <MarkdownRenderer content={stream.text} />}
 
-          {stream.kind === 'error' && (
-            <div data-testid="stream-error" className="mt-2 flex items-center gap-3">
-              <span className="text-sm text-destructive">Response interrupted — retry?</span>
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                className="cursor-pointer"
-                onClick={onRetry}
-              >
-                Retry
-              </Button>
-            </div>
-          )}
+            {stream.kind === 'error' && (
+              <div data-testid="stream-error" className="mt-2 flex items-center gap-3">
+                <span className="text-sm text-destructive">Response interrupted — retry?</span>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="cursor-pointer"
+                  onClick={onRetry}
+                >
+                  Retry
+                </Button>
+              </div>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/apps/web/src/features/advisor/components/Transcript.tsx
+++ b/apps/web/src/features/advisor/components/Transcript.tsx
@@ -49,22 +49,31 @@ export interface TranscriptProps {
 
 const IDLE: StreamState = { kind: 'idle' };
 
-// Chat bubbles. The row owns the side (the BUBBLE is justified, never the text
-// inside it) and the bubble owns the fill, so the two speakers are told apart
-// twice over — by position and by colour.
+// Chat bubbles: you on the left, the advisor on the right. Three nested
+// elements, each with one job —
+//   ROW    justifies to a side. It is the STACK that moves, never the text
+//          inside the bubble, which stays left-read on both sides.
+//   STACK  holds the nametag over the bubble and caps the pair's width. It
+//          shrinks to its content, so a short message gets a short bubble.
+//   BUBBLE carries the fill, so the speakers are told apart twice over — by
+//          position and by colour.
 //
-// `min-w-0` matters: the bubble is a flex item, whose default `min-width: auto`
-// would refuse to shrink below its content and let a wide table or code block
-// push the whole transcript sideways. With it, those keep their own
-// `overflow-x-auto` and scroll inside the bubble.
-const ROW_USER = 'flex justify-end';
-const ROW_ASSISTANT = 'flex justify-start';
-const BUBBLE = 'min-w-0 max-w-[85%] rounded-xl px-4 py-3 break-words';
+// `min-w-0` on both STACK and BUBBLE is load-bearing: a flex item's default
+// `min-width: auto` refuses to shrink below its content, so a wide table or a
+// long code line would push the whole transcript sideways instead of scrolling
+// inside its own `overflow-x-auto` container.
+const ROW_USER = 'flex justify-start';
+const ROW_ASSISTANT = 'flex justify-end';
+const STACK = 'flex min-w-0 max-w-[85%] flex-col gap-1';
+const BUBBLE = 'min-w-0 rounded-xl px-4 py-3 break-words';
 const BUBBLE_USER = 'bg-primary text-primary-foreground';
 // Deliberately a bordered card, NOT a grey fill: `muted` and `secondary` hold
 // the same value in both themes, and MarkdownRenderer's inline code and code
 // fallback are `bg-muted` — on a muted bubble they would vanish into it.
 const BUBBLE_ASSISTANT = 'border border-border bg-card';
+// Quiet enough to read as an attribution rather than content. Aligned to the
+// bubble's own edge, so it sits over the side its speaker occupies.
+const LABEL = 'px-1 text-xs text-muted-foreground';
 
 function userText(message: Message): string {
   return message.contentParts
@@ -261,15 +270,21 @@ export function Transcript({ conversationId, onRetry }: TranscriptProps) {
       {messages.map((message) =>
         message.role === 'user' ? (
           <div key={message.id} className={ROW_USER}>
-            <div data-role="user" className={`${BUBBLE} ${BUBBLE_USER} whitespace-pre-wrap`}>
-              {userText(message)}
-              {renderImageParts(message, conversationId)}
+            <div className={STACK}>
+              <span className={`${LABEL} text-left`}>Me</span>
+              <div data-role="user" className={`${BUBBLE} ${BUBBLE_USER} whitespace-pre-wrap`}>
+                {userText(message)}
+                {renderImageParts(message, conversationId)}
+              </div>
             </div>
           </div>
         ) : (
           <div key={message.id} className={ROW_ASSISTANT}>
-            <div data-role="assistant" className={`${BUBBLE} ${BUBBLE_ASSISTANT}`}>
-              {renderAssistantParts(message, conversationId)}
+            <div className={STACK}>
+              <span className={`${LABEL} text-right`}>Advisor</span>
+              <div data-role="assistant" className={`${BUBBLE} ${BUBBLE_ASSISTANT}`}>
+                {renderAssistantParts(message, conversationId)}
+              </div>
             </div>
           </div>
         ),
@@ -277,41 +292,44 @@ export function Transcript({ conversationId, onRetry }: TranscriptProps) {
 
       {showStreamEntry && (
         <div className={ROW_ASSISTANT}>
-          <div
-            data-role="assistant"
-            data-testid="stream-entry"
-            className={`${BUBBLE} ${BUBBLE_ASSISTANT}`}
-          >
-            {billingMode && (
-              <div data-testid="billing-mode" className="mb-1 text-xs text-muted-foreground">
-                {billingMode.mode === 'platform'
-                  ? billingMode.fellThrough
-                    ? 'Billed with platform credits (no key for this provider).'
-                    : 'Billed with platform credits.'
-                  : 'Using your own provider key (no credits charged).'}
-              </div>
-            )}
+          <div className={STACK}>
+            <span className={`${LABEL} text-right`}>Advisor</span>
+            <div
+              data-role="assistant"
+              data-testid="stream-entry"
+              className={`${BUBBLE} ${BUBBLE_ASSISTANT}`}
+            >
+              {billingMode && (
+                <div data-testid="billing-mode" className="mb-1 text-xs text-muted-foreground">
+                  {billingMode.mode === 'platform'
+                    ? billingMode.fellThrough
+                      ? 'Billed with platform credits (no key for this provider).'
+                      : 'Billed with platform credits.'
+                    : 'Using your own provider key (no credits charged).'}
+                </div>
+              )}
 
-            {tools.map((t) => (
-              <StreamingToolAffordance key={t.id} tool={t} />
-            ))}
+              {tools.map((t) => (
+                <StreamingToolAffordance key={t.id} tool={t} />
+              ))}
 
-            {stream.text.length > 0 && <MarkdownRenderer content={stream.text} />}
+              {stream.text.length > 0 && <MarkdownRenderer content={stream.text} />}
 
-            {stream.kind === 'error' && (
-              <div data-testid="stream-error" className="mt-2 flex items-center gap-3">
-                <span className="text-sm text-destructive">Response interrupted — retry?</span>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  className="cursor-pointer"
-                  onClick={onRetry}
-                >
-                  Retry
-                </Button>
-              </div>
-            )}
+              {stream.kind === 'error' && (
+                <div data-testid="stream-error" className="mt-2 flex items-center gap-3">
+                  <span className="text-sm text-destructive">Response interrupted — retry?</span>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className="cursor-pointer"
+                    onClick={onRetry}
+                  >
+                    Retry
+                  </Button>
+                </div>
+              )}
+            </div>
           </div>
         </div>
       )}

--- a/apps/web/src/features/advisor/components/__tests__/MarkdownRenderer.test.tsx
+++ b/apps/web/src/features/advisor/components/__tests__/MarkdownRenderer.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+// MarkdownRenderer typography (REQ-1.13).
+//
+// These pin the properties that were silently broken while the component
+// carried `prose` classes with no @tailwindcss/typography installed: under
+// Preflight's reset the headings, list markers, table rules and block margins
+// all resolved to nothing, and links rendered in the body text colour. The
+// assertions are on the emitted classes rather than computed style because
+// jsdom does not run Tailwind — a class-less heading or list is the bug.
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { MarkdownRenderer } from '../MarkdownRenderer';
+
+afterEach(cleanup);
+
+describe('MarkdownRenderer typography', () => {
+  it('gives h1/h2/h3 distinct tiers instead of body text', () => {
+    const { container } = render(<MarkdownRenderer content={'# One\n\n## Two\n\n### Three\n'} />);
+
+    const h1 = container.querySelector('h1')!;
+    const h2 = container.querySelector('h2')!;
+    const h3 = container.querySelector('h3')!;
+    for (const h of [h1, h2, h3]) expect(h.className).not.toBe('');
+    // Each tier is told apart by something — size, then weight, then case.
+    expect(h1.className).toContain('text-lg');
+    expect(h2.className).toContain('font-semibold');
+    expect(h3.className).toContain('uppercase');
+    expect(h1.className).not.toBe(h2.className);
+    expect(h2.className).not.toBe(h3.className);
+  });
+
+  it('keeps list markers, including ordered numbering and nesting', () => {
+    const md = '- a\n- b\n  - nested\n\n1. first\n2. second\n';
+    const { container } = render(<MarkdownRenderer content={md} />);
+
+    const ul = container.querySelector('ul')!;
+    const ol = container.querySelector('ol')!;
+    // An unnumbered ordered list is lost information, not just lost styling.
+    expect(ul.className).toContain('list-disc');
+    expect(ol.className).toContain('list-decimal');
+    expect(ul.className).toContain('pl-6');
+    // The sub-list survives as a real nested list rather than being flattened.
+    expect(container.querySelector('li ul')).not.toBeNull();
+  });
+
+  it('renders links visibly distinct from prose, and safe for a new tab', () => {
+    const { container } = render(<MarkdownRenderer content="see [docs](https://example.com/x)" />);
+
+    const link = container.querySelector('a')!;
+    expect(link.getAttribute('href')).toBe('https://example.com/x');
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toBe('noreferrer noopener');
+    // Colour alone is easy to miss mid-sentence, so the underline is not
+    // hover-only — and the link must not inherit plain body styling.
+    expect(link.className).toContain('text-primary');
+    expect(link.className).toContain('underline');
+  });
+
+  it('does not wrap a fenced code block in a redundant outer <pre>', () => {
+    const { container } = render(<MarkdownRenderer content={'```ts\nconst a = 1;\n```\n'} />);
+
+    // The `code` handler emits its own block wrapper (shiki, or this Suspense
+    // fallback), so react-markdown's default <pre> would nest one inside it.
+    expect(container.querySelector('pre')).not.toBeNull();
+    expect(container.querySelector('pre pre')).toBeNull();
+  });
+
+  it('styles GFM tables with real rules', () => {
+    const md = '| Metric | Value |\n| ------ | ----- |\n| Stop | 4.20 |';
+    const { container } = render(<MarkdownRenderer content={md} />);
+
+    const table = container.querySelector('table')!;
+    expect(table.querySelectorAll('th')).toHaveLength(2);
+    expect(container.querySelector('th')!.className).not.toBe('');
+    expect(container.querySelector('td')!.className).toContain('border-b');
+  });
+
+  it('still renders inline HTML as text, never live markup (sanitize property)', () => {
+    const md = 'before <script>alert("xss")</script> after <b>bold</b>';
+    const { container } = render(<MarkdownRenderer content={md} />);
+
+    // The typography change must not have loosened the sanitiser: no
+    // rehype-raw, default schema, so tags never become live DOM elements.
+    expect(container.querySelector('script')).toBeNull();
+    expect(container.querySelector('b')).toBeNull();
+    expect(container.textContent).toContain('alert("xss")');
+    expect(container.textContent).toContain('bold');
+  });
+});

--- a/apps/web/src/features/advisor/components/__tests__/Transcript.test.tsx
+++ b/apps/web/src/features/advisor/components/__tests__/Transcript.test.tsx
@@ -114,7 +114,7 @@ afterEach(() => {
 });
 
 describe('Transcript chat bubbles', () => {
-  it('puts each speaker on its own side, justifying the bubble and not the text', () => {
+  it('puts you on the left and the advisor on the right, moving the bubble not the text', () => {
     conversationMessages = [
       textMessage({ id: 'u1', role: 'user', text: 'question' }),
       textMessage({ id: 'a1', role: 'assistant', text: 'answer' }),
@@ -124,16 +124,36 @@ describe('Transcript chat bubbles', () => {
     const userBubble = document.querySelector('[data-role="user"]')!;
     const assistantBubble = document.querySelector('[data-role="assistant"]')!;
 
-    // The row is what carries the side; the bubble itself never sets
-    // text-alignment, so wrapped lines stay left-read inside both bubbles.
-    expect(userBubble.parentElement!.className).toContain('justify-end');
-    expect(assistantBubble.parentElement!.className).toContain('justify-start');
+    // The row (bubble → stack → row) is what carries the side. The bubble
+    // itself never sets text-alignment, so wrapped lines stay left-read on
+    // both sides.
+    expect(userBubble.parentElement!.parentElement!.className).toContain('justify-start');
+    expect(assistantBubble.parentElement!.parentElement!.className).toContain('justify-end');
     expect(userBubble.className).not.toContain('text-right');
+    expect(assistantBubble.className).not.toContain('text-right');
 
     // Distinct fills, so the speakers are told apart by colour as well as side.
     expect(userBubble.className).toContain('bg-primary');
     expect(assistantBubble.className).toContain('bg-card');
     expect(assistantBubble.className).not.toContain('bg-primary');
+  });
+
+  it('labels each bubble with its speaker, on that speaker’s side', () => {
+    conversationMessages = [
+      textMessage({ id: 'u1', role: 'user', text: 'question' }),
+      textMessage({ id: 'a1', role: 'assistant', text: 'answer' }),
+    ];
+    mount(<Transcript conversationId={CID} onRetry={vi.fn()} />);
+
+    const userLabel = document.querySelector('[data-role="user"]')!.previousElementSibling!;
+    const assistantLabel =
+      document.querySelector('[data-role="assistant"]')!.previousElementSibling!;
+
+    expect(userLabel.textContent).toBe('Me');
+    expect(assistantLabel.textContent).toBe('Advisor');
+    // Each nametag hugs the edge its bubble sits on.
+    expect(userLabel.className).toContain('text-left');
+    expect(assistantLabel.className).toContain('text-right');
   });
 
   it('constrains bubbles so wide content scrolls inside instead of stretching them', () => {
@@ -142,19 +162,22 @@ describe('Transcript chat bubbles', () => {
 
     const bubble = document.querySelector('[data-role="assistant"]')!;
     // Without min-w-0 a flex item refuses to shrink below its content, and a
-    // wide table or code block would push the whole transcript sideways.
+    // wide table or code block would push the whole transcript sideways. The
+    // width cap lives on the stack, which wraps the nametag and the bubble.
     expect(bubble.className).toContain('min-w-0');
-    expect(bubble.className).toContain('max-w-[85%]');
+    expect(bubble.parentElement!.className).toContain('min-w-0');
+    expect(bubble.parentElement!.className).toContain('max-w-[85%]');
   });
 
-  it('bubbles the in-flight stream entry the same way as a persisted reply', () => {
+  it('bubbles and labels the in-flight stream entry like a persisted reply', () => {
     conversationMessages = [];
     streamSlice = { kind: 'streaming', text: 'thinking' };
     mount(<Transcript conversationId={CID} onRetry={vi.fn()} />);
 
     const entry = document.querySelector('[data-testid="stream-entry"]')!;
     expect(entry.className).toContain('bg-card');
-    expect(entry.parentElement!.className).toContain('justify-start');
+    expect(entry.previousElementSibling!.textContent).toBe('Advisor');
+    expect(entry.parentElement!.parentElement!.className).toContain('justify-end');
   });
 });
 

--- a/apps/web/src/features/advisor/components/__tests__/Transcript.test.tsx
+++ b/apps/web/src/features/advisor/components/__tests__/Transcript.test.tsx
@@ -113,6 +113,51 @@ afterEach(() => {
   }
 });
 
+describe('Transcript chat bubbles', () => {
+  it('puts each speaker on its own side, justifying the bubble and not the text', () => {
+    conversationMessages = [
+      textMessage({ id: 'u1', role: 'user', text: 'question' }),
+      textMessage({ id: 'a1', role: 'assistant', text: 'answer' }),
+    ];
+    mount(<Transcript conversationId={CID} onRetry={vi.fn()} />);
+
+    const userBubble = document.querySelector('[data-role="user"]')!;
+    const assistantBubble = document.querySelector('[data-role="assistant"]')!;
+
+    // The row is what carries the side; the bubble itself never sets
+    // text-alignment, so wrapped lines stay left-read inside both bubbles.
+    expect(userBubble.parentElement!.className).toContain('justify-end');
+    expect(assistantBubble.parentElement!.className).toContain('justify-start');
+    expect(userBubble.className).not.toContain('text-right');
+
+    // Distinct fills, so the speakers are told apart by colour as well as side.
+    expect(userBubble.className).toContain('bg-primary');
+    expect(assistantBubble.className).toContain('bg-card');
+    expect(assistantBubble.className).not.toContain('bg-primary');
+  });
+
+  it('constrains bubbles so wide content scrolls inside instead of stretching them', () => {
+    conversationMessages = [textMessage({ id: 'a1', role: 'assistant', text: 'answer' })];
+    mount(<Transcript conversationId={CID} onRetry={vi.fn()} />);
+
+    const bubble = document.querySelector('[data-role="assistant"]')!;
+    // Without min-w-0 a flex item refuses to shrink below its content, and a
+    // wide table or code block would push the whole transcript sideways.
+    expect(bubble.className).toContain('min-w-0');
+    expect(bubble.className).toContain('max-w-[85%]');
+  });
+
+  it('bubbles the in-flight stream entry the same way as a persisted reply', () => {
+    conversationMessages = [];
+    streamSlice = { kind: 'streaming', text: 'thinking' };
+    mount(<Transcript conversationId={CID} onRetry={vi.fn()} />);
+
+    const entry = document.querySelector('[data-testid="stream-entry"]')!;
+    expect(entry.className).toContain('bg-card');
+    expect(entry.parentElement!.className).toContain('justify-start');
+  });
+});
+
 describe('Transcript', () => {
   it('renders user messages as plain text, not Markdown', () => {
     conversationMessages = [textMessage({ id: 'u1', role: 'user', text: '**not bold**' })];


### PR DESCRIPTION
Supersedes #7, which was closed when its branch was renamed. Same first commit, plus the chat-conversation work.

## 1. `fix`: restore markdown hierarchy in assistant messages

`MarkdownRenderer` carried `prose prose-sm dark:prose-invert`, but **`@tailwindcss/typography` is not a dependency** and `index.css` never loads it, so those classes emitted nothing. This was the last inert `prose` usage in the app.

Under Preflight's reset that cost model output more than styling. Measured in the browser before the fix:

| Symptom | Measured |
|---|---|
| No heading tier | `h2` computed to `16px` — identical to `p` |
| Lists lost their markers | every `ul`/`ol`: `list-style: none; padding-left: 0` |
| Links invisible as links | link colour `oklch(0.18 0 0)` — exactly the body text colour |

Three of those are information loss, not aesthetics: an ordered list with no numbering is a lost sequence, a nested list flattened to its parent's indent is a lost relationship, and a table with no rules ran its cells together. A link you cannot distinguish from prose is a functional defect.

Styled the elements directly via react-markdown's `components` map, as the changelog renderer already does — no new dependency, and `shiki` stays out of the initial chunk. Choices specific to this surface: body size is **inherited rather than `text-sm`** (the transcript renders user messages at default size, so shrinking assistant text would make the reply smaller than the question); three modest heading tiers, since models reach for `##` and `###` constantly; and links are **always underlined**, not hover-only, because model output embeds them mid-sentence.

Also fixed a structural bug found along the way: the `code` handler returns its own block wrapper, so react-markdown's default `<pre>` was wrapping it — shiki output sat in an invalid `<pre><div><pre>` nest.

## 2. `feat`: render the transcript as a chat conversation

Messages were undifferentiated blocks in a column; a reply looked the same as the question that prompted it. Each message now gets a bubble, and the two speakers sit on opposite sides — told apart twice over, by position and by fill.

- **The row owns the justification, the bubble owns the fill.** It is the bubble that moves to its side; text inside stays left-read.
- **User:** `bg-primary` on the right. **Assistant:** a bordered card on the left.
- The assistant bubble is deliberately **not** a grey fill. `muted` and `secondary` hold the same value in both themes, and the markdown renderer's inline code and code fallback are `bg-muted` — they would have vanished into a muted bubble.
- `min-w-0` on the bubble is load-bearing: a flex item's default `min-width: auto` refuses to shrink below its content, so a wide table or long code line would push the whole transcript sideways.

## Verified

- Both themes, against a real conversation in a running stack and against representative model output.
- The overflow case explicitly: at a 390px viewport, **page horizontal overflow is 0** while the table and code block scroll *inside* the bubble.
- 9 new tests total — 6 on the markdown tiers, markers, link visibility, the absent nested `<pre>`, table rules, and the sanitize property; 3 on bubble side/fill, the width constraint, and that the in-flight stream entry is bubbled like a persisted reply. Full advisor suite: **117 pass**.
- Whole `checks` job locally: `lint`, `eslint:deps`, `check-types`, frontend build, `check-bundle-size`, `check-contrast`, `check-design-lint`, `check-fonts` — all clean.

The sanitiser is untouched throughout: still `rehype-sanitize` with the default schema, still no `rehype-raw`.