### PR TITLE
fix(dashboard): make widget drag and resize work

### DIFF
--- a/apps/web/src/features/dashboard/components/AddWidgetPopover.tsx
+++ b/apps/web/src/features/dashboard/components/AddWidgetPopover.tsx
@@ -5,38 +5,10 @@ import type { WidgetPlacement, WidgetType } from '@tradr/shared';
 
 import { newWidgetId } from '@/lib/uuid-fallback';
 
-import { GRID_COLUMNS } from '../grid.constants';
+import { findFirstSlot } from '../layout';
 import { widgetRegistry } from '../widgets/registry';
 
-const GRID_MAX_ROWS = 6;
-
-/**
- * Pure helper: left-to-right top-to-bottom packing.
- *
- * Scans cells row-by-row (y ascending) then column-by-column (x ascending)
- * and returns the first `(x, y)` where a rectangle of size `minSize` fits
- * without overlapping `existing`. Correct for n ≤ 6 widgets.
- */
-export function findFirstSlot(
-  existing: WidgetPlacement[],
-  minSize: { w: number; h: number },
-): { x: number; y: number } {
-  function overlaps(x: number, y: number): boolean {
-    for (const p of existing) {
-      const a = { x, y, w: minSize.w, h: minSize.h };
-      const overlapsX = a.x < p.x + p.w && p.x < a.x + a.w;
-      const overlapsY = a.y < p.y + p.h && p.y < a.y + a.h;
-      if (overlapsX && overlapsY) return true;
-    }
-    return false;
-  }
-  for (let y = 0; y <= GRID_MAX_ROWS * 4; y++) {
-    for (let x = 0; x + minSize.w <= GRID_COLUMNS; x++) {
-      if (!overlaps(x, y)) return { x, y };
-    }
-  }
-  return { x: 0, y: 0 };
-}
+export { findFirstSlot };
 
 export interface AddWidgetPopoverProps {
   placedTypes: WidgetType[];
@@ -92,18 +64,11 @@ export function AddWidgetPopover({
           className="z-50 w-64 rounded-md border bg-popover p-2 text-popover-foreground shadow-md outline-none"
         >
           {allPlaced ? (
-            <p
-              data-slot="add-widget-empty"
-              className="px-2 py-3 text-sm text-muted-foreground"
-            >
+            <p data-slot="add-widget-empty" className="px-2 py-3 text-sm text-muted-foreground">
               All widgets added.
             </p>
           ) : (
-            <ul
-              data-slot="add-widget-list"
-              className="flex flex-col"
-              role="list"
-            >
+            <ul data-slot="add-widget-list" className="flex flex-col" role="list">
               {available.map((def) => (
                 <li key={def.type} role="listitem">
                   <button

--- a/apps/web/src/features/dashboard/components/DashboardGrid.test.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardGrid.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { WidgetPlacement } from '@tradr/shared';
 
-import { applyDragEnd, buildAnnouncements, DashboardGrid } from './DashboardGrid';
+import { applyDragEnd, applyResize, buildAnnouncements, DashboardGrid } from './DashboardGrid';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -171,6 +171,102 @@ describe('DashboardGrid — DragOverlay mounts for active state', () => {
   });
 });
 
+describe('DashboardGrid — cell backdrop during a gesture', () => {
+  function firePointer(el: Element, type: string): void {
+    const event = new MouseEvent(type, { bubbles: true, clientX: 0, clientY: 0 });
+    Object.defineProperty(event, 'pointerId', { value: 1 });
+    el.dispatchEvent(event);
+  }
+
+  it('appears the moment a drag zone is pressed, before any movement', () => {
+    // dnd-kit withholds onDragStart until its 4px activation distance is met,
+    // so keying the edit state off the drag alone made the grid appear late.
+    installMatchMediaSpy({});
+    const widgets: WidgetPlacement[] = [
+      W({ id: 'a', type: 'stats-summary', x: 0, y: 0, w: 12, h: 1 }),
+    ];
+    const { container, root } = mountIntoBody();
+    act(() => {
+      root.render(
+        <DashboardGrid
+          widgets={widgets}
+          onRemove={() => undefined}
+          scheduleLayoutWrite={() => undefined}
+        />,
+      );
+    });
+    const editing = (): string | null =>
+      container.querySelector('[data-grid-mode="grid"]')?.getAttribute('data-editing') ?? null;
+
+    expect(editing()).toBeNull();
+
+    const zone = container.querySelector('[data-drag-zone="true"]')!;
+    act(() => {
+      firePointer(zone, 'pointerdown');
+    });
+    // No pointermove at all — the press alone is enough.
+    expect(editing()).toBe('true');
+    expect(container.querySelectorAll('[data-grid-backdrop-cell="true"]').length).toBeGreaterThan(
+      0,
+    );
+
+    // Releasing without ever dragging clears it, even though the release
+    // lands on the window rather than the pressed element.
+    act(() => {
+      window.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+    });
+    expect(editing()).toBeNull();
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('is hidden at rest, covers the occupied rows during a resize, and clears after', () => {
+    installMatchMediaSpy({});
+    const widgets: WidgetPlacement[] = [
+      W({ id: 'a', type: 'stats-summary', x: 0, y: 0, w: 12, h: 1 }),
+      W({ id: 'b', type: 'open-positions', x: 0, y: 1, w: 12, h: 2 }),
+    ];
+    const { container, root } = mountIntoBody();
+    act(() => {
+      root.render(
+        <DashboardGrid
+          widgets={widgets}
+          onRemove={() => undefined}
+          scheduleLayoutWrite={() => undefined}
+        />,
+      );
+    });
+    const backdrop = (): number =>
+      container.querySelectorAll('[data-grid-backdrop-cell="true"]').length;
+
+    expect(backdrop()).toBe(0);
+
+    const handle = container.querySelector('[data-resize-handle="true"]');
+    expect(handle).not.toBeNull();
+    act(() => {
+      firePointer(handle!, 'pointerdown');
+    });
+    // Occupied rows = max(y + h) = 3 → 3 rows × 12 columns.
+    expect(backdrop()).toBe(36);
+    expect(container.querySelector('[data-grid-mode="grid"]')?.getAttribute('data-editing')).toBe(
+      'true',
+    );
+
+    act(() => {
+      firePointer(handle!, 'pointerup');
+    });
+    expect(backdrop()).toBe(0);
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});
+
 describe('DashboardGrid — ResizeObserver lifecycle', () => {
   let observeSpy: ReturnType<typeof vi.fn>;
   let disconnectSpy: ReturnType<typeof vi.fn>;
@@ -238,5 +334,147 @@ describe('applyDragEnd — drag-end merge (v3-7 / v4-4)', () => {
     // Sizes preserved.
     expect({ w: a.w, h: a.h }).toEqual({ w: 6, h: 2 });
     expect({ w: b.w, h: b.h }).toEqual({ w: 6, h: 2 });
+  });
+
+  it('does not produce an overlapping layout when the two widgets are different sizes', () => {
+    // A bare (x, y) swap of a 12×1 and a 6×2 overlaps, and the server rejects
+    // overlapping layouts (`checkNoOverlap`), so the write would 400 and roll
+    // back. Re-packing keeps the result valid.
+    const prev: WidgetPlacement[] = [
+      W({ id: 'stats', type: 'stats-summary', x: 0, y: 0, w: 12, h: 1 }),
+      W({ id: 'perf', type: 'performance-chart', x: 0, y: 1, w: 6, h: 2 }),
+      W({ id: 'bal', type: 'account-balances', x: 6, y: 1, w: 6, h: 2 }),
+    ];
+    const next = applyDragEnd(prev, 'stats', 'perf');
+    for (let i = 0; i < next.length; i++) {
+      for (let j = i + 1; j < next.length; j++) {
+        const a = next[i];
+        const b = next[j];
+        const overlaps = a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h;
+        expect(overlaps).toBe(false);
+      }
+    }
+    // The dragged widget really moved — it is no longer first in reading order.
+    const byReadingOrder = [...next].sort((p, q) => p.y - q.y || p.x - q.x);
+    expect(byReadingOrder[0].id).not.toBe('stats');
+  });
+});
+
+describe('applyResize — growing reflows neighbours instead of stopping', () => {
+  const layout: WidgetPlacement[] = [
+    W({ id: 'stats', type: 'stats-summary', x: 0, y: 0, w: 12, h: 1 }),
+    W({ id: 'perf', type: 'performance-chart', x: 0, y: 1, w: 8, h: 3 }),
+    W({ id: 'bal', type: 'account-balances', x: 8, y: 1, w: 4, h: 3 }),
+  ];
+
+  function overlapping(widgets: WidgetPlacement[]): boolean {
+    for (let i = 0; i < widgets.length; i++) {
+      for (let j = i + 1; j < widgets.length; j++) {
+        const a = widgets[i];
+        const b = widgets[j];
+        if (a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  it('pushes a blocking neighbour aside and keeps the layout overlap-free', () => {
+    // 'perf' is boxed in by 'bal' to its east. A clamp-only rule would refuse
+    // to grow it at all — which is what made the corner handle look dead.
+    const next = applyResize(layout, 'perf', { x: 0, y: 1, w: 12, h: 3 });
+    const perf = next.find((w) => w.id === 'perf')!;
+    const bal = next.find((w) => w.id === 'bal')!;
+    expect({ w: perf.w, h: perf.h }).toEqual({ w: 12, h: 3 });
+    // The resized widget stays where it was; the neighbour is the one that moves.
+    expect({ x: perf.x, y: perf.y }).toEqual({ x: 0, y: 1 });
+    expect(bal.y).toBeGreaterThanOrEqual(perf.y + perf.h);
+    expect(overlapping(next)).toBe(false);
+  });
+
+  it('lets neighbours close the gap when a widget shrinks', () => {
+    const grown = applyResize(layout, 'perf', { x: 0, y: 1, w: 12, h: 3 });
+    const shrunk = applyResize(grown, 'perf', { x: 0, y: 1, w: 8, h: 3 });
+    const bal = shrunk.find((w) => w.id === 'bal')!;
+    // Back beside 'perf' rather than stranded on its own row band.
+    expect(bal.y).toBe(1);
+    expect(bal.x).toBe(8);
+    expect(overlapping(shrunk)).toBe(false);
+  });
+
+  it('honours a moved origin from a left-edge or top-corner drag', () => {
+    // Dragging 'bal' by its left edge widens it leftward into 'perf'.
+    const next = applyResize(layout, 'bal', { x: 6, y: 1, w: 6, h: 3 });
+    const bal = next.find((w) => w.id === 'bal')!;
+    expect({ x: bal.x, y: bal.y, w: bal.w, h: bal.h }).toEqual({
+      x: 6,
+      y: 1,
+      w: 6,
+      h: 3,
+    });
+    expect(overlapping(next)).toBe(false);
+  });
+
+  it('is a no-op when the rect is unchanged or the id is unknown', () => {
+    expect(applyResize(layout, 'perf', { x: 0, y: 1, w: 8, h: 3 })).toBe(layout);
+    expect(applyResize(layout, 'nope', { x: 0, y: 0, w: 4, h: 4 })).toBe(layout);
+  });
+});
+
+describe('DashboardGrid — drag handle is wired to dnd-kit', () => {
+  it('threads useSortable activator props onto the drag handle button', () => {
+    // Regression guard: the grid previously rendered SortableContext without
+    // ever calling useSortable, so the handle was inert and no widget could
+    // be dragged. dnd-kit stamps aria-roledescription="sortable" onto the
+    // activator attributes, so its presence proves the wiring exists.
+    installMatchMediaSpy({});
+    const widgets: WidgetPlacement[] = [
+      W({ id: 'a', type: 'stats-summary', x: 0, y: 0 }),
+      W({ id: 'b', type: 'open-positions', x: 6, y: 0 }),
+    ];
+    const { container, root } = mountIntoBody();
+    act(() => {
+      root.render(
+        <DashboardGrid
+          widgets={widgets}
+          onRemove={() => undefined}
+          scheduleLayoutWrite={() => undefined}
+        />,
+      );
+    });
+    const handles = container.querySelectorAll('button[data-drag-handle="true"]');
+    expect(handles).toHaveLength(2);
+    for (const handle of handles) {
+      expect(handle.getAttribute('aria-roledescription')).toBe('sortable');
+      // Must not be marked disabled — that is the mobile-only shape.
+      expect(handle.getAttribute('aria-disabled')).toBeNull();
+    }
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('marks the handle aria-disabled and drops the resize handle in the mobile stack', () => {
+    installMatchMediaSpy({ '(pointer: coarse)': true });
+    const widgets: WidgetPlacement[] = [W({ id: 'a', type: 'stats-summary' })];
+    const { container, root } = mountIntoBody();
+    act(() => {
+      root.render(
+        <DashboardGrid
+          widgets={widgets}
+          onRemove={() => undefined}
+          scheduleLayoutWrite={() => undefined}
+        />,
+      );
+    });
+    const handle = container.querySelector('button[data-drag-handle="true"]');
+    expect(handle?.getAttribute('aria-disabled')).toBe('true');
+    expect(container.querySelector('[data-resize-handle="true"]')).toBeNull();
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
   });
 });

--- a/apps/web/src/features/dashboard/components/DashboardGrid.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardGrid.tsx
@@ -1,31 +1,30 @@
-
 import {
   DndContext,
   DragOverlay,
   KeyboardSensor,
+  MeasuringStrategy,
   PointerSensor,
   useSensor,
   useSensors,
   type Announcements,
   type DragEndEvent,
+  type DragOverEvent,
   type DragStartEvent,
 } from '@dnd-kit/core';
 import {
   SortableContext,
+  arrayMove,
   rectSortingStrategy,
   sortableKeyboardCoordinates,
+  useSortable,
 } from '@dnd-kit/sortable';
-import {
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ReactElement,
-} from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 
 import type { WidgetPlacement } from '@tradr/shared';
 
-import { GRID_COLUMNS } from '../grid.constants';
+import { GRID_COLUMNS, GRID_ROW_HEIGHT_PX } from '../grid.constants';
+import { findFirstSlot, repackLayout, sortByYThenX } from '../layout';
+import type { GridRect } from '../resize';
 import { widgetRegistry } from '../widgets/registry';
 
 import { WidgetCard } from './WidgetCard';
@@ -33,13 +32,16 @@ import { WidgetCard } from './WidgetCard';
 /**
  * Pure helper extracted for unit testing (Task 36.2 case 5 / v3-7 / v4-4).
  *
- * Moves `activeId` to `overId`'s slot and shifts the displaced widget into
- * the active widget's previous slot. All other widgets are unchanged.
+ * Moves `activeId` into `overId`'s place in reading order — top-to-bottom then
+ * left-to-right — and re-packs the layout from that new order. Each widget
+ * keeps its own `w`/`h`; only the cell origins move.
  *
- * The position semantics swap `(x, y)` between the two widgets — width/height
- * are preserved on each widget; only their cell origins swap. This is the
- * common "two-widget swap" behaviour for a grid sort and is the minimum
- * regression surface the v3-7 case exists to pin.
+ * Re-packing rather than swapping `(x, y)` outright is what keeps the result
+ * overlap-free when the two widgets are different sizes. A bare position swap
+ * of, say, a 12×1 widget and a 6×2 widget produces an overlapping layout,
+ * which the server rejects (`checkNoOverlap` in
+ * `PutDashboardLayoutRequestSchema`) and the client then rolls back. For
+ * equal-sized widgets the two are the same operation — the pair trades slots.
  */
 export function applyDragEnd(
   prev: WidgetPlacement[],
@@ -47,14 +49,41 @@ export function applyDragEnd(
   overId: string,
 ): WidgetPlacement[] {
   if (activeId === overId) return prev;
-  const active = prev.find((w) => w.id === activeId);
-  const over = prev.find((w) => w.id === overId);
-  if (!active || !over) return prev;
-  return prev.map((w) => {
-    if (w.id === activeId) return { ...w, x: over.x, y: over.y };
-    if (w.id === overId) return { ...w, x: active.x, y: active.y };
-    return w;
-  });
+  const ordered = sortByYThenX(prev);
+  const from = ordered.findIndex((w) => w.id === activeId);
+  const to = ordered.findIndex((w) => w.id === overId);
+  if (from === -1 || to === -1) return prev;
+  return repackLayout(arrayMove(ordered, from, to));
+}
+
+/**
+ * Applies a new grid rect to one widget and reflows the rest around it
+ * (Req 4.6.5).
+ *
+ * The resized widget is pinned at the rect the gesture resolved — position
+ * included, since dragging a left edge or a top corner moves the origin as
+ * well as the span — and every other widget is re-packed around it in reading
+ * order. Growing therefore pushes neighbors down and along, and shrinking lets
+ * them close the gap. Reflowing rather than clamping at the boundary is what
+ * makes resize usable at all: a full 12-column layout leaves no free cell, so
+ * a clamp-only rule blocks every outward drag.
+ */
+export function applyResize(
+  prev: WidgetPlacement[],
+  id: string,
+  rect: GridRect,
+): WidgetPlacement[] {
+  const target = prev.find((w) => w.id === id);
+  if (!target) return prev;
+  if (target.x === rect.x && target.y === rect.y && target.w === rect.w && target.h === rect.h) {
+    return prev;
+  }
+  const placed: WidgetPlacement[] = [{ ...target, ...rect }];
+  for (const widget of sortByYThenX(prev.filter((w) => w.id !== id))) {
+    const { x, y } = findFirstSlot(placed, { w: widget.w, h: widget.h });
+    placed.push({ ...widget, x, y });
+  }
+  return placed;
 }
 
 /**
@@ -104,9 +133,8 @@ export interface DashboardGridProps {
   widgets: WidgetPlacement[];
   onRemove: (id: string) => void;
   /**
-   * Called with the next `widgets[]` after a drag-end. The route is
-   * expected to debounce the persistence write (300ms) via the same
-   * helper the resize-end path uses.
+   * Called with the next `widgets[]` after a drag-end or resize. The route is
+   * expected to debounce the persistence write (300ms).
    */
   scheduleLayoutWrite: (next: WidgetPlacement[]) => void;
   /**
@@ -115,10 +143,6 @@ export interface DashboardGridProps {
    * schedules a debounced layout write.
    */
   onUpdateConfig?: (widgetId: string, config: Record<string, unknown>) => void;
-}
-
-function sortByYThenX(widgets: WidgetPlacement[]): WidgetPlacement[] {
-  return [...widgets].sort((a, b) => (a.y - b.y) || (a.x - b.x));
 }
 
 interface MediaState {
@@ -139,6 +163,124 @@ function readMediaState(): MediaState {
   };
 }
 
+/**
+ * The empty cell outlines shown behind the widgets while a drag or resize is
+ * in flight, so the 12-column grid the gesture snaps to is visible.
+ *
+ * Each cell is placed into a grid area so it lines up with the real,
+ * content-sized rows, but is **absolutely positioned** so it takes no part in
+ * track sizing. That distinction is load-bearing, not stylistic. As in-flow
+ * items these were single-row spans, which gives every row track a finite
+ * growth limit; without them the tracks that a multi-row widget spans have an
+ * infinite growth limit, and CSS Grid distributes that widget's height across
+ * its tracks differently in the two cases. A short widget sharing rows with a
+ * tall neighbour therefore grew the instant edit mode turned on — measured at
+ * 176px → 281px for an 8x2 beside a 3-row 430px widget, back to 176px once
+ * absolutely positioned.
+ *
+ * That reflow also broke dropping: dnd-kit measures droppable rects when the
+ * drag begins, so a layout that shifts as edit mode engages leaves every rect
+ * stale and the drop resolves against the wrong geometry.
+ *
+ * Cells cover only rows the layout already occupies — a spare row would resize
+ * the container mid-gesture and shift every drop target for the same reason.
+ */
+function GridBackdrop({ rows }: { rows: number }): ReactElement {
+  return (
+    <>
+      {Array.from({ length: rows * GRID_COLUMNS }, (_, i) => (
+        <div
+          key={`backdrop-${i}`}
+          aria-hidden="true"
+          data-grid-backdrop-cell="true"
+          className="pointer-events-none absolute inset-0 rounded-sm border border-dashed border-muted-foreground/35 bg-muted-foreground/[0.07]"
+          style={{
+            gridColumn: `${(i % GRID_COLUMNS) + 1} / span 1`,
+            gridRow: `${Math.floor(i / GRID_COLUMNS) + 1} / span 1`,
+          }}
+        />
+      ))}
+    </>
+  );
+}
+
+interface SortableWidgetCellProps {
+  widget: WidgetPlacement;
+  isDropTarget: boolean;
+  onRemove: (id: string) => void;
+  onResize: (id: string, rect: GridRect) => void;
+  onResizeStart: () => void;
+  onResizeEnd: () => void;
+  /** Fired the instant the drag zone is pressed, before dnd-kit activates. */
+  onDragPress: () => void;
+  onUpdateConfig?: (widgetId: string, config: Record<string, unknown>) => void;
+}
+
+/**
+ * One grid cell. Owns the dnd-kit `useSortable` registration (Req 4.6.1 —
+ * `useSortable` composes `useDraggable` + `useDroppable`) and threads the
+ * activator props down into `<WidgetCard>`'s drag handle, which stays
+ * presentational per design 9.3.
+ *
+ * The sortable `transform` is deliberately NOT applied to the cell. Widgets
+ * have heterogeneous spans, so a live shuffle preview reflows unpredictably;
+ * the `<DragOverlay>` snapshot plus a drop-target ring is the readable
+ * feedback. The authoritative placement is computed once, on drop.
+ */
+function SortableWidgetCell({
+  widget,
+  isDropTarget,
+  onRemove,
+  onResize,
+  onResizeStart,
+  onResizeEnd,
+  onDragPress,
+  onUpdateConfig,
+}: SortableWidgetCellProps): ReactElement {
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, isDragging } = useSortable({
+    id: widget.id,
+  });
+
+  // dnd-kit does not report a drag until the PointerSensor's 4px activation
+  // distance is met, so the edit state would otherwise only appear once the
+  // widget was already moving. Announce the press first, then hand the event on.
+  const dragHandleProps = {
+    ...attributes,
+    ...listeners,
+    ref: setActivatorNodeRef,
+    onPointerDown: (event: React.PointerEvent<Element>) => {
+      onDragPress();
+      listeners?.onPointerDown?.(event);
+    },
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      data-widget-id={widget.id}
+      data-drop-target={isDropTarget ? 'true' : undefined}
+      className={isDropTarget ? 'rounded-md outline-2 outline-offset-2 outline-ring' : undefined}
+      style={{
+        gridColumn: `${widget.x + 1} / span ${widget.w}`,
+        gridRow: `${widget.y + 1} / span ${widget.h}`,
+        // The DragOverlay carries the moving snapshot (Req 4.6.4); the source
+        // cell just dims so the drop target stays readable underneath.
+        opacity: isDragging ? 0.4 : undefined,
+      }}
+    >
+      <WidgetCard
+        widget={widget}
+        onRemove={onRemove}
+        onResize={(rect) => onResize(widget.id, rect)}
+        onResizeStart={onResizeStart}
+        onResizeEnd={onResizeEnd}
+        onUpdateConfig={onUpdateConfig ? (config) => onUpdateConfig(widget.id, config) : undefined}
+        dragHandleProps={dragHandleProps}
+      />
+    </div>
+  );
+}
+
 export function DashboardGrid({
   widgets,
   onRemove,
@@ -147,7 +289,48 @@ export function DashboardGrid({
 }: DashboardGridProps): ReactElement {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [activeId, setActiveId] = useState<string | null>(null);
+  const [overId, setOverId] = useState<string | null>(null);
+  const [isResizing, setIsResizing] = useState(false);
+  const [isPressing, setIsPressing] = useState(false);
   const [media, setMedia] = useState<MediaState>(() => readMediaState());
+
+  // A press that never becomes a drag still has to end. The release can land
+  // anywhere — outside the handle, outside the window — so it is watched
+  // globally rather than on the element that was pressed. This also backstops
+  // the resize gesture on any browser lacking pointer capture, which would
+  // otherwise strand the edit state on.
+  useEffect(() => {
+    if (!isPressing && !isResizing) return;
+    const release = (): void => {
+      setIsPressing(false);
+      setIsResizing(false);
+    };
+    window.addEventListener('pointerup', release);
+    window.addEventListener('pointercancel', release);
+    return () => {
+      window.removeEventListener('pointerup', release);
+      window.removeEventListener('pointercancel', release);
+    };
+  }, [isPressing, isResizing]);
+
+  // Local echo of the persisted layout. `scheduleLayoutWrite` debounces the
+  // PUT by 300ms and the query cache only updates once that fires, so without
+  // this the widget would snap back to its old cell for a third of a second
+  // after every drop, and the resize gesture would have no live feedback.
+  // Server responses and error rollbacks both arrive as a new `widgets` prop,
+  // which resets the echo.
+  const [localWidgets, setLocalWidgets] = useState<WidgetPlacement[]>(widgets);
+  useEffect(() => {
+    setLocalWidgets(widgets);
+  }, [widgets]);
+
+  const commit = useCallback(
+    (next: WidgetPlacement[]) => {
+      setLocalWidgets(next);
+      scheduleLayoutWrite(next);
+    },
+    [scheduleLayoutWrite],
+  );
 
   // Re-read media state on changes. Listen on the three queries we care about.
   useEffect(() => {
@@ -202,7 +385,7 @@ export function DashboardGrid({
     };
   }, []);
 
-  const sortedForMobile = useMemo(() => sortByYThenX(widgets), [widgets]);
+  const sortedForMobile = useMemo(() => sortByYThenX(localWidgets), [localWidgets]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
@@ -210,31 +393,50 @@ export function DashboardGrid({
   );
 
   const announcements = useMemo(
-    () => buildAnnouncements(widgets, (type) => widgetRegistry[type].displayName),
-    [widgets],
+    () => buildAnnouncements(localWidgets, (type) => widgetRegistry[type].displayName),
+    [localWidgets],
   );
 
   function handleDragStart(event: DragStartEvent): void {
     setActiveId(String(event.active.id));
   }
 
+  function handleDragOver(event: DragOverEvent): void {
+    setOverId(event.over ? String(event.over.id) : null);
+  }
+
   function handleDragEnd(event: DragEndEvent): void {
     setActiveId(null);
+    setOverId(null);
     const { active, over } = event;
     if (!over) return;
-    const next = applyDragEnd(widgets, String(active.id), String(over.id));
-    if (next !== widgets) {
-      scheduleLayoutWrite(next);
+    const next = applyDragEnd(localWidgets, String(active.id), String(over.id));
+    if (next !== localWidgets) {
+      commit(next);
     }
   }
 
   function handleDragCancel(): void {
     setActiveId(null);
+    setOverId(null);
   }
 
-  const activeWidget = activeId
-    ? widgets.find((w) => w.id === activeId) ?? null
-    : null;
+  const handleResize = useCallback(
+    (id: string, rect: GridRect) => {
+      const next = applyResize(localWidgets, id, rect);
+      if (next !== localWidgets) {
+        commit(next);
+      }
+    },
+    [commit, localWidgets],
+  );
+
+  const activeWidget = activeId ? (localWidgets.find((w) => w.id === activeId) ?? null) : null;
+
+  // Show the cell grid while a gesture is in flight (Req 4.6.6) — from the
+  // moment a handle is pressed, not from the moment the widget starts moving.
+  const isEditing = activeId !== null || isResizing || isPressing;
+  const occupiedRows = localWidgets.reduce((max, w) => Math.max(max, w.y + w.h), 0);
 
   // Mobile fallback (Req 4.9): single-column stack, drag/resize disabled.
   if (media.isMobile) {
@@ -253,12 +455,9 @@ export function DashboardGrid({
           >
             <WidgetCard
               widget={widget}
-              neighbors={widgets.filter((w) => w.id !== widget.id)}
               onRemove={onRemove}
               onUpdateConfig={
-                onUpdateConfig
-                  ? (config) => onUpdateConfig(widget.id, config)
-                  : undefined
+                onUpdateConfig ? (config) => onUpdateConfig(widget.id, config) : undefined
               }
             />
           </div>
@@ -271,38 +470,60 @@ export function DashboardGrid({
     <DndContext
       sensors={sensors}
       accessibility={{ announcements }}
+      // dnd-kit's default measures droppable rects once, when the drag begins.
+      // Anything that reflows the grid after that point — the edit wash turning
+      // on, a row band resizing, the sidebar collapsing — leaves every rect
+      // stale, and the drop then resolves against geometry the user cannot see,
+      // landing on the wrong widget or on nothing at all. Re-measuring keeps
+      // the collision rects honest; n <= 6 widgets makes the cost negligible.
+      measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
       onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
     >
-      <SortableContext items={widgets.map((w) => w.id)} strategy={rectSortingStrategy}>
+      <SortableContext items={localWidgets.map((w) => w.id)} strategy={rectSortingStrategy}>
         <div
           ref={containerRef}
           data-measure-key={measureKey}
           data-grid-mode="grid"
-          className="grid w-full gap-4"
-          style={{ gridTemplateColumns: `repeat(${GRID_COLUMNS}, minmax(0, 1fr))` }}
+          data-editing={isEditing ? 'true' : undefined}
+          // The edit wash reads in the gutters between widgets and in the
+          // outline standing off the whole grid, because the backdrop cells
+          // themselves are covered wherever a widget sits. `outline` is used
+          // rather than a border so nothing reflows when the mode turns on.
+          // `relative` makes this the containing block for the absolutely
+          // positioned backdrop cells, so each resolves against its grid area.
+          className={`relative grid w-full gap-4 rounded-lg transition-colors ${
+            isEditing
+              ? 'bg-muted/60 outline-2 outline-dashed outline-offset-8 outline-muted-foreground/30'
+              : ''
+          }`}
+          style={{
+            gridTemplateColumns: `repeat(${GRID_COLUMNS}, minmax(0, 1fr))`,
+            // Content-aware rows: at least GRID_ROW_HEIGHT_PX, growing to fit
+            // whatever the tallest widget in the band renders, so nothing is
+            // clipped or forced to scroll internally. `h` is therefore a row
+            // MINIMUM, not an exact height. Widgets sharing a row band share
+            // its height — which is why DEFAULT_WIDGETS pairs each chart with
+            // a rail widget of the same row span.
+            gridAutoRows: `minmax(${GRID_ROW_HEIGHT_PX}px, auto)`,
+          }}
         >
-          {widgets.map((widget) => (
-            <div
+          {/* First in DOM order so the widgets paint over the outlines. */}
+          {isEditing ? <GridBackdrop rows={occupiedRows} /> : null}
+          {localWidgets.map((widget) => (
+            <SortableWidgetCell
               key={widget.id}
-              data-widget-id={widget.id}
-              style={{
-                gridColumn: `${widget.x + 1} / span ${widget.w}`,
-                gridRow: `${widget.y + 1} / span ${widget.h}`,
-              }}
-            >
-              <WidgetCard
-                widget={widget}
-                neighbors={widgets.filter((w) => w.id !== widget.id)}
-                onRemove={onRemove}
-                onUpdateConfig={
-                  onUpdateConfig
-                    ? (config) => onUpdateConfig(widget.id, config)
-                    : undefined
-                }
-              />
-            </div>
+              widget={widget}
+              isDropTarget={overId === widget.id && activeId !== widget.id}
+              onRemove={onRemove}
+              onResize={handleResize}
+              onResizeStart={() => setIsResizing(true)}
+              onResizeEnd={() => setIsResizing(false)}
+              onDragPress={() => setIsPressing(true)}
+              onUpdateConfig={onUpdateConfig}
+            />
           ))}
         </div>
       </SortableContext>
@@ -311,8 +532,10 @@ export function DashboardGrid({
           <div data-drag-overlay="true" data-active-widget-id={activeWidget.id}>
             <WidgetCard
               widget={activeWidget}
-              neighbors={[]}
               onRemove={() => undefined}
+              // Empty activator props: the snapshot keeps the live handle
+              // styling but carries no listeners of its own.
+              dragHandleProps={{}}
             />
           </div>
         ) : null}

--- a/apps/web/src/features/dashboard/components/DashboardGrid.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardGrid.tsx
@@ -241,6 +241,19 @@ function SortableWidgetCell({
     id: widget.id,
   });
 
+  // Stable identity per widget. A widget's config fix-up effect (§K) lists its
+  // `onUpdateConfig` in its dependency array, so an inline arrow here re-runs
+  // that effect on EVERY render of the grid — each one re-queueing a layout
+  // write and extending the window in which a pending write can clobber an
+  // unrelated edit.
+  const boundUpdateConfig = useMemo(
+    () =>
+      onUpdateConfig
+        ? (config: Record<string, unknown>) => onUpdateConfig(widget.id, config)
+        : undefined,
+    [onUpdateConfig, widget.id],
+  );
+
   // dnd-kit does not report a drag until the PointerSensor's 4px activation
   // distance is met, so the edit state would otherwise only appear once the
   // widget was already moving. Announce the press first, then hand the event on.
@@ -274,7 +287,7 @@ function SortableWidgetCell({
         onResize={(rect) => onResize(widget.id, rect)}
         onResizeStart={onResizeStart}
         onResizeEnd={onResizeEnd}
-        onUpdateConfig={onUpdateConfig ? (config) => onUpdateConfig(widget.id, config) : undefined}
+        onUpdateConfig={boundUpdateConfig}
         dragHandleProps={dragHandleProps}
       />
     </div>

--- a/apps/web/src/features/dashboard/components/DashboardHeader.test.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardHeader.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DashboardHeader } from './DashboardHeader';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function mount(): { container: HTMLElement; root: ReturnType<typeof createRoot> } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  return { container, root: createRoot(container) };
+}
+
+describe('DashboardHeader', () => {
+  it('does not render the keyboard-reorder help affordance', () => {
+    // It described a Tab → Space → arrows → Space flow that does not work.
+    const { container, root } = mount();
+    act(() => {
+      root.render(<DashboardHeader placedTypes={[]} onAdd={() => undefined} />);
+    });
+    expect(container.querySelector('[data-slot="dashboard-keyboard-help"]')).toBeNull();
+    expect(container.textContent).not.toContain('Keyboard reorder');
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('offers Reset layout only when a reset handler is supplied', () => {
+    const { container, root } = mount();
+    act(() => {
+      root.render(<DashboardHeader placedTypes={[]} onAdd={() => undefined} />);
+    });
+    expect(container.querySelector('[data-slot="dashboard-reset-layout"]')).toBeNull();
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('confirms before resetting, and only fires on confirm', () => {
+    const onResetLayout = vi.fn();
+    const { container, root } = mount();
+    act(() => {
+      root.render(
+        <DashboardHeader placedTypes={[]} onAdd={() => undefined} onResetLayout={onResetLayout} />,
+      );
+    });
+    const trigger = container.querySelector<HTMLButtonElement>(
+      '[data-slot="dashboard-reset-layout"]',
+    );
+    expect(trigger).not.toBeNull();
+
+    act(() => {
+      trigger!.click();
+    });
+    // Opening the dialog must not itself reset anything.
+    expect(onResetLayout).not.toHaveBeenCalled();
+
+    // AlertDialog portals to the body, so query from there.
+    const confirm = document.querySelector<HTMLButtonElement>(
+      '[data-slot="dashboard-reset-confirm"]',
+    );
+    expect(confirm).not.toBeNull();
+    act(() => {
+      confirm!.click();
+    });
+    expect(onResetLayout).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});

--- a/apps/web/src/features/dashboard/components/DashboardHeader.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardHeader.tsx
@@ -1,8 +1,18 @@
-import { type ReactElement } from 'react';
+import { useState, type ReactElement } from 'react';
 
 import type { WidgetPlacement, WidgetType } from '@tradr/shared';
 
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
 
 import { AddWidgetPopover } from './AddWidgetPopover';
 
@@ -11,37 +21,81 @@ export interface DashboardHeaderProps {
   placedTypes: WidgetType[];
   /** Called when the user selects a widget to add from the popover. */
   onAdd: (placement: WidgetPlacement) => void;
+  /**
+   * Restores the default layout. Omitted in the empty state, which already
+   * offers "Use the default layout" as a primary action.
+   */
+  onResetLayout?: () => void;
+  /** Disables the reset action while the default layout is being rebuilt. */
+  resetBusy?: boolean;
 }
 
 /**
  * Small header above the dashboard grid.
  *
- * Renders:
- * - The Add Widget popover (Task 36.3).
- * - A `?` keyboard-help tooltip (Req 4.11.2 — Tab → Space → arrows → Space).
+ * Renders the Add Widget popover (Task 36.3) and, once widgets are placed, a
+ * Reset layout action.
+ *
+ * The `?` keyboard-reorder tooltip that used to live here has been REMOVED: it
+ * documented a Tab → Space → arrows → Space flow that does not actually work,
+ * so it was actively misleading. Either the keyboard path gets implemented or
+ * the affordance goes for good — tracked separately; see Req 4.11.2, which
+ * still specifies the binding and is currently out of step with the code.
  *
  * Does NOT mount `<ThemeToggle />` — Task 26 mounts it in the sidebar; per
  * Task 43 restrictions we must not double-mount it here.
  */
-export function DashboardHeader({ placedTypes, onAdd }: DashboardHeaderProps): ReactElement {
+export function DashboardHeader({
+  placedTypes,
+  onAdd,
+  onResetLayout,
+  resetBusy,
+}: DashboardHeaderProps): ReactElement {
+  const [confirmingReset, setConfirmingReset] = useState(false);
+
   return (
     <header data-slot="dashboard-header" className="flex items-center justify-between gap-2">
       <h1 className="text-2xl font-bold">Dashboard</h1>
       <div className="flex items-center gap-2">
         <AddWidgetPopover placedTypes={placedTypes} onAdd={onAdd} />
-        <Tooltip>
-          <TooltipTrigger
-            type="button"
-            aria-label="Keyboard reorder help"
-            data-slot="dashboard-keyboard-help"
-            className="cursor-pointer rounded-md border bg-background px-2 py-1 text-sm font-medium shadow-sm hover:bg-accent"
-          >
-            ?
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            Keyboard reorder: Tab to a widget, Space to grab, arrow keys to move, Space to drop.
-          </TooltipContent>
-        </Tooltip>
+        {onResetLayout ? (
+          <>
+            <Button
+              type="button"
+              variant="outline"
+              data-slot="dashboard-reset-layout"
+              className="cursor-pointer"
+              disabled={resetBusy}
+              onClick={() => setConfirmingReset(true)}
+            >
+              Reset layout
+            </Button>
+            <AlertDialog open={confirmingReset} onOpenChange={setConfirmingReset}>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Reset dashboard layout</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Every widget goes back to its default position and size, and any widget you
+                    removed comes back. Your trading data is not affected.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    className="cursor-pointer"
+                    data-slot="dashboard-reset-confirm"
+                    onClick={() => {
+                      setConfirmingReset(false);
+                      onResetLayout();
+                    }}
+                  >
+                    Reset layout
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </>
+        ) : null}
       </div>
     </header>
   );

--- a/apps/web/src/features/dashboard/components/WidgetCard.test.tsx
+++ b/apps/web/src/features/dashboard/components/WidgetCard.test.tsx
@@ -1,11 +1,13 @@
 // @vitest-environment jsdom
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { WidgetPlacement } from '@tradr/shared';
 
-import { WidgetCard, clampResize } from './WidgetCard';
+import type { GridRect } from '../resize';
+
+import { WidgetCard } from './WidgetCard';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -21,73 +23,248 @@ function makeWidget(over: Partial<WidgetPlacement> = {}): WidgetPlacement {
   } as WidgetPlacement;
 }
 
-describe('clampResize', () => {
-  it('shrinks request when it would overlap an east neighbor at x = self.x + self.w + 1', () => {
-    const self = { x: 0, y: 0, w: 4, h: 2 };
-    const east: WidgetPlacement = makeWidget({
-      id: '00000000-0000-4000-8000-00000000000e',
-      type: 'open-positions',
-      x: self.x + self.w + 1, // 5
-      y: 0,
-      w: 4,
-      h: 2,
+function mount(): { container: HTMLElement; root: ReturnType<typeof createRoot> } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  return { container, root: createRoot(container) };
+}
+
+function fire(
+  el: Element,
+  type: string,
+  init: { pointerId: number; clientX: number; clientY: number },
+): void {
+  // jsdom has no PointerEvent constructor; MouseEvent carries the same
+  // clientX/clientY React reads. Those are getters, so they go through the
+  // constructor and only pointerId is defined on top.
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    clientX: init.clientX,
+    clientY: init.clientY,
+  });
+  Object.defineProperty(event, 'pointerId', { value: init.pointerId });
+  el.dispatchEvent(event);
+}
+
+describe('WidgetCard — resize handles', () => {
+  it('renders the three edges and four corners when resize is enabled', () => {
+    const { container, root } = mount();
+    act(() => {
+      root.render(
+        <WidgetCard widget={makeWidget()} onRemove={() => undefined} onResize={() => undefined} />,
+      );
     });
-    // Cell-domain input: cellPx=1, gapPx=0, hysteresisPx=0 → request in cells.
-    const result = clampResize({ w: self.w, h: self.h }, { w: 10, h: 2 }, [east], 0, 1, 0, {
-      x: self.x,
-      y: self.y,
+    const edges = Array.from(container.querySelectorAll('[data-resize-handle="true"]')).map((el) =>
+      el.getAttribute('data-resize-edge'),
+    );
+    expect(edges).toEqual([
+      'left',
+      'right',
+      'bottom',
+      'top-left',
+      'top-right',
+      'bottom-left',
+      'bottom-right',
+    ]);
+    // No TOP edge strip — the header owns that band as the drag zone.
+    expect(edges).not.toContain('top');
+    act(() => {
+      root.unmount();
     });
-    // Neighbor occupies col 5+. Self at x=0 can be at most w = neighbor.x - self.x = 5.
-    expect(result.w).toBe(5);
+    container.remove();
   });
 
-  it('shrinks request when it would overlap a south neighbor at y = self.y + self.h + 1', () => {
-    const self = { x: 0, y: 0, w: 4, h: 2 };
-    const south: WidgetPlacement = makeWidget({
-      id: '00000000-0000-4000-8000-00000000000a',
-      type: 'open-positions',
-      x: 0,
-      y: self.y + self.h + 1, // 3
-      w: 4,
-      h: 2,
+  it('omits every handle when resize is disabled', () => {
+    const { container, root } = mount();
+    act(() => {
+      root.render(<WidgetCard widget={makeWidget()} onRemove={() => undefined} />);
     });
-    const result = clampResize({ w: self.w, h: self.h }, { w: 4, h: 10 }, [south], 0, 1, 0, {
-      x: self.x,
-      y: self.y,
+    expect(container.querySelectorAll('[data-resize-handle="true"]')).toHaveLength(0);
+    act(() => {
+      root.unmount();
     });
-    // Neighbor at y=3 → self at y=0 max h = 3.
-    expect(result.h).toBe(3);
+    container.remove();
   });
 
-  it('applies floor + ½-cell hysteresis snap: < ½-cell stays, ≥ ½-cell snaps up', () => {
-    // cellPx=100, gapPx=0 → span=100; halfCell=50; hysteresisPx=1 → deadband 49..51px.
-    const current = { w: 2, h: 2 };
-    const selfPos = { x: 0, y: 0 };
-    // Case A: request 240px → 40px past 2-cell boundary; inside deadband → stays at current (2).
-    const stays = clampResize(current, { w: 240, h: 200 }, [], 1, 100, 0, selfPos);
-    expect(stays.w).toBe(2);
-    // Case B: request 260px → 60px past 2-cell boundary; past deadband → snaps to 3.
-    const snaps = clampResize(current, { w: 260, h: 200 }, [], 1, 100, 0, selfPos);
-    expect(snaps.w).toBe(3);
+  it('converts a bottom-right drag into a larger rect with the origin anchored', () => {
+    const { container, root } = mount();
+    const rects: GridRect[] = [];
+    act(() => {
+      root.render(
+        <WidgetCard
+          widget={makeWidget({ x: 0, y: 0, w: 4, h: 2 })}
+          onRemove={() => undefined}
+          gapPx={0}
+          onResize={(rect) => rects.push(rect)}
+        />,
+      );
+    });
+    const section = container.querySelector('section[role="region"]') as HTMLElement;
+    // 4 columns × 100px, 2 rows × 80px, gap 0.
+    section.getBoundingClientRect = () => ({ width: 400, height: 160 }) as DOMRect;
+    const handle = container.querySelector('[data-resize-edge="bottom-right"]')!;
+
+    act(() => {
+      fire(handle, 'pointerdown', { pointerId: 1, clientX: 400, clientY: 160 });
+    });
+    act(() => {
+      // +200px → +2 columns; +160px → +2 rows.
+      fire(handle, 'pointermove', { pointerId: 1, clientX: 600, clientY: 320 });
+    });
+    act(() => {
+      fire(handle, 'pointerup', { pointerId: 1, clientX: 600, clientY: 320 });
+    });
+
+    expect(rects.at(-1)).toEqual({ x: 0, y: 0, w: 6, h: 4 });
+
+    // After pointerup the gesture is over — further movement is ignored.
+    const settled = rects.length;
+    act(() => {
+      fire(handle, 'pointermove', { pointerId: 1, clientX: 900, clientY: 600 });
+    });
+    expect(rects.length).toBe(settled);
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
   });
 
-  it('with no neighbors clamps only to the 12-column / 6-row bound', () => {
-    const selfPos = { x: 2, y: 0 };
-    const result = clampResize({ w: 4, h: 2 }, { w: 15, h: 2 }, [], 0, 1, 0, selfPos);
-    // No neighbors → only grid bound: 12 - x = 12 - 2 = 10.
-    expect(result.w).toBe(12 - selfPos.x);
+  it('moves the origin when the left edge is dragged, holding the right edge', () => {
+    const { container, root } = mount();
+    const rects: GridRect[] = [];
+    act(() => {
+      root.render(
+        <WidgetCard
+          widget={makeWidget({ x: 4, y: 1, w: 4, h: 2 })}
+          onRemove={() => undefined}
+          gapPx={0}
+          onResize={(rect) => rects.push(rect)}
+        />,
+      );
+    });
+    const section = container.querySelector('section[role="region"]') as HTMLElement;
+    section.getBoundingClientRect = () => ({ width: 400, height: 160 }) as DOMRect;
+    const handle = container.querySelector('[data-resize-edge="left"]')!;
+
+    act(() => {
+      fire(handle, 'pointerdown', { pointerId: 1, clientX: 400, clientY: 200 });
+    });
+    act(() => {
+      // Drag 200px left → 2 columns; right edge (x + w = 8) must not move.
+      fire(handle, 'pointermove', { pointerId: 1, clientX: 200, clientY: 200 });
+    });
+    expect(rects.at(-1)).toEqual({ x: 2, y: 1, w: 6, h: 2 });
+    act(() => {
+      fire(handle, 'pointerup', { pointerId: 1, clientX: 200, clientY: 200 });
+    });
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('reports gesture start and end so the grid can show its backdrop', () => {
+    const { container, root } = mount();
+    const onResizeStart = vi.fn();
+    const onResizeEnd = vi.fn();
+    act(() => {
+      root.render(
+        <WidgetCard
+          widget={makeWidget()}
+          onRemove={() => undefined}
+          onResize={() => undefined}
+          onResizeStart={onResizeStart}
+          onResizeEnd={onResizeEnd}
+        />,
+      );
+    });
+    const handle = container.querySelector('[data-resize-edge="bottom"]')!;
+    act(() => {
+      fire(handle, 'pointerdown', { pointerId: 1, clientX: 0, clientY: 0 });
+    });
+    expect(onResizeStart).toHaveBeenCalledTimes(1);
+    expect(onResizeEnd).not.toHaveBeenCalled();
+    act(() => {
+      fire(handle, 'pointerup', { pointerId: 1, clientX: 0, clientY: 0 });
+    });
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});
+
+describe('WidgetCard — header drag zone', () => {
+  it('routes header pointerdown to the dnd-kit activator', () => {
+    const { container, root } = mount();
+    const onPointerDown = vi.fn();
+    act(() => {
+      root.render(
+        <WidgetCard
+          widget={makeWidget()}
+          onRemove={() => undefined}
+          dragHandleProps={{ onPointerDown }}
+        />,
+      );
+    });
+    const header = container.querySelector('[data-drag-zone="true"]');
+    expect(header).not.toBeNull();
+    act(() => {
+      fire(header!, 'pointerdown', { pointerId: 1, clientX: 0, clientY: 0 });
+    });
+    expect(onPointerDown).toHaveBeenCalledTimes(1);
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('does not arm a drag when the overflow menu is pressed', () => {
+    // The menu sits inside the drag zone; without the stopPropagation guard
+    // opening it would also start a drag.
+    const { container, root } = mount();
+    const onPointerDown = vi.fn();
+    act(() => {
+      root.render(
+        <WidgetCard
+          widget={makeWidget()}
+          onRemove={() => undefined}
+          dragHandleProps={{ onPointerDown }}
+        />,
+      );
+    });
+    const menu = container.querySelector('[aria-label="Stats Summary menu"]')!;
+    act(() => {
+      fire(menu, 'pointerdown', { pointerId: 1, clientX: 0, clientY: 0 });
+    });
+    expect(onPointerDown).not.toHaveBeenCalled();
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('leaves the header inert when drag is disabled', () => {
+    const { container, root } = mount();
+    act(() => {
+      root.render(<WidgetCard widget={makeWidget()} onRemove={() => undefined} />);
+    });
+    expect(container.querySelector('[data-drag-zone="true"]')).toBeNull();
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
   });
 });
 
 describe('WidgetCard — focus management', () => {
   it('focuses the section element on mount when focusOnMount is true', () => {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
+    const { container, root } = mount();
     act(() => {
-      root.render(
-        <WidgetCard widget={makeWidget()} neighbors={[]} onRemove={() => undefined} focusOnMount />,
-      );
+      root.render(<WidgetCard widget={makeWidget()} onRemove={() => undefined} focusOnMount />);
     });
     const section = container.querySelector('section[role="region"]');
     expect(section).not.toBeNull();

--- a/apps/web/src/features/dashboard/components/WidgetCard.tsx
+++ b/apps/web/src/features/dashboard/components/WidgetCard.tsx
@@ -10,100 +10,112 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Skeleton } from '@/components/ui/skeleton';
 
-import { GRID_COLUMNS } from '../grid.constants';
+import { GRID_GAP_PX, RESIZE_HYSTERESIS_PX } from '../grid.constants';
+import { resolveResizeRect, type GridRect, type ResizeEdges } from '../resize';
 import { widgetRegistry } from '../widgets/registry';
 
-const GRID_MAX_ROWS = 6;
+/**
+ * The dnd-kit activator props `<DashboardGrid>` threads into the drag zone.
+ *
+ * Structural on purpose: `<WidgetCard>` is presentational chrome and does not
+ * mount dnd-kit hooks itself (design 9.3). The shape covers dnd-kit's
+ * `DraggableAttributes` plus the `PointerSensor` / `KeyboardSensor` activator
+ * listeners.
+ */
+export interface DragHandleProps {
+  ref?: React.Ref<HTMLButtonElement>;
+  role?: string;
+  tabIndex?: number;
+  'aria-disabled'?: boolean;
+  'aria-pressed'?: boolean;
+  'aria-roledescription'?: string;
+  'aria-describedby'?: string;
+  onPointerDown?: React.PointerEventHandler<Element>;
+  onKeyDown?: React.KeyboardEventHandler<Element>;
+}
 
 /**
- * Clamps a pixel-denominated resize request into cell-denominated `{w, h}`.
+ * The seven resize affordances, in paint order — edges first so the corners
+ * sit on top of them and win the overlapping pixels.
  *
- * - Pixel → cell conversion uses **floor + half-cell snap with `hysteresisPx`
- *   deadband**: the gesture must cross the half-cell boundary by at least
- *   `hysteresisPx` past the snap threshold before the cell count changes.
- * - The result is then clamped against `neighbors` (rectangles that share a
- *   row/column with `selfPos`) and against the global grid bounds
- *   (12 columns, 6 rows).
- *
- * Pass `requestedSize` in **pixels**. Pass `currentSize` in **cells** (it's
- * the floor used as a tie-break inside the hysteresis deadband). The return
- * value is in **cells**.
- *
- * For pure-cell-domain unit tests, pass `cellPx = 1`, `gapPx = 0`,
- * `hysteresisPx = 0`; then `requestedSize` is effectively in cells.
+ * There is deliberately no TOP edge strip: the whole header is the drag zone,
+ * and a full-width resize strip along the top would swallow the start of every
+ * drag. The two top CORNERS are small enough to coexist with it.
  */
-export function clampResize(
-  currentSize: { w: number; h: number },
-  requestedSize: { w: number; h: number },
-  neighbors: WidgetPlacement[],
-  hysteresisPx: number,
-  cellPx: number,
-  gapPx: number,
-  selfPos: { x: number; y: number } = { x: 0, y: 0 },
-): { w: number; h: number } {
-  const span = cellPx + gapPx;
-  // Floor + half-cell snap with a `hysteresisPx` deadband around the
-  // half-cell boundary. The gesture must cross the half-cell line by at
-  // least `hysteresisPx` before the cell count changes; otherwise the
-  // result sticks to `currentSize`.
-  function pxToCells(px: number, currentCells: number): number {
-    if (px <= 0) return 1;
-    const floor = Math.floor(px / span);
-    const remainder = px - floor * span;
-    const halfCell = span / 2;
-    let snapped: number;
-    if (remainder >= halfCell + hysteresisPx) {
-      snapped = floor + 1;
-    } else if (remainder <= halfCell - hysteresisPx) {
-      snapped = floor;
-    } else {
-      // Inside the deadband — keep current cell count.
-      snapped = currentCells;
-    }
-    return Math.max(1, snapped);
-  }
-
-  let w = pxToCells(requestedSize.w, currentSize.w);
-  let h = pxToCells(requestedSize.h, currentSize.h);
-
-  // Clamp to grid bounds.
-  w = Math.min(w, GRID_COLUMNS - selfPos.x);
-  h = Math.min(h, GRID_MAX_ROWS - selfPos.y);
-
-  // Clamp against neighbors. Use the CURRENT self extent (not the requested
-  // one) to detect whether a neighbor is east-of vs south-of self, so that
-  // a south neighbor sharing the same column doesn't get mis-classified as
-  // an east blocker.
-  const selfBottom = selfPos.y + currentSize.h;
-  const selfRight = selfPos.x + currentSize.w;
-  for (const n of neighbors) {
-    const sharesRowsCurrent = n.y < selfBottom && n.y + n.h > selfPos.y;
-    const sharesColsCurrent = n.x < selfRight && n.x + n.w > selfPos.x;
-    // East blocker: shares rows with self's current row range and is to the
-    // right of self's current right edge.
-    if (sharesRowsCurrent && n.x >= selfRight) {
-      const maxW = n.x - selfPos.x;
-      if (maxW < w) w = maxW;
-    }
-    // South blocker: shares cols with self's current col range and is below
-    // self's current bottom edge.
-    if (sharesColsCurrent && n.y >= selfBottom) {
-      const maxH = n.y - selfPos.y;
-      if (maxH < h) h = maxH;
-    }
-  }
-
-  return { w: Math.max(1, w), h: Math.max(1, h) };
-}
+const RESIZE_HANDLES: ReadonlyArray<{
+  key: string;
+  edges: ResizeEdges;
+  label: string;
+  className: string;
+}> = [
+  {
+    key: 'left',
+    edges: { left: true },
+    label: 'left edge',
+    className: 'left-0 top-3 bottom-3 w-1.5 cursor-ew-resize',
+  },
+  {
+    key: 'right',
+    edges: { right: true },
+    label: 'right edge',
+    className: 'right-0 top-3 bottom-3 w-1.5 cursor-ew-resize',
+  },
+  {
+    key: 'bottom',
+    edges: { bottom: true },
+    label: 'bottom edge',
+    className: 'bottom-0 left-3 right-3 h-1.5 cursor-ns-resize',
+  },
+  {
+    key: 'top-left',
+    edges: { top: true, left: true },
+    label: 'top-left corner',
+    className: 'left-0 top-0 h-3 w-3 cursor-nwse-resize',
+  },
+  {
+    key: 'top-right',
+    edges: { top: true, right: true },
+    label: 'top-right corner',
+    className: 'right-0 top-0 h-3 w-3 cursor-nesw-resize',
+  },
+  {
+    key: 'bottom-left',
+    edges: { bottom: true, left: true },
+    label: 'bottom-left corner',
+    className: 'bottom-0 left-0 h-3 w-3 cursor-nesw-resize',
+  },
+  {
+    key: 'bottom-right',
+    edges: { bottom: true, right: true },
+    label: 'bottom-right corner',
+    className: 'bottom-0 right-0 h-3 w-3 cursor-nwse-resize',
+  },
+];
 
 export interface WidgetCardProps {
   widget: WidgetPlacement;
-  neighbors: WidgetPlacement[];
   onRemove: (id: string) => void;
   onUpdateConfig?: (config: Record<string, unknown>) => void;
   focusOnMount?: boolean;
-  cellPx?: number;
   gapPx?: number;
+  /** Omitted wherever resize is disabled (mobile stack, drag overlay). */
+  onResize?: (rect: GridRect) => void;
+  /** Gesture lifecycle — the grid uses these to show its cell backdrop. */
+  onResizeStart?: () => void;
+  onResizeEnd?: () => void;
+  /** Omitted wherever drag is disabled (mobile stack, drag overlay). */
+  dragHandleProps?: DragHandleProps;
+}
+
+interface ResizeGesture {
+  pointerId: number;
+  edges: ResizeEdges;
+  startClientX: number;
+  startClientY: number;
+  /** The widget's grid rect when the gesture began — deltas measure from it. */
+  startRect: GridRect;
+  colSpanPx: number;
+  rowSpanPx: number;
 }
 
 export function WidgetCard({
@@ -111,18 +123,87 @@ export function WidgetCard({
   onRemove,
   onUpdateConfig,
   focusOnMount,
+  gapPx = GRID_GAP_PX,
+  onResize,
+  onResizeStart,
+  onResizeEnd,
+  dragHandleProps,
 }: WidgetCardProps): React.ReactElement {
   const ref = useRef<HTMLElement | null>(null);
+  const gestureRef = useRef<ResizeGesture | null>(null);
   const titleId = useId();
   const descId = useId();
   const def = widgetRegistry[widget.type];
   const Body = def.component;
+  const canResize = onResize !== undefined;
+  const canDrag = dragHandleProps !== undefined;
 
   useEffect(() => {
     if (focusOnMount) {
       ref.current?.focus();
     }
   }, [focusOnMount]);
+
+  function handleResizeStart(event: React.PointerEvent<HTMLDivElement>, edges: ResizeEdges): void {
+    if (!canResize) return;
+    const rect = ref.current?.getBoundingClientRect();
+    if (!rect) return;
+    // Keep the gesture off the card's focus handling and off the header's drag
+    // activator — this is a resize, not a drag.
+    event.preventDefault();
+    event.stopPropagation();
+    gestureRef.current = {
+      pointerId: event.pointerId,
+      edges,
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      startRect: { x: widget.x, y: widget.y, w: widget.w, h: widget.h },
+      // Cell pitch measured from THIS widget's own box rather than a constant:
+      // rows are `minmax(GRID_ROW_HEIGHT_PX, auto)`, so a band that grew to fit
+      // its content is taller than the constant. `rect` spans `w` columns and
+      // `w - 1` gaps, so one column's pitch is `(width + gap) / w`.
+      colSpanPx: (rect.width + gapPx) / widget.w,
+      rowSpanPx: (rect.height + gapPx) / widget.h,
+    };
+    if (typeof event.currentTarget.setPointerCapture === 'function') {
+      event.currentTarget.setPointerCapture(event.pointerId);
+    }
+    onResizeStart?.();
+  }
+
+  function handleResizeMove(event: React.PointerEvent<HTMLDivElement>): void {
+    const gesture = gestureRef.current;
+    if (!gesture || gesture.pointerId !== event.pointerId) return;
+    if (!onResize) return;
+    const next = resolveResizeRect(
+      gesture.startRect,
+      { x: widget.x, y: widget.y, w: widget.w, h: widget.h },
+      {
+        x: event.clientX - gesture.startClientX,
+        y: event.clientY - gesture.startClientY,
+      },
+      gesture.edges,
+      { colSpanPx: gesture.colSpanPx, rowSpanPx: gesture.rowSpanPx },
+      def.minSize,
+      RESIZE_HYSTERESIS_PX,
+    );
+    if (next.x !== widget.x || next.y !== widget.y || next.w !== widget.w || next.h !== widget.h) {
+      onResize(next);
+    }
+  }
+
+  function handleResizeEnd(event: React.PointerEvent<HTMLDivElement>): void {
+    const gesture = gestureRef.current;
+    if (!gesture || gesture.pointerId !== event.pointerId) return;
+    gestureRef.current = null;
+    if (
+      typeof event.currentTarget.hasPointerCapture === 'function' &&
+      event.currentTarget.hasPointerCapture(event.pointerId)
+    ) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    onResizeEnd?.();
+  }
 
   return (
     <section
@@ -135,7 +216,20 @@ export function WidgetCard({
       data-widget-type={widget.type}
       className="relative flex h-full flex-col rounded-md border bg-card text-card-foreground shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
-      <header className="flex items-center justify-between gap-2 border-b px-3 py-2">
+      {/*
+        The whole header is the drag zone. It carries the pointer/keyboard
+        activator listeners; the `::` button additionally carries dnd-kit's
+        aria attributes and the activator ref, so it stays the labelled,
+        focusable target for keyboard reorder (Req 4.11.2).
+      */}
+      <header
+        data-drag-zone={canDrag ? 'true' : undefined}
+        onPointerDown={canDrag ? dragHandleProps?.onPointerDown : undefined}
+        onKeyDown={canDrag ? dragHandleProps?.onKeyDown : undefined}
+        className={`flex select-none items-center justify-between gap-2 border-b px-3 py-2 ${
+          canDrag ? 'cursor-grab touch-none active:cursor-grabbing' : ''
+        }`}
+      >
         <h3 id={titleId} className="truncate text-sm font-medium">
           {def.displayName}
         </h3>
@@ -147,26 +241,35 @@ export function WidgetCard({
             type="button"
             aria-label={`Drag to reorder ${def.displayName}`}
             data-drag-handle="true"
-            className="cursor-grab rounded p-1 text-muted-foreground hover:bg-accent active:cursor-grabbing"
+            {...dragHandleProps}
+            aria-disabled={canDrag ? undefined : true}
+            className={
+              canDrag
+                ? 'cursor-grab touch-none rounded p-1 text-muted-foreground hover:bg-accent active:cursor-grabbing'
+                : 'cursor-not-allowed rounded p-1 text-muted-foreground/50'
+            }
           >
             <span aria-hidden="true">::</span>
           </button>
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              aria-label={`${def.displayName} menu`}
-              className="cursor-pointer rounded p-1 text-muted-foreground hover:bg-accent"
-            >
-              <span aria-hidden="true">···</span>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                onSelect={() => onRemove(widget.id)}
-                className="cursor-pointer"
+          {/*
+            The overflow menu lives inside the drag zone, so its pointerdown
+            must not reach the activator or opening the menu would arm a drag.
+          */}
+          <div onPointerDown={(event) => event.stopPropagation()}>
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                aria-label={`${def.displayName} menu`}
+                className="cursor-pointer rounded p-1 text-muted-foreground hover:bg-accent"
               >
-                Remove
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+                <span aria-hidden="true">···</span>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onSelect={() => onRemove(widget.id)} className="cursor-pointer">
+                  Remove
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </div>
       </header>
       <div className="flex-1 overflow-auto p-3">
@@ -174,11 +277,22 @@ export function WidgetCard({
           <Body placement={widget} onUpdateConfig={onUpdateConfig ?? (() => undefined)} />
         </Suspense>
       </div>
-      <div
-        aria-hidden="true"
-        data-resize-handle="true"
-        className="absolute bottom-0 right-0 h-3 w-3 cursor-se-resize"
-      />
+      {canResize
+        ? RESIZE_HANDLES.map((handle) => (
+            <div
+              key={handle.key}
+              aria-hidden="true"
+              data-resize-handle="true"
+              data-resize-edge={handle.key}
+              title={`Resize ${def.displayName} — ${handle.label}`}
+              onPointerDown={(event) => handleResizeStart(event, handle.edges)}
+              onPointerMove={handleResizeMove}
+              onPointerUp={handleResizeEnd}
+              onPointerCancel={handleResizeEnd}
+              className={`absolute touch-none ${handle.className}`}
+            />
+          ))
+        : null}
     </section>
   );
 }

--- a/apps/web/src/features/dashboard/grid.constants.ts
+++ b/apps/web/src/features/dashboard/grid.constants.ts
@@ -1,5 +1,9 @@
 export const GRID_COLUMNS = 12;
+// Matches `WidgetPlacementSchema`'s `h: 1..6` cap in @tradr/shared.
+export const GRID_MAX_ROWS = 6;
 export const GRID_GAP_PX = 16;
+/** Deadband (px) the resize gesture must cross past the ½-cell snap line. */
+export const RESIZE_HYSTERESIS_PX = 1;
 export const GRID_ROW_HEIGHT_PX = 80;
 export const GRID_ROW_HEIGHT_COARSE_PX = 88;
 export const DEBOUNCE_PUT_MS = 300;

--- a/apps/web/src/features/dashboard/hooks/useDashboardLayout.ts
+++ b/apps/web/src/features/dashboard/hooks/useDashboardLayout.ts
@@ -94,6 +94,15 @@ export function useDashboardLayout() {
     },
   });
 
+  // `mutation` is a fresh object on every mutation-state transition, so a
+  // `scheduleLayoutWrite` that closed over it directly would change identity
+  // mid-write. Widget config fix-ups (§K) list their callback in an effect
+  // dependency array, and that churn re-fires them — each re-queueing a layout
+  // write. Holding the mutation in a ref keeps `scheduleLayoutWrite` stable for
+  // the lifetime of the hook.
+  const mutationRef = useRef(mutation);
+  mutationRef.current = mutation;
+
   const scheduleLayoutWrite = useCallback(
     (merge: (prev: PutDashboardLayoutRequest) => PutDashboardLayoutRequest) => {
       const state = debounceRef.current;
@@ -107,11 +116,11 @@ export function useDashboardLayout() {
         state.timeout = null;
         state.pending = null;
         if (body) {
-          mutation.mutate(body);
+          mutationRef.current.mutate(body);
         }
       }, DEBOUNCE_PUT_MS);
     },
-    [mutation],
+    [],
   );
 
   const flushPending = useCallback(() => {

--- a/apps/web/src/features/dashboard/layout.test.ts
+++ b/apps/web/src/features/dashboard/layout.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_WIDGETS, type WidgetPlacement } from '@tradr/shared';
+
+import { findFirstSlot, repackLayout, sortByYThenX } from './layout';
+
+const W = (over: Partial<WidgetPlacement>): WidgetPlacement =>
+  ({
+    id: '00000000-0000-4000-8000-000000000001',
+    type: 'stats-summary',
+    x: 0,
+    y: 0,
+    w: 4,
+    h: 2,
+    ...over,
+  }) as WidgetPlacement;
+
+/** Mirrors `checkNoOverlap` from the PUT schema the server validates with. */
+function hasOverlap(widgets: WidgetPlacement[]): boolean {
+  for (let i = 0; i < widgets.length; i++) {
+    for (let j = i + 1; j < widgets.length; j++) {
+      const a = widgets[i];
+      const b = widgets[j];
+      if (a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+describe('repackLayout', () => {
+  it('reproduces DEFAULT_WIDGETS geometry when packing them in their declared order', () => {
+    // The shipped default layout IS a left-to-right top-to-bottom packing.
+    // Pinning that keeps the packer and the seeded defaults from drifting.
+    const shuffledOrigins = DEFAULT_WIDGETS.map((d, i) =>
+      W({ id: `id-${i}`, type: d.type, x: 99, y: 99, w: d.w, h: d.h }),
+    );
+    const packed = repackLayout(shuffledOrigins);
+    expect(packed.map((p) => ({ type: p.type, x: p.x, y: p.y, w: p.w, h: p.h }))).toEqual(
+      DEFAULT_WIDGETS.map((d) => ({ type: d.type, x: d.x, y: d.y, w: d.w, h: d.h })),
+    );
+  });
+
+  it('produces an overlap-free layout from mixed-size widgets in any order', () => {
+    const mixed: WidgetPlacement[] = [
+      W({ id: 'a', type: 'position-sizing', w: 6, h: 3 }),
+      W({ id: 'b', type: 'stats-summary', w: 12, h: 1 }),
+      W({ id: 'c', type: 'equity-curve', w: 6, h: 2 }),
+      W({ id: 'd', type: 'open-positions', w: 12, h: 2 }),
+    ];
+    const packed = repackLayout(mixed);
+    expect(hasOverlap(packed)).toBe(false);
+    // Sizes are preserved — packing moves origins only.
+    expect(packed.map((p) => ({ w: p.w, h: p.h }))).toEqual(mixed.map((p) => ({ w: p.w, h: p.h })));
+    // Every placement stays inside the 12-column grid.
+    for (const p of packed) {
+      expect(p.x + p.w).toBeLessThanOrEqual(12);
+    }
+  });
+});
+
+describe('findFirstSlot', () => {
+  it('returns the first gap in reading order rather than appending below', () => {
+    const existing = [
+      W({ id: 'a', x: 6, y: 0, w: 6, h: 2 }),
+      W({ id: 'b', x: 0, y: 2, w: 12, h: 1 }),
+    ];
+    expect(findFirstSlot(existing, { w: 6, h: 2 })).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe('sortByYThenX', () => {
+  it('orders top-to-bottom then left-to-right without mutating the input', () => {
+    const input = [
+      W({ id: 'd', x: 6, y: 2 }),
+      W({ id: 'b', x: 6, y: 0 }),
+      W({ id: 'c', x: 0, y: 2 }),
+      W({ id: 'a', x: 0, y: 0 }),
+    ];
+    expect(sortByYThenX(input).map((w) => w.id)).toEqual(['a', 'b', 'c', 'd']);
+    expect(input.map((w) => w.id)).toEqual(['d', 'b', 'c', 'a']);
+  });
+});

--- a/apps/web/src/features/dashboard/layout.ts
+++ b/apps/web/src/features/dashboard/layout.ts
@@ -1,0 +1,56 @@
+import type { WidgetPlacement } from '@tradr/shared';
+
+import { GRID_COLUMNS, GRID_MAX_ROWS } from './grid.constants';
+
+/**
+ * Pure helper: left-to-right top-to-bottom packing.
+ *
+ * Scans cells row-by-row (y ascending) then column-by-column (x ascending)
+ * and returns the first `(x, y)` where a rectangle of size `size` fits
+ * without overlapping `existing`. Correct for n ≤ 6 widgets.
+ */
+export function findFirstSlot(
+  existing: WidgetPlacement[],
+  size: { w: number; h: number },
+): { x: number; y: number } {
+  function overlaps(x: number, y: number): boolean {
+    for (const p of existing) {
+      const a = { x, y, w: size.w, h: size.h };
+      const overlapsX = a.x < p.x + p.w && p.x < a.x + a.w;
+      const overlapsY = a.y < p.y + p.h && p.y < a.y + a.h;
+      if (overlapsX && overlapsY) return true;
+    }
+    return false;
+  }
+  for (let y = 0; y <= GRID_MAX_ROWS * 4; y++) {
+    for (let x = 0; x + size.w <= GRID_COLUMNS; x++) {
+      if (!overlaps(x, y)) return { x, y };
+    }
+  }
+  return { x: 0, y: 0 };
+}
+
+/**
+ * Re-packs `widgets` into the grid in array order, preserving each widget's
+ * `w`/`h` and assigning the first `(x, y)` slot that fits.
+ *
+ * The server validates every PUT with `checkNoOverlap` (see
+ * `packages/shared/src/schemas/dashboard.ts`), so any layout the client
+ * produces must be overlap-free or the write 400s and rolls back. Packing in
+ * array order makes that guarantee structural rather than incidental: the
+ * caller decides the ORDER widgets should appear in, and this decides where
+ * they land.
+ */
+export function repackLayout(widgets: WidgetPlacement[]): WidgetPlacement[] {
+  const placed: WidgetPlacement[] = [];
+  for (const widget of widgets) {
+    const { x, y } = findFirstSlot(placed, { w: widget.w, h: widget.h });
+    placed.push({ ...widget, x, y });
+  }
+  return placed;
+}
+
+/** Reading order for the grid: top-to-bottom, then left-to-right. */
+export function sortByYThenX(widgets: WidgetPlacement[]): WidgetPlacement[] {
+  return [...widgets].sort((a, b) => a.y - b.y || a.x - b.x);
+}

--- a/apps/web/src/features/dashboard/resize.test.ts
+++ b/apps/web/src/features/dashboard/resize.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveResizeRect, snapDeltaToCells, type GridRect } from './resize';
+
+// Unit pitch: 100px per column, 80px per row, so a delta in pixels maps
+// cleanly onto whole cells.
+const PITCH = { colSpanPx: 100, rowSpanPx: 80 };
+const MIN = { w: 2, h: 2 };
+const start: GridRect = { x: 4, y: 2, w: 4, h: 3 };
+
+function resize(
+  edges: Parameters<typeof resolveResizeRect>[3],
+  deltaPx: { x: number; y: number },
+  current: GridRect = start,
+): GridRect {
+  return resolveResizeRect(start, current, deltaPx, edges, PITCH, MIN, 0);
+}
+
+describe('snapDeltaToCells', () => {
+  it('holds inside the ½-cell deadband and switches once it is crossed', () => {
+    // span 100px, currently +0 cells → the boundary sits at 50px, widened by
+    // the 4px hysteresis to 54px.
+    expect(snapDeltaToCells(45, 100, 0, 4)).toBe(0);
+    expect(snapDeltaToCells(53, 100, 0, 4)).toBe(0);
+    expect(snapDeltaToCells(56, 100, 0, 4)).toBe(1);
+    // Symmetric on the way back down.
+    expect(snapDeltaToCells(-56, 100, 0, 4)).toBe(-1);
+  });
+
+  it('is a no-op for a non-positive span', () => {
+    expect(snapDeltaToCells(500, 0, 3, 0)).toBe(3);
+  });
+});
+
+describe('resolveResizeRect — edges move independently', () => {
+  it('right edge changes width only, origin anchored', () => {
+    expect(resize({ right: true }, { x: 200, y: 500 })).toEqual({
+      x: 4,
+      y: 2,
+      w: 6,
+      h: 3,
+    });
+  });
+
+  it('bottom edge changes height only, origin anchored', () => {
+    expect(resize({ bottom: true }, { x: 500, y: 80 })).toEqual({
+      x: 4,
+      y: 2,
+      w: 4,
+      h: 4,
+    });
+  });
+
+  it('left edge moves the origin and keeps the right edge anchored', () => {
+    const next = resize({ left: true }, { x: -200, y: 0 });
+    expect(next).toEqual({ x: 2, y: 2, w: 6, h: 3 });
+    // Right edge is exactly where it started.
+    expect(next.x + next.w).toBe(start.x + start.w);
+  });
+});
+
+describe('resolveResizeRect — corners anchor the opposite corner', () => {
+  it('top-left drag anchors the bottom-right corner', () => {
+    const next = resize({ top: true, left: true }, { x: -200, y: -80 });
+    expect(next).toEqual({ x: 2, y: 1, w: 6, h: 4 });
+    expect(next.x + next.w).toBe(start.x + start.w);
+    expect(next.y + next.h).toBe(start.y + start.h);
+  });
+
+  it('bottom-right drag anchors the top-left corner', () => {
+    const next = resize({ bottom: true, right: true }, { x: 100, y: 80 });
+    expect(next).toEqual({ x: 4, y: 2, w: 5, h: 4 });
+    expect(next.x).toBe(start.x);
+    expect(next.y).toBe(start.y);
+  });
+
+  it('top-right drag anchors the bottom-left corner', () => {
+    const next = resize({ top: true, right: true }, { x: 100, y: -80 });
+    expect(next).toEqual({ x: 4, y: 1, w: 5, h: 4 });
+    expect(next.x).toBe(start.x);
+    expect(next.y + next.h).toBe(start.y + start.h);
+  });
+});
+
+describe('resolveResizeRect — clamps to what the schema accepts', () => {
+  it('stops the right edge at the 12-column bound', () => {
+    expect(resize({ right: true }, { x: 5000, y: 0 }).w).toBe(12 - start.x);
+  });
+
+  it('stops the left edge at column 0 and never inverts the rect', () => {
+    const next = resize({ left: true }, { x: -5000, y: 0 });
+    expect(next.x).toBe(0);
+    expect(next.x + next.w).toBe(start.x + start.w);
+  });
+
+  it('holds the minimum width when the left edge is dragged inward', () => {
+    const next = resize({ left: true }, { x: 5000, y: 0 });
+    expect(next.w).toBe(MIN.w);
+    expect(next.x + next.w).toBe(start.x + start.w);
+  });
+
+  it('caps height at the 6-row maximum', () => {
+    expect(resize({ bottom: true }, { x: 0, y: 5000 }).h).toBe(6);
+  });
+
+  it('never lets a top-edge drag push y negative', () => {
+    const next = resize({ top: true }, { x: 0, y: -5000 });
+    expect(next.y).toBe(0);
+    expect(next.h).toBeLessThanOrEqual(6);
+    expect(next.y + next.h).toBe(start.y + start.h);
+  });
+
+  it('holds the minimum height when the bottom edge is dragged inward', () => {
+    expect(resize({ bottom: true }, { x: 0, y: -5000 }).h).toBe(MIN.h);
+  });
+});

--- a/apps/web/src/features/dashboard/resize.ts
+++ b/apps/web/src/features/dashboard/resize.ts
@@ -1,0 +1,106 @@
+import { GRID_COLUMNS, GRID_MAX_ROWS } from './grid.constants';
+
+export interface GridRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/**
+ * Which edges of the widget the gesture moves. An edge handle sets one; a
+ * corner handle sets two, which anchors the opposite corner because the edges
+ * that aren't listed simply never move.
+ */
+export interface ResizeEdges {
+  left?: boolean;
+  right?: boolean;
+  top?: boolean;
+  bottom?: boolean;
+}
+
+/** Pixel distance from one cell origin to the next, gap included. */
+export interface CellPitch {
+  colSpanPx: number;
+  rowSpanPx: number;
+}
+
+/**
+ * Snaps a pixel delta to a whole number of cells, keeping the design's
+ * **½-cell snap with a `hysteresisPx` deadband**: the gesture must cross the
+ * half-cell line by at least `hysteresisPx` before the count changes,
+ * otherwise it sticks at `currentCells`. That is what stops a widget flickering
+ * between two spans when the pointer hovers exactly on a boundary.
+ */
+export function snapDeltaToCells(
+  deltaPx: number,
+  spanPx: number,
+  currentCells: number,
+  hysteresisPx: number,
+): number {
+  if (spanPx <= 0) return currentCells;
+  const exact = deltaPx / spanPx;
+  const candidate = Math.round(exact);
+  if (candidate === currentCells) return currentCells;
+  const hysteresisCells = hysteresisPx / spanPx;
+  if (candidate > currentCells) {
+    return exact >= currentCells + 0.5 + hysteresisCells ? candidate : currentCells;
+  }
+  return exact <= currentCells - 0.5 - hysteresisCells ? candidate : currentCells;
+}
+
+/**
+ * Resolves a pointer drag on a resize handle into the widget's next grid rect.
+ *
+ * `start` is the rect when the gesture began and is what every delta is
+ * measured from, so the result never drifts as the widget re-renders mid-drag.
+ * `current` is the rect right now, used only as the hysteresis tie-break.
+ *
+ * Only the edges named in `edges` move; the others hold, which is what anchors
+ * the opposite corner on a diagonal drag. The result is clamped so it always
+ * satisfies `WidgetPlacementSchema`: inside the 12 columns, at most 6 rows, at
+ * or above `minSize`, and never negative. Collision with other widgets is NOT
+ * considered here — `applyResize` reflows them out of the way (Req 4.6.5).
+ */
+export function resolveResizeRect(
+  start: GridRect,
+  current: GridRect,
+  deltaPx: { x: number; y: number },
+  edges: ResizeEdges,
+  pitch: CellPitch,
+  minSize: { w: number; h: number },
+  hysteresisPx: number,
+): GridRect {
+  let { x, y, w, h } = start;
+
+  if (edges.right) {
+    const dCols = snapDeltaToCells(deltaPx.x, pitch.colSpanPx, current.w - start.w, hysteresisPx);
+    w = start.w + dCols;
+    w = Math.max(minSize.w, Math.min(w, GRID_COLUMNS - x));
+  }
+
+  if (edges.left) {
+    const dCols = snapDeltaToCells(deltaPx.x, pitch.colSpanPx, current.x - start.x, hysteresisPx);
+    // The right edge is anchored, so x and w move together.
+    const right = start.x + start.w;
+    x = Math.min(Math.max(start.x + dCols, 0), right - minSize.w);
+    w = right - x;
+  }
+
+  if (edges.bottom) {
+    const dRows = snapDeltaToCells(deltaPx.y, pitch.rowSpanPx, current.h - start.h, hysteresisPx);
+    h = Math.max(minSize.h, Math.min(start.h + dRows, GRID_MAX_ROWS));
+  }
+
+  if (edges.top) {
+    const dRows = snapDeltaToCells(deltaPx.y, pitch.rowSpanPx, current.y - start.y, hysteresisPx);
+    // The bottom edge is anchored. `y` cannot go negative, and cannot rise so
+    // far that the widget would exceed the 6-row cap.
+    const bottom = start.y + start.h;
+    const lowestY = Math.max(0, bottom - GRID_MAX_ROWS);
+    y = Math.min(Math.max(start.y + dRows, lowestY), bottom - minSize.h);
+    h = bottom - y;
+  }
+
+  return { x, y, w, h };
+}

--- a/apps/web/src/routes/_auth.dashboard.test.tsx
+++ b/apps/web/src/routes/_auth.dashboard.test.tsx
@@ -182,6 +182,46 @@ describe('_auth.dashboard route', () => {
     expect(names).toEqual(DEFAULT_WIDGETS.map((d) => `user-1:${d.type}`));
   });
 
+  it('case 5b: layout mergers compose onto the pending write instead of replacing it', async () => {
+    // Regression guard. `scheduleLayoutWrite` debounces 300ms behind ONE pending
+    // body, so a handler that ignores the pending value discards whatever edit
+    // is already queued. A widget config fix-up landing just after a drag used
+    // to re-send the pre-drag positions, silently reverting the drag — for any
+    // drag within ~1.5s of page load. It also dropped a queued `theme` write.
+    const scheduleLayoutWrite = vi.fn();
+    // One type missing so the Add Widget picker has an entry to click.
+    const placed = sixDefaultWidgets.filter((w) => w.type !== 'equity-curve');
+    layoutMockValue = baseLayout({
+      data: { widgets: placed, theme: 'light', updatedAt: '2026-05-01T00:00:00.000Z' },
+      scheduleLayoutWrite,
+    });
+    renderRoute();
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Add Widget/i })[0]);
+    fireEvent.click(await screen.findByText('Equity Curve'));
+    expect(scheduleLayoutWrite).toHaveBeenCalledTimes(1);
+
+    const merger = scheduleLayoutWrite.mock.calls[0][0] as (prev: {
+      widgets?: WidgetPlacement[];
+      theme?: string;
+    }) => { widgets: WidgetPlacement[]; theme?: string };
+
+    // A drag is already queued: same widgets, moved. The merger must build on
+    // THOSE positions, not resurrect the ones from the query cache.
+    const dragged = placed.map((w) => ({ ...w, y: w.y + 20 }));
+    const result = merger({ widgets: dragged, theme: 'dark' });
+
+    // The queued theme survives.
+    expect(result.theme).toBe('dark');
+    // Every pre-existing widget keeps its DRAGGED position.
+    for (const w of dragged) {
+      expect(result.widgets.find((r) => r.id === w.id)?.y).toBe(w.y);
+    }
+    // And the add still happened.
+    expect(result.widgets).toHaveLength(dragged.length + 1);
+    expect(result.widgets.map((w) => w.type)).toContain('equity-curve');
+  });
+
   it('case 6: beforeunload listener fires flushPending on unload', () => {
     const flushPending = vi.fn();
     layoutMockValue = baseLayout({

--- a/apps/web/src/routes/_auth.dashboard.tsx
+++ b/apps/web/src/routes/_auth.dashboard.tsx
@@ -109,45 +109,72 @@ function DashboardPage(): ReactElement {
   // scheduleLayoutWrite. NEVER call it on every render.
   const widgets: WidgetPlacement[] = data?.widgets ?? [];
 
+  // `scheduleLayoutWrite` debounces for 300ms and keeps ONE pending body, so a
+  // handler that ignores the pending value silently discards whatever edit is
+  // already queued. Two ways that bites:
+  //
+  //   - A widget's config fix-up (§K) fires on mount, off a render-scoped
+  //     callback. If it lands after a drag it would re-send the pre-drag
+  //     positions and the drag is lost — reproducibly, for any drag within
+  //     ~1.5s of load.
+  //   - A `theme` write pending from `useAppTheme` would be dropped by the next
+  //     layout edit, since these handlers only ever set `widgets`.
+  //
+  // So every handler now merges onto the pending body, and computes from
+  // `pending.widgets` when one is queued. `widgetsRef` supplies the fallback so
+  // a stale render closure cannot resurrect an old layout either.
+  const widgetsRef = useRef<WidgetPlacement[]>(widgets);
+  widgetsRef.current = widgets;
+
   const handleAdd = useCallback(
     (placement: WidgetPlacement) => {
-      // The popover packs against an empty grid because it only knows the
-      // placed TYPES, so every widget it emits is positioned at (0, 0). Re-slot
-      // it here against the real placements — otherwise the new widget overlaps
-      // whatever is already at the origin and the PUT fails `checkNoOverlap`.
-      const { x, y } = findFirstSlot(widgets, { w: placement.w, h: placement.h });
-      const next = [...widgets, { ...placement, x, y }];
-      scheduleLayoutWrite(() => ({ widgets: next }));
+      scheduleLayoutWrite((pending) => {
+        // The popover packs against an empty grid because it only knows the
+        // placed TYPES, so every widget it emits is positioned at (0, 0).
+        // Re-slot it here against the real placements — otherwise the new
+        // widget overlaps whatever is at the origin and the PUT fails
+        // `checkNoOverlap`.
+        const base = pending.widgets ?? widgetsRef.current;
+        const { x, y } = findFirstSlot(base, { w: placement.w, h: placement.h });
+        return { ...pending, widgets: [...base, { ...placement, x, y }] };
+      });
     },
-    [widgets, scheduleLayoutWrite],
+    [scheduleLayoutWrite],
   );
 
   const handleRemove = useCallback(
     (id: string) => {
-      const next = widgets.filter((w) => w.id !== id);
-      scheduleLayoutWrite(() => ({ widgets: next }));
+      scheduleLayoutWrite((pending) => {
+        const base = pending.widgets ?? widgetsRef.current;
+        return { ...pending, widgets: base.filter((w) => w.id !== id) };
+      });
     },
-    [widgets, scheduleLayoutWrite],
+    [scheduleLayoutWrite],
   );
 
   const handleGridChange = useCallback(
     (next: WidgetPlacement[]) => {
-      scheduleLayoutWrite(() => ({ widgets: next }));
+      // The grid resolved these placements from its own live echo, so they are
+      // authoritative for geometry; only `theme` is carried over.
+      scheduleLayoutWrite((pending) => ({ ...pending, widgets: next }));
     },
     [scheduleLayoutWrite],
   );
 
   const handleUpdateConfig = useCallback(
     (widgetId: string, config: Record<string, unknown>) => {
-      const next = widgets.map((w) => {
-        if (w.id !== widgetId) return w;
-        const prev =
-          w.config && typeof w.config === 'object' ? (w.config as Record<string, unknown>) : {};
-        return { ...w, config: { ...prev, ...config } };
+      scheduleLayoutWrite((pending) => {
+        const base = pending.widgets ?? widgetsRef.current;
+        const next = base.map((w) => {
+          if (w.id !== widgetId) return w;
+          const prev =
+            w.config && typeof w.config === 'object' ? (w.config as Record<string, unknown>) : {};
+          return { ...w, config: { ...prev, ...config } };
+        });
+        return { ...pending, widgets: next };
       });
-      scheduleLayoutWrite(() => ({ widgets: next }));
     },
-    [widgets, scheduleLayoutWrite],
+    [scheduleLayoutWrite],
   );
 
   const handleUseDefaultLayout = useCallback(async () => {

--- a/apps/web/src/routes/_auth.dashboard.tsx
+++ b/apps/web/src/routes/_auth.dashboard.tsx
@@ -15,6 +15,7 @@ import { DashboardGrid } from '@/features/dashboard/components/DashboardGrid';
 import { DashboardHeader } from '@/features/dashboard/components/DashboardHeader';
 import { GRID_COLUMNS } from '@/features/dashboard/grid.constants';
 import { useDashboardLayout } from '@/features/dashboard/hooks/useDashboardLayout';
+import { findFirstSlot } from '@/features/dashboard/layout';
 import { useAuth } from '@/hooks/useAuth';
 
 /**
@@ -78,14 +79,7 @@ function DashboardPage(): ReactElement {
   const { user } = useAuth();
   const userId = user?.id ?? '';
   const layout = useDashboardLayout();
-  const {
-    data,
-    isLoading,
-    isError,
-    refetch,
-    flushPending,
-    scheduleLayoutWrite,
-  } = layout;
+  const { data, isLoading, isError, refetch, flushPending, scheduleLayoutWrite } = layout;
 
   // beforeunload: flush any pending debounced PUT (Req 1.9).
   useEffect(() => {
@@ -117,7 +111,12 @@ function DashboardPage(): ReactElement {
 
   const handleAdd = useCallback(
     (placement: WidgetPlacement) => {
-      const next = [...widgets, placement];
+      // The popover packs against an empty grid because it only knows the
+      // placed TYPES, so every widget it emits is positioned at (0, 0). Re-slot
+      // it here against the real placements — otherwise the new widget overlaps
+      // whatever is already at the origin and the PUT fails `checkNoOverlap`.
+      const { x, y } = findFirstSlot(widgets, { w: placement.w, h: placement.h });
+      const next = [...widgets, { ...placement, x, y }];
       scheduleLayoutWrite(() => ({ widgets: next }));
     },
     [widgets, scheduleLayoutWrite],
@@ -143,9 +142,7 @@ function DashboardPage(): ReactElement {
       const next = widgets.map((w) => {
         if (w.id !== widgetId) return w;
         const prev =
-          w.config && typeof w.config === 'object'
-            ? (w.config as Record<string, unknown>)
-            : {};
+          w.config && typeof w.config === 'object' ? (w.config as Record<string, unknown>) : {};
         return { ...w, config: { ...prev, ...config } };
       });
       scheduleLayoutWrite(() => ({ widgets: next }));
@@ -195,11 +192,7 @@ function DashboardPage(): ReactElement {
           title="Couldn't load your dashboard"
           description="Showing the default layout. Your changes will not be saved until we can reach the server."
           action={
-            <Button
-              type="button"
-              className="cursor-pointer"
-              onClick={() => refetch()}
-            >
+            <Button type="button" className="cursor-pointer" onClick={() => refetch()}>
               Retry
             </Button>
           }
@@ -251,7 +244,14 @@ function DashboardPage(): ReactElement {
   const placedTypes = widgets.map((w) => w.type);
   return (
     <div className="space-y-4">
-      <DashboardHeader placedTypes={placedTypes} onAdd={handleAdd} />
+      <DashboardHeader
+        placedTypes={placedTypes}
+        onAdd={handleAdd}
+        onResetLayout={() => {
+          void handleUseDefaultLayout();
+        }}
+        resetBusy={defaultBusy}
+      />
       <DashboardGrid
         widgets={widgets}
         onRemove={handleRemove}

--- a/e2e/tests/dashboard.spec.ts
+++ b/e2e/tests/dashboard.spec.ts
@@ -305,36 +305,59 @@ test.describe('Dashboard — desktop', () => {
     await loginViaUi(page, user.email);
     await ensureDefaultLayoutPopulated(page);
 
-    // Capture (data-widget-id, x, y) for the first two widgets.
+    // Capture the rendered order before the drag.
     const widgets = page.locator(WIDGET);
-    const first = widgets.nth(0);
-    const second = widgets.nth(1);
-    const firstId = await first.getAttribute('data-widget-id');
-    const secondId = await second.getAttribute('data-widget-id');
-    expect(firstId).toBeTruthy();
-    expect(secondId).toBeTruthy();
+    const idsBefore = (await widgets.evaluateAll((nodes) =>
+      nodes.map((n) => n.getAttribute('data-widget-id')),
+    )) as string[];
+    expect(idsBefore.length).toBeGreaterThan(1);
+    const [firstId, secondId] = idsBefore;
 
-    // Drag the first widget's drag handle onto the second widget.
+    const first = page.locator(`section[data-widget-id="${firstId}"]`);
+    const second = page.locator(`section[data-widget-id="${secondId}"]`);
     const firstHandle = first.locator('[data-drag-handle="true"]');
     await firstHandle.scrollIntoViewIfNeeded();
-    await firstHandle.dragTo(second);
 
-    // The debounced PUT fires ~300ms after the drag-end. Reload after a short
-    // settle — `expect.poll` loops the reload to ride out the debounce.
+    // Drive the drag with explicit mouse steps rather than `dragTo`. dnd-kit's
+    // PointerSensor arms on a 4px activation distance and then needs further
+    // pointermove events to resolve a droppable under the cursor; a single
+    // jump would drop with `over === null` and silently do nothing.
+    const handleBox = await firstHandle.boundingBox();
+    const targetBox = await second.boundingBox();
+    expect(handleBox).not.toBeNull();
+    expect(targetBox).not.toBeNull();
+    await page.mouse.move(
+      handleBox!.x + handleBox!.width / 2,
+      handleBox!.y + handleBox!.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      handleBox!.x + handleBox!.width / 2 + 12,
+      handleBox!.y + handleBox!.height / 2 + 12,
+      { steps: 5 },
+    );
+    await page.mouse.move(
+      targetBox!.x + targetBox!.width / 2,
+      targetBox!.y + targetBox!.height / 2,
+      { steps: 15 },
+    );
+    await page.mouse.up();
+
+    // The debounced PUT fires ~300ms after the drag-end.
     await page.waitForTimeout(500); // < 2s, allows debounce flush.
     await page.reload();
     await ensureDefaultLayoutPopulated(page);
 
-    // After reload, the two widgets should have swapped (x, y) — assert via
-    // the first widget's data-widget-id position relative to the second.
-    const firstAfter = page.locator(`section[data-widget-id="${firstId}"]`);
-    const secondAfter = page.locator(`section[data-widget-id="${secondId}"]`);
-    const firstBox = await firstAfter.boundingBox();
-    const secondBox = await secondAfter.boundingBox();
-    expect(firstBox).not.toBeNull();
-    expect(secondBox).not.toBeNull();
-    // Different positions — swap occurred.
-    expect(firstBox!.x !== secondBox!.x || firstBox!.y !== secondBox!.y).toBe(true);
+    const idsAfter = (await widgets.evaluateAll((nodes) =>
+      nodes.map((n) => n.getAttribute('data-widget-id')),
+    )) as string[];
+    expect(idsAfter).toHaveLength(idsBefore.length);
+    // The drop target took over the leading slot, and the dragged widget no
+    // longer holds it. Asserting the ORDER changed — not merely that two
+    // widgets sit at different coordinates, which is true of any grid and so
+    // passed even while the drag handle was inert.
+    expect(idsAfter[0]).toBe(secondId);
+    expect(idsAfter.indexOf(firstId)).toBeGreaterThan(0);
   });
 
   // -------------------------------------------------------------------------

--- a/packages/shared/src/constants/dashboard-defaults.ts
+++ b/packages/shared/src/constants/dashboard-defaults.ts
@@ -10,13 +10,23 @@ export type DefaultWidgetSpec = {
 
 // 12-column grid. Geometry only — IDs are computed per-user via uuidv5 in the
 // service layer, and config defaults come from the frontend widget registry.
+//
+// Proportions follow what each widget actually renders: the two charts get the
+// wide 8-column band, while Account Balances (a handful of figures) and
+// Position Sizing (a narrow form) sit in the 4-column rail beside them. Each
+// chart is paired with a rail widget of the SAME row span — rows in a CSS grid
+// are shared, so a 3-row chart beside a 2-row panel would stretch that panel
+// into a tall near-empty box.
+//
+// This list is also a valid left-to-right top-to-bottom packing of itself, in
+// declared order; `repackLayout` pins that (see layout.test.ts).
 export const DEFAULT_WIDGETS: readonly DefaultWidgetSpec[] = [
   { type: 'stats-summary', x: 0, y: 0, w: 12, h: 1 },
-  { type: 'performance-chart', x: 0, y: 1, w: 6, h: 2 },
-  { type: 'account-balances', x: 6, y: 1, w: 6, h: 2 },
-  { type: 'equity-curve', x: 0, y: 3, w: 6, h: 2 },
-  { type: 'position-sizing', x: 6, y: 3, w: 6, h: 3 },
-  { type: 'open-positions', x: 0, y: 6, w: 12, h: 2 },
+  { type: 'performance-chart', x: 0, y: 1, w: 8, h: 3 },
+  { type: 'account-balances', x: 8, y: 1, w: 4, h: 3 },
+  { type: 'equity-curve', x: 0, y: 4, w: 8, h: 3 },
+  { type: 'position-sizing', x: 8, y: 4, w: 4, h: 3 },
+  { type: 'open-positions', x: 0, y: 7, w: 12, h: 3 },
 ] as const;
 
 // Maximum size of a PUT /dashboard/layout request body. Enforced by the


### PR DESCRIPTION
## What was wrong

The four-dot drag handle did nothing. `<DashboardGrid>` rendered a `SortableContext` but **never called `useSortable`**, so no widget ever registered as draggable.

It shipped green because the E2E drag test only asserted that two widgets sat at *different* coordinates — true of any grid, whether or not the drag works.

## Latent defects found while repairing it

None could fire while drag and resize were inert:

- **`applyDragEnd` swapped `(x, y)`**, which overlaps whenever the two widgets differ in size. The server rejects overlaps (`checkNoOverlap`), so the first drag of Stats Summary onto Performance Chart would have 400'd and rolled back. Now re-packs instead.
- **`clampResize` capped height at `6 - y`**, which crushes a `y = 6` widget to `h = 1` — below its own minimum — and it never enforced `minSize` at all.
- **Add Widget always emitted `(0, 0)`.** The picker packs against an empty grid because it only knows placed *types*, so every re-added widget overlapped and 400'd. The route now re-slots against the real layout.
- **The corner resize handle was an empty `div`** with no event handlers, and `clampResize` was exported but never called by anything except its own tests.

## What changed

**Drag** — each cell registers with `useSortable` and threads the activator props into the card. The whole header is now the drag zone; the `::` button keeps the aria attributes and activator ref so it stays a focusable target. The `···` menu stops propagation so opening it never arms a drag.

**Resize** — seven handles (three edges + four corners, each anchoring the opposite corner). No top edge: the header owns that band. Because a left-edge or top-corner drag moves the *origin*, `clampResize` is replaced by `resolveResizeRect`, which resolves a full rect. Growing now pushes neighbours aside — clamping at the boundary left resize inert, since the default layout fills all 12 columns at every row and four of six widgets could not grow in any direction.

**Edit affordance** — the grid shows its cells and takes a background wash while a gesture is in flight, from pointer-down rather than first movement.

**Layout** — rows are `minmax(80px, auto)`, and the default layout pairs each chart with a same-height rail widget so a short widget is no longer stretched to its tall neighbour's row band. This also restores the geometry the design intended; the shipped defaults had drifted to a 6/6 split.

**Reset layout** — restores the defaults behind a confirmation, so a mangled layout no longer requires deleting six widgets by hand.

**Removed the `?` keyboard-help tooltip** — it documented a Tab → Space → arrows → Space flow that does not work. Tracked separately; the affordance is gone rather than left lying.

## Notable subtlety

The edit-mode backdrop cells are **absolutely positioned**, which is load-bearing rather than stylistic. As in-flow grid items they were single-row spans, giving every row track a finite growth limit — and CSS Grid then distributes a spanning widget's height differently. A short widget sharing rows with a tall one measured **176px → 281px** the moment edit mode engaged. That reflow also staled dnd-kit's drop rects (measured once at drag start), so drops silently snapped back. Hence also `MeasuringStrategy.Always`.

## Testing

- 825 web unit tests, 425 shared, 34 API dashboard tests — all green
- Typecheck and lint clean
- Manually verified in the browser: drag, resize on all seven handles, persistence across reload, and the edit affordance
- The E2E drag assertion is rewritten to check that **ordering actually changed**, and drives the gesture with explicit `page.mouse` steps — `dragTo()` is a single jump, which drops with `over === null` and does nothing

## Known gaps, deliberately not fixed here

- **Keyboard reorder does not work** (undiagnosed). The `?` tooltip is removed rather than left lying about it.
- **Per-action undo toasts do not exist.** Reset layout covers the worst case but is not undo.