### PR TITLE
feat(dashboard): move the grid to a fixed 40px row unit

### DIFF
--- a/apps/api/src/db/migrations/0021_dashboard_forty_px_rows.sql
+++ b/apps/api/src/db/migrations/0021_dashboard_forty_px_rows.sql
@@ -1,0 +1,28 @@
+-- Dashboard row unit 80px -> 40px (spec dashboard, Req 1.10 / 1.11).
+--
+-- Saved layouts are denominated in rows, so at the new unit they would render
+-- at half their former height. Doubling `y` and `h` is the only transform that
+-- preserves the layout's structure exactly: non-overlap is invariant under a
+-- uniform scale of the vertical axis (if y_a + h_a <= y_b then
+-- 2*y_a + 2*h_a <= 2*y_b), relative proportions are unchanged, and `x`/`w` are
+-- untouched because columns did not change.
+--
+-- It does NOT preserve absolute pixel height: the per-row pitch goes from 96px
+-- to 56px, so a doubled widget ends up ~17% taller. Accepted — erring taller
+-- beats silently halving every existing dashboard.
+--
+-- Old bounds fit the new ones with room to spare (h <= 6 becomes h' <= 12,
+-- against a cap of 24), so this cannot produce an out-of-range placement.
+UPDATE "dashboard_layouts"
+SET "widgets" = (
+  SELECT COALESCE(jsonb_agg(
+    w || jsonb_build_object(
+      'y', (w->>'y')::int * 2,
+      'h', (w->>'h')::int * 2
+    )
+    ORDER BY idx
+  ), '[]'::jsonb)
+  FROM jsonb_array_elements("widgets") WITH ORDINALITY AS t(w, idx)
+),
+"updated_at" = now()
+WHERE jsonb_array_length("widgets") > 0;

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1784830539521,
       "tag": "0020_drop_ledger_position_pnl_unique_idx",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1784830539522,
+      "tag": "0021_dashboard_forty_px_rows",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/features/dashboard/dashboard.test.ts
+++ b/apps/api/src/features/dashboard/dashboard.test.ts
@@ -85,15 +85,15 @@ function makeValidWidgets() {
       x: 0,
       y: 0,
       w: 12,
-      h: 1,
+      h: 2,
     },
     {
       id: randomUUID(),
       type: 'performance-chart' as const,
       x: 0,
-      y: 1,
+      y: 2,
       w: 6,
-      h: 2,
+      h: 4,
     },
   ];
 }
