### PR TITLE
fix(db): close idle pool connections so resumed hosts re-dial

### DIFF
--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -20,8 +20,27 @@ export function poolerDriverOptions(transactionPooler: boolean): { prepare?: fal
   return transactionPooler ? { prepare: false } : {};
 }
 
+/**
+ * Seconds an unused pooled connection is kept open. postgres.js defaults to
+ * `null` — idle connections are NEVER closed — which leaves the pool holding
+ * sockets the server may already have dropped: a pooler that reaps idle
+ * backends, a NAT that expires the flow, or a host that suspends. The next
+ * query then writes into a dead socket and blocks on TCP retransmit for
+ * minutes rather than failing fast or dialing fresh.
+ *
+ * postgres.js's own staleness guards do not cover the suspend case:
+ * `max_lifetime` (30–60min) and `keep_alive` (60s) are in-process timers, so
+ * they freeze with the host. Closing the connection ourselves while still
+ * running is what makes resume safe.
+ *
+ * 60s sits below every idle reaper we run behind while staying far above
+ * normal request spacing, so a warm instance re-dials rarely.
+ */
+const IDLE_TIMEOUT_SECONDS = 60;
+
 const sql = postgres(config.DATABASE_URL, {
   max: config.DB_POOL_SIZE,
+  idle_timeout: IDLE_TIMEOUT_SECONDS,
   ...poolerDriverOptions(config.DB_TRANSACTION_POOLER),
 });
 

--- a/apps/api/src/db/pool-idle-timeout.test.ts
+++ b/apps/api/src/db/pool-idle-timeout.test.ts
@@ -1,0 +1,28 @@
+/**
+ * App-pool idle-connection recycling.
+ *
+ * postgres.js defaults `idle_timeout` to `null`, meaning idle connections are
+ * never closed. A pool that holds them indefinitely will, after the host
+ * suspends or a pooler reaps the backend, resume with sockets the server has
+ * already dropped — and the next query blocks on TCP retransmit instead of
+ * dialing fresh. The app pool must therefore set the option explicitly.
+ */
+import postgres from 'postgres';
+import { describe, it, expect } from 'vitest';
+
+import { sql } from '@/db';
+
+describe('app-pool idle timeout', () => {
+  it('closes idle connections instead of holding them open forever', () => {
+    expect(sql.options.idle_timeout).toBe(60);
+  });
+
+  it('pins the postgres.js default the option exists to override', async () => {
+    const bare = postgres('postgresql://user:pass@localhost:5432/db', { max: 10 });
+    try {
+      expect(bare.options.idle_timeout).toBeNull();
+    } finally {
+      await bare.end({ timeout: 0 });
+    }
+  });
+});


### PR DESCRIPTION
## What & why

postgres.js defaults `idle_timeout` to `null`, so the app pool never closes an
idle connection. Confirmed against the installed source (`postgres/src/index.js:452`):

```js
idle_timeout    : null,
connect_timeout : 30,
max_lifetime    : max_lifetime,  // 30–60 min, randomised
keep_alive      : 60,
```

When a host is suspended and later resumed — or a pooler reaps the backend, or a
NAT expires the flow — the pool comes back holding sockets the server has already
dropped. The next query writes into a dead socket and blocks on TCP retransmit for
minutes instead of failing fast or dialing a fresh connection.

That is enough to take an instance out of service. `GET /api/health` runs
`SELECT 1` on the same pool (`apps/api/src/features/health/health.route.ts:23`),
so a health check wired to it times out. A load balancer that gates routing on
that check stops sending traffic to the instance until a later check passes, and
serves its own error responses meanwhile. Those responses carry no CORS headers,
so a split-origin SPA surfaces the outage as a failed preflight — "No
'Access-Control-Allow-Origin' header" — which points the investigation at CORS
config that is in fact correct. The `net::ERR_FAILED` next to it is the tell.

postgres.js's own staleness guards do not cover this case: `max_lifetime` and
`keep_alive` are in-process timers, so they freeze along with a suspended host.
Closing idle connections while the process is still running is what makes resume
safe.

Observed as intermittent login failures on a deployment whose instances suspend
when idle; every request after the routing recovered succeeded, with the failing
ones absent from the application log entirely.

## Change

`idle_timeout: 60` on the app pool. 60s sits below the idle reapers we run behind
while staying well above normal request spacing, so a warm instance rarely
re-dials. No config surface added — this is not an operator knob.

No linked issue — found while investigating a deployment incident.

## Checklist

- [x] One focused, logical change (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
- [x] Every commit is signed off (`git commit -s`) — the DCO is required.
- [x] Conventional Commit title (`feat:`, `fix:`, `chore:`, `docs:`, …), first line under 72 characters.
- [x] `pnpm check-types` and `pnpm lint` pass locally (both full-workspace, clean).
      Tests were run **scoped**, not as a full `pnpm test` — `vitest --project api`
      over `db/pool-idle-timeout`, `db/pooler-correctness` (13 passed) and
      `app.self-host-parity` (5 passed). CI covers the full suite.
- [x] Tests added or updated for the behavior this PR changes.
- [x] No API endpoint changed, so no OpenAPI/Swagger update is needed.

## Tests

`apps/api/src/db/pool-idle-timeout.test.ts` asserts the pool sets the option, and
pins the upstream `null` default that the option exists to override — so if
postgres.js ever changes that default and makes this redundant, it surfaces as a
failing test rather than silently.