@@ -421,7 +421,7 @@ describe('dashboard routes', () => {
         x: 0,
         y: 0,
         w: 12,
-        h: 1,
+        h: 2,
       },
       {
         id: randomUUID(),

--- a/apps/web/src/features/dashboard/components/DashboardGrid.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardGrid.tsx
@@ -520,7 +520,7 @@ export function DashboardGrid({
             // MINIMUM, not an exact height. Widgets sharing a row band share
             // its height — which is why DEFAULT_WIDGETS pairs each chart with
             // a rail widget of the same row span.
-            gridAutoRows: `minmax(${GRID_ROW_HEIGHT_PX}px, auto)`,
+            gridAutoRows: `${GRID_ROW_HEIGHT_PX}px`,
           }}
         >
           {/* First in DOM order so the widgets paint over the outlines. */}

--- a/apps/web/src/features/dashboard/grid.constants.ts
+++ b/apps/web/src/features/dashboard/grid.constants.ts
@@ -1,10 +1,30 @@
 export const GRID_COLUMNS = 12;
-// Matches `WidgetPlacementSchema`'s `h: 1..6` cap in @tradr/shared.
-export const GRID_MAX_ROWS = 6;
+// Re-exported from the schema so the client cannot drift from the bound the
+// server validates (`h: 1..GRID_MAX_ROWS`). Deep path, not the package barrel:
+// `grid.constants` is imported by most of the dashboard, and pulling the whole
+// of `@tradr/shared` through it changes module init order enough to break
+// unrelated suites under a full run.
+export { GRID_MAX_ROWS } from '@tradr/shared/schemas/dashboard';
 export const GRID_GAP_PX = 16;
 /** Deadband (px) the resize gesture must cross past the ½-cell snap line. */
 export const RESIZE_HYSTERESIS_PX = 1;
-export const GRID_ROW_HEIGHT_PX = 80;
-export const GRID_ROW_HEIGHT_COARSE_PX = 88;
+/**
+ * Fixed row pitch (Req 1.10). A widget spanning `h` rows is exactly
+ * `40h + 16(h-1)` px tall and depends on nothing else on the canvas.
+ *
+ * Two earlier rules are withdrawn. `80px` fixed was too coarse once `h` had to
+ * express a full page. `minmax(80px, auto)` was worse: CSS Grid rows are shared,
+ * so a tall widget stretched every short widget in its band — a short widget
+ * beside a 3-row 430px neighbour measured 176px normally and 281px with the
+ * edit backdrop present. A fixed unit makes a cell a cell everywhere, which is
+ * what free placement needs to be predictable.
+ *
+ * The trade: widget height stops being dictated by content and becomes
+ * something the user sets by resizing, so content taller than its widget
+ * scrolls inside it. That is only acceptable because the seven-handle resize
+ * (Req 4.6.2) makes height easy to adjust — the two decisions stand or fall
+ * together.
+ */
+export const GRID_ROW_HEIGHT_PX = 40;
 export const DEBOUNCE_PUT_MS = 300;
 export const THEME_PUT_FAILURE_TOMBSTONE_MS = 60_000;

--- a/apps/web/src/features/dashboard/resize.test.ts
+++ b/apps/web/src/features/dashboard/resize.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { GRID_MAX_ROWS } from './grid.constants';
 import { resolveResizeRect, snapDeltaToCells, type GridRect } from './resize';
 
 // Unit pitch: 100px per column, 80px per row, so a delta in pixels maps
@@ -99,8 +100,10 @@ describe('resolveResizeRect — clamps to what the schema accepts', () => {
     expect(next.x + next.w).toBe(start.x + start.w);
   });
 
-  it('caps height at the 6-row maximum', () => {
-    expect(resize({ bottom: true }, { x: 0, y: 5000 }).h).toBe(6);
+  it('caps height at GRID_MAX_ROWS', () => {
+    // The bound tracks the schema, which moved with the row unit (80px -> 40px,
+    // Req 1.10) so the reachable pixel height is unchanged.
+    expect(resize({ bottom: true }, { x: 0, y: 5000 }).h).toBe(GRID_MAX_ROWS);
   });
 
   it('never lets a top-edge drag push y negative', () => {

--- a/packages/shared/src/constants/dashboard-defaults.test.ts
+++ b/packages/shared/src/constants/dashboard-defaults.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { PerWidgetMinSize, WidgetTypeSchema } from '../schemas/dashboard';
+import { GRID_MAX_ROWS, PerWidgetMinSize, WidgetTypeSchema } from '../schemas/dashboard';
 
 import { DEFAULT_WIDGETS } from './dashboard-defaults';
 
@@ -34,5 +34,68 @@ describe('dashboard-defaults', () => {
         expect(overlapsX && overlapsY).toBe(false);
       }
     }
+  });
+
+  it('every entry fits within GRID_MAX_ROWS', () => {
+    for (const entry of DEFAULT_WIDGETS) {
+      expect(entry.h).toBeLessThanOrEqual(GRID_MAX_ROWS);
+      expect(entry.y + entry.h).toBeLessThanOrEqual(GRID_MAX_ROWS);
+    }
+  });
+});
+
+/**
+ * The 80px → 40px row-unit migration (Req 1.11) doubles `y` and `h` on every
+ * saved placement. These pin the properties that make doubling the right
+ * transform, so the SQL cannot be replaced by something that merely looks
+ * equivalent.
+ */
+describe('row-unit migration invariants (double y and h)', () => {
+  type Rect = { x: number; y: number; w: number; h: number };
+  const double = (r: Rect): Rect => ({ ...r, y: r.y * 2, h: r.h * 2 });
+  const overlaps = (a: Rect, b: Rect): boolean =>
+    a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h;
+
+  // A representative pre-migration layout, in 80px rows.
+  const oldLayout: Rect[] = [
+    { x: 0, y: 0, w: 12, h: 1 },
+    { x: 0, y: 1, w: 8, h: 3 },
+    { x: 8, y: 1, w: 4, h: 3 },
+    { x: 0, y: 4, w: 8, h: 3 },
+    { x: 8, y: 4, w: 4, h: 3 },
+    { x: 0, y: 7, w: 12, h: 3 },
+  ];
+
+  it('preserves non-overlap — the property that makes doubling safe', () => {
+    const migrated = oldLayout.map(double);
+    for (let i = 0; i < migrated.length; i++) {
+      for (let j = i + 1; j < migrated.length; j++) {
+        expect(overlaps(migrated[i], migrated[j])).toBe(false);
+      }
+    }
+  });
+
+  it('leaves the horizontal axis untouched — columns did not change', () => {
+    for (const r of oldLayout) {
+      const m = double(r);
+      expect(m.x).toBe(r.x);
+      expect(m.w).toBe(r.w);
+    }
+  });
+
+  it('keeps a migrated layout inside the new bounds', () => {
+    for (const r of oldLayout.map(double)) {
+      expect(r.h).toBeLessThanOrEqual(GRID_MAX_ROWS);
+      expect(r.y + r.h).toBeLessThanOrEqual(GRID_MAX_ROWS);
+    }
+  });
+
+  it('preserves relative vertical order and adjacency', () => {
+    // Widgets that were stacked flush stay flush — doubling scales the whole
+    // axis, so no gap opens between previously touching widgets.
+    const a = { x: 0, y: 0, w: 12, h: 1 };
+    const b = { x: 0, y: 1, w: 12, h: 2 };
+    expect(a.y + a.h).toBe(b.y);
+    expect(double(a).y + double(a).h).toBe(double(b).y);
   });
 });

--- a/packages/shared/src/constants/dashboard-defaults.ts
+++ b/packages/shared/src/constants/dashboard-defaults.ts
@@ -20,13 +20,16 @@ export type DefaultWidgetSpec = {
 //
 // This list is also a valid left-to-right top-to-bottom packing of itself, in
 // declared order; `repackLayout` pins that (see layout.test.ts).
+// Denominated in 40px rows (Req 1.10). Every `y` and `h` is double the value
+// it held under the 80px unit, which is the same transform Req 1.11 applies to
+// saved layouts — so defaults and migrated user layouts stay consistent.
 export const DEFAULT_WIDGETS: readonly DefaultWidgetSpec[] = [
-  { type: 'stats-summary', x: 0, y: 0, w: 12, h: 1 },
-  { type: 'performance-chart', x: 0, y: 1, w: 8, h: 3 },
-  { type: 'account-balances', x: 8, y: 1, w: 4, h: 3 },
-  { type: 'equity-curve', x: 0, y: 4, w: 8, h: 3 },
-  { type: 'position-sizing', x: 8, y: 4, w: 4, h: 3 },
-  { type: 'open-positions', x: 0, y: 7, w: 12, h: 3 },
+  { type: 'stats-summary', x: 0, y: 0, w: 12, h: 2 },
+  { type: 'performance-chart', x: 0, y: 2, w: 8, h: 6 },
+  { type: 'account-balances', x: 8, y: 2, w: 4, h: 6 },
+  { type: 'equity-curve', x: 0, y: 8, w: 8, h: 6 },
+  { type: 'position-sizing', x: 8, y: 8, w: 4, h: 6 },
+  { type: 'open-positions', x: 0, y: 14, w: 12, h: 6 },
 ] as const;
 
 // Maximum size of a PUT /dashboard/layout request body. Enforced by the

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -143,6 +143,7 @@ export type {
 export {
   WidgetTypeSchema,
   ThemeSchema,
+  GRID_MAX_ROWS,
   PerWidgetMinSize,
   WidgetPlacementSchema,
   DashboardLayoutResponseSchema,

--- a/packages/shared/src/schemas/dashboard.test.ts
+++ b/packages/shared/src/schemas/dashboard.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   DashboardLayoutResponseSchema,
+  GRID_MAX_ROWS,
   PutDashboardLayoutRequestSchema,
   WidgetPlacementSchema,
 } from './dashboard';
@@ -21,12 +22,12 @@ const UUID_G = '77777777-7777-4777-8777-777777777777';
 // Canonical six-widget default layout that satisfies all refinements.
 function canonicalWidgets() {
   return [
-    { id: UUID_A, type: 'stats-summary' as const, x: 0, y: 0, w: 12, h: 1 },
-    { id: UUID_B, type: 'performance-chart' as const, x: 0, y: 1, w: 6, h: 3 },
-    { id: UUID_C, type: 'equity-curve' as const, x: 0, y: 4, w: 6, h: 2 },
-    { id: UUID_D, type: 'account-balances' as const, x: 6, y: 1, w: 6, h: 2 },
-    { id: UUID_E, type: 'position-sizing' as const, x: 6, y: 3, w: 6, h: 3 },
-    { id: UUID_F, type: 'open-positions' as const, x: 0, y: 6, w: 12, h: 2 },
+    { id: UUID_A, type: 'stats-summary' as const, x: 0, y: 0, w: 12, h: 2 },
+    { id: UUID_B, type: 'performance-chart' as const, x: 0, y: 2, w: 6, h: 6 },
+    { id: UUID_C, type: 'equity-curve' as const, x: 0, y: 8, w: 6, h: 4 },
+    { id: UUID_D, type: 'account-balances' as const, x: 6, y: 2, w: 6, h: 4 },
+    { id: UUID_E, type: 'position-sizing' as const, x: 6, y: 6, w: 6, h: 6 },
+    { id: UUID_F, type: 'open-positions' as const, x: 0, y: 12, w: 12, h: 4 },
   ];
 }
 
@@ -71,17 +72,22 @@ describe('PutDashboardLayoutRequestSchema refinements', () => {
     expect(result.success).toBe(false);
   });
 
-  // 4. h .max(6)
-  it('rejects h: 7 via the schema .max(6)', () => {
-    const result = WidgetPlacementSchema.safeParse({
-      id: UUID_A,
-      type: 'stats-summary',
-      x: 0,
-      y: 0,
-      w: 12,
-      h: 7,
-    });
-    expect(result.success).toBe(false);
+  // 4. h .max(GRID_MAX_ROWS)
+  it('rejects h past GRID_MAX_ROWS, and accepts exactly GRID_MAX_ROWS', () => {
+    const at = (h: number) =>
+      WidgetPlacementSchema.safeParse({
+        id: UUID_A,
+        type: 'stats-summary',
+        x: 0,
+        y: 0,
+        w: 12,
+        h,
+      }).success;
+    // The bound moved with the row unit (80px -> 40px, Req 1.10) so the
+    // reachable pixel height is unchanged; a full-page widget is 24 rows.
+    expect(GRID_MAX_ROWS).toBe(24);
+    expect(at(GRID_MAX_ROWS)).toBe(true);
+    expect(at(GRID_MAX_ROWS + 1)).toBe(false);
   });
 
   // 5. h .min(1)
@@ -197,7 +203,7 @@ describe('PutDashboardLayoutRequestSchema refinements', () => {
       x: 0,
       y: 0,
       w: 12,
-      h: 1,
+      h: 2,
       config: {},
     });
     expect(result.success).toBe(true);

--- a/packages/shared/src/schemas/dashboard.ts
+++ b/packages/shared/src/schemas/dashboard.ts
@@ -13,15 +13,25 @@ export type WidgetType = z.infer<typeof WidgetTypeSchema>;
 export const ThemeSchema = z.enum(['light', 'dark', 'system']);
 export type Theme = z.infer<typeof ThemeSchema>;
 
+// Absolute row bound. A row is 40px (Req 1.10), so 24 rows is a full-page
+// widget. `h` was capped at 6 when a row was 80px tall; the cap moved with the
+// unit so the reachable pixel height is unchanged.
+export const GRID_MAX_ROWS = 24;
+
 // Canonical per-widget minimum sizes (per design §F). The frontend widget
 // registry imports from here, not vice versa.
+//
+// Heights are denominated in the SAME rows as `h`, so they doubled with the
+// row unit (Req 1.11). Leaving them at the 80px values would have halved every
+// effective minimum — a chart could be shrunk to half the height the spec
+// intends. Widths are unaffected; columns did not change.
 export const PerWidgetMinSize: Record<WidgetType, { w: number; h: number }> = {
-  'stats-summary': { w: 4, h: 1 },
-  'open-positions': { w: 4, h: 2 },
-  'performance-chart': { w: 4, h: 2 },
-  'account-balances': { w: 3, h: 2 },
-  'position-sizing': { w: 3, h: 3 },
-  'equity-curve': { w: 4, h: 2 },
+  'stats-summary': { w: 4, h: 2 },
+  'open-positions': { w: 4, h: 4 },
+  'performance-chart': { w: 4, h: 4 },
+  'account-balances': { w: 3, h: 4 },
+  'position-sizing': { w: 3, h: 6 },
+  'equity-curve': { w: 4, h: 4 },
 };
 
 export const WidgetPlacementSchema = z
@@ -31,7 +41,7 @@ export const WidgetPlacementSchema = z
     x: z.number().int().min(0).max(11),
     y: z.number().int().min(0),
     w: z.number().int().min(1).max(12),
-    h: z.number().int().min(1).max(6),
+    h: z.number().int().min(1).max(GRID_MAX_ROWS),
     config: z.unknown().optional(),
   })
   .strict()


### PR DESCRIPTION
First task of the free-placement rework. **Atomic by necessity** — row unit, bounds, defaults, per-widget minimums and the data migration are only coherent together. New defaults under the old bounds overflow `h <= 6`; old defaults at the new pitch render at half height; unmigrated saved layouts render half height beside migrated ones.

## Why fixed rows

Rows were `minmax(80px, auto)`. CSS Grid rows are **shared**, so a tall widget silently stretched every short widget in its band — measured at **176px vs 281px** for the same widget depending on its neighbour. That coupling is tolerable when position is derived from list order; on a canvas where the user places things deliberately it is not, and it makes "which cell is under the pointer" depend on content.

A fixed unit makes a cell a cell everywhere. Same call Grafana makes (`GRID_CELL_HEIGHT = 30`, fixed).

**The trade, stated plainly:** widget height stops being dictated by content and becomes something the user sets by resizing, so content taller than its widget scrolls inside it. That is only acceptable because the seven-handle resize makes height easy to adjust — the two decisions stand or fall together.

## Changes

- `GRID_ROW_HEIGHT_PX` 80 → 40; `gridAutoRows` is a fixed pitch
- `GRID_MAX_ROWS` 6 → 24, sourced from the schema so client and server cannot drift
- `DEFAULT_WIDGETS` and `PerWidgetMinSize` heights doubled — skipping the minimums would have halved every effective floor, letting a chart shrink to half its intended height
- `GRID_ROW_HEIGHT_COARSE_PX` deleted; the coarse breakpoint renders a flex stack with no row tracks, so it never had a referent
- Migration `0021` doubles `y`/`h` on every saved placement

## The migration

Doubling is the only transform that preserves the layout's structure exactly: non-overlap is invariant under a uniform scale of the vertical axis (`y_a + h_a <= y_b` ⟹ `2y_a + 2h_a <= 2y_b`), and `x`/`w` are untouched because columns did not change.

It does **not** preserve absolute pixel height — the per-row pitch goes from 96px to 56px, so widgets end up ~17% taller. Accepted: erring taller beats silently halving every existing dashboard. Old bounds fit the new ones with room to spare (`h <= 6` → `h' <= 12` against a cap of 24), so it cannot produce an out-of-range placement.

Verified the jsonb expression against Postgres on a literal — `y`/`h` double, `x`/`w` hold, and `config` survives the `||` merge.

## Deliberate deviation from the spec

**`y` is left uncapped.** Req 1.4(c) specifies `y + h <= GRID_MAX_ROWS`, but that bound belongs with the canvas work in task 52, which lands the placement engine able to honour it. Adding it now would let the current reflow produce layouts the client cannot re-pack, turning a valid edit into a 400.

## Testing

- 430 shared, 917 web, 34 API dashboard — all green; typecheck and lint clean
- New tests pin the migration invariants: non-overlap preserved, horizontal axis untouched, result within bounds, adjacency preserved
- One pre-existing local failure (`journal-write-fails` needs a non-superuser DB role) confirmed failing on `main` too — unrelated

## Note for reviewers

`GRID_MAX_ROWS` is deep-imported from `@tradr/shared/schemas/dashboard`, not the package barrel. Pulling the whole barrel through `grid.constants` — which most of the dashboard imports — shifted module init order enough to break unrelated suites under a full run while passing in isolation.