### PR TITLE
fix(config): tolerate blank optional encryption keys, and test the quickstart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,11 +240,15 @@ jobs:
     timeout-minutes: 15
 
     # Boot the full compose stack against a FRESH, EMPTY throwaway Postgres
-    # (named volume torn down with `down -v`). The api boots with ONLY
-    # DATABASE_URL, SESSION_SECRET and ENCRYPTION_KEY set — neither encryption
-    # gate is exercised here (no ENCRYPTION_KEY_FINGERPRINT, no
-    # ENCRYPTION_KEY_PREVIOUS), so the api degrades gracefully and runs its
-    # migrations on boot. POSTGRES_* feed both the throwaway postgres init and
+    # (named volume torn down with `down -v`). The .env is written by
+    # ./docker/quickstart.sh, the script the README documents, so this job also
+    # covers the setup instructions themselves.
+    #
+    # That means ENCRYPTION_KEY_FINGERPRINT IS now set and its startup gate is
+    # exercised: the script derives it from the ENCRYPTION_KEY below, and a bad
+    # derivation would exit(1) on boot and fail this job. Only
+    # ENCRYPTION_KEY_PREVIOUS (rotation) stays unexercised.
+    # POSTGRES_* feed both the throwaway postgres init and
     # the DATABASE_URL the base compose builds in api.environment; they are not
     # app secrets. WEB_PORT avoids the runner's other dev ports.
     env:
@@ -261,18 +265,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      # Write the .env the base compose reads (env_file: .env). DATABASE_URL is
-      # built from POSTGRES_* in api.environment, so it is NOT set here.
-      - name: Write CI .env
-        run: |
-          cat > .env <<EOF
-          POSTGRES_USER=${POSTGRES_USER}
-          POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-          POSTGRES_DB=${POSTGRES_DB}
-          SESSION_SECRET=${SESSION_SECRET}
-          ENCRYPTION_KEY=${ENCRYPTION_KEY}
-          WEB_PORT=${WEB_PORT}
-          EOF
+      # Write the .env the base compose reads (env_file: .env) by running the
+      # SAME script the README tells a self-hoster to run. This is the point: the
+      # documented setup path is executed on every push instead of proofread, so
+      # the quickstart cannot rot into instructions that no longer work.
+      #
+      # --env-only stops before `docker compose up -d`, because the steps below
+      # need the CI overlay to boot local images rather than GHCR tags. The env
+      # vars above are pre-set, and the script honours them instead of generating
+      # random ones — DATABASE_URL stays unset, built from POSTGRES_* in
+      # api.environment.
+      - name: Write .env via the documented quickstart
+        run: ./docker/quickstart.sh --env-only
 
       # Build BOTH images locally and load them into the daemon under the exact
       # refs the base compose resolves (R5 — this is the real guarantee CI tests

--- a/README.md
+++ b/README.md
@@ -1,108 +1,131 @@
-# Tradr
+<h1 align="center">▴ Tradr</h1>
 
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
+<p align="center">
+  <strong>The open-source trading journal that shows its work.</strong><br>
+  Log every fill, size the trade before you take it, and ask an AI advisor about your own P&amp;L.
+</p>
 
-A self-hostable trading journal and analysis platform. Log trades, review
-performance, and (optionally) get AI advisor feedback. It runs as a plain manual
-journal with **no optional keys** configured — the AI advisor and external
-integrations are opt-in. See
-[docs/external-services.md](docs/external-services.md) for the full inventory
-of external services and what enables each.
+<p align="center">
+  <a href="./LICENSE"><img alt="License: Apache 2.0" src="https://img.shields.io/badge/License-Apache_2.0-blue.svg"></a>
+  <a href="https://github.com/madmatt112/tradr/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/madmatt112/tradr/actions/workflows/ci.yml/badge.svg?branch=main"></a>
+  <a href="https://github.com/madmatt112/tradr/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/madmatt112/tradr?sort=semver"></a>
+</p>
 
-## Self-hosting quickstart
+<!-- Screenshot slot: a real capture of a seeded instance goes here. Do not use
+     the marketing hero mock — its figures are illustrative sample data, and an
+     invented equity curve in the README of a finance tool is a credibility risk. -->
 
-Requires Docker with Compose v2 (`docker compose`).
+Tradr is a self-hostable journal for options and equities traders. It records the whole
+arc of a position — draft, scale-in, partial close — with every fill, fee, and note
+attached, then shows you what your record actually says.
+
+It runs as a complete manual journal with **no keys configured at all**. The AI advisor
+and every external integration are opt-in, and nothing phones home until you switch it
+on. It never places an order.
+
+## Try it, or run it
+
+- **Hosted** — [app.tradr.cloud](https://app.tradr.cloud). Managed, free tier, nothing to run.
+- **Self-hosted** — free and completely unlimited, forever. No feature is fenced off;
+  plan gating is a single deployment setting that ships **off**.
+
+## Quickstart
+
+Requires Docker with Compose v2 and `openssl`. About two minutes.
 
 ```bash
-# 1. Clone
-git clone <repo-url> tradr
+git clone https://github.com/madmatt112/tradr.git
 cd tradr
-
-# 2. Create your env file from the template
-cp .env.example .env
-
-# 3. Generate the required secrets and paste them into .env:
-openssl rand -base64 24   # -> SESSION_SECRET (>=32 chars)
-openssl rand -hex 24      # -> POSTGRES_PASSWORD (URL-safe; hex avoids @ : / ?)
-openssl rand -hex 32      # -> ENCRYPTION_KEY
-
-# 4. Set POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB in .env.
-#    Compose derives DATABASE_URL for the api from these — do NOT set it yourself.
-
-# 5. Start the stack
-docker compose up -d
+./docker/quickstart.sh
 ```
 
-The web UI is published on `http://localhost:8080` by default (override with
-`WEB_PORT` in `.env`). Check liveness:
+The script generates the three required secrets, writes your `.env`, starts the stack,
+and waits for the API to report healthy. It never overwrites an existing `.env`. When it
+finishes, Tradr is on <http://localhost:8080> (override with `WEB_PORT`).
 
-```bash
-curl -fsS http://localhost:8080/api/health    # {"status":"ok","version":"vX.Y.Z"}
-```
+This is the same script CI runs in its `docker-smoke` job, so these instructions are
+executed on every push rather than proofread. To do it by hand instead, or to run behind
+TLS, against your own Postgres, or on a different port, see the
+[self-hosting guide](https://www.tradr.cloud/docs/self-hosting/docker-compose/).
 
-### Required vs. optional
+## Status
 
-**Required** (the stack will not work without these):
+**v0.5.x — pre-1.0, and moving quickly.** What that promises:
 
-- `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` — database credentials.
-  Compose builds the api's `DATABASE_URL` from them.
-- `SESSION_SECRET` — auth session signing key (≥32 chars).
-- `ENCRYPTION_KEY` — 32-byte hex key used to encrypt stored provider keys.
+- **The HTTP API is not stable yet.** Breaking endpoint changes can land in any release
+  until v1.0.0. Pin a tag rather than tracking `:latest` if that matters to you.
+- **Migrations are forward-only and run automatically on API startup.** There are no
+  down-migrations. Schema changes are split expand-then-contract across releases, so
+  redeploying the previous image stays a viable recovery.
+- **Releases are CI-gated.** A tag publishes images only after CI passes on that exact
+  commit.
+- **Back up before every upgrade.** See the [deployment runbook](docs/runbooks/deployment.md).
 
-**Optional** — Tradr runs as a manual journal without any of these:
+Full policy — what counts as a breaking change, which surfaces are covered — in
+[`docs/versioning.md`](docs/versioning.md). Release notes are the changelog: see
+[Releases](https://github.com/madmatt112/tradr/releases), which the app also renders
+in-product.
 
-- AI advisor provider keys (added in-app, encrypted with `ENCRYPTION_KEY`).
-- `ENCRYPTION_KEY_FINGERPRINT` — recommended; pins the key so a wrong-key boot
-  fails fast (see the runbook).
-- `ENCRYPTION_KEY_PREVIOUS` — only used during key rotation.
-- `ADVISOR_*` tuning, `UNUSUAL_WHALES_BASE_URL`, persona prompt overrides.
+## What it does
 
-See `.env.example` for the full annotated list with generation recipes.
+- **Positions** — draft, open, scale in, close in parts. Multiple fills roll up into one
+  position with a correct average and realized P&L, net of per-fill fees.
+- **Trade calculator** — position size, R:R, dollar risk, and estimated fees from your
+  entry, target, and stop, before anything is at risk.
+- **Accounts & ledger** — multiple brokerages and currencies on a double-entry ledger,
+  with reconciliation.
+- **Performance** — equity curve built from net P&L, broken down daily through all-time.
+- **Options tools** — chain lookup, OCC symbol parsing, Black-Scholes pricing with full Greeks.
+- **AI advisor** — conversation grounded in your own trade history, opt-in and off by
+  default. Bring your own Anthropic or OpenAI key; self-hosted, it is never metered.
+- **CSV import** — bring years of history from any broker with a column-mapping step.
+  Direct read-only broker connections are on the roadmap, not shipped.
 
-### Analytics (optional, off by default)
+## Configuration
 
-Tradr can optionally send **product analytics** to
-[PostHog](https://posthog.com) — set `POSTHOG_API_KEY` (backend business events)
-and/or `POSTHOG_PUBLIC_KEY` (frontend UI events) to turn it on. With no keys set
-it constructs no client and makes no telemetry calls; there is nothing to opt
-out of. Events carry no PII and no trading data — users are identified only by an
-opaque id, and payloads (including captured error stacks) are redaction-scrubbed
-before they leave the container. See [docs/analytics.md](docs/analytics.md) for
-the event catalogue and privacy design.
+Three values must be set; everything else has a working default. `./docker/quickstart.sh`
+generates all three:
 
-### TLS
+| Variable            | What it is                                                                                                                    |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `POSTGRES_PASSWORD` | Database password. Compose builds the API's `DATABASE_URL` from the `POSTGRES_*` values — do not set `DATABASE_URL` yourself. |
+| `SESSION_SECRET`    | Signs auth session cookies (≥32 chars).                                                                                       |
+| `ENCRYPTION_KEY`    | 32-byte hex key encrypting stored provider keys at rest (AES-256-GCM).                                                        |
 
-The shipped compose file does **not** terminate TLS. Running HTTPS is the
-operator's responsibility: put your own reverse proxy / edge in front of the
-`web` container. If you do, add that edge to `TRUSTED_PROXIES` so per-IP rate
-limiting stays accurate (see the runbook).
+`ENCRYPTION_KEY_FINGERPRINT` is optional but recommended — it makes a wrong-key boot fail
+fast and loudly instead of failing later when a stored key won't decrypt.
 
-### Operations
+Every key is documented inline in [`.env.example`](.env.example). What a running instance
+talks to over the network, and which setting enables each connection, is in
+[`docs/external-services.md`](docs/external-services.md). Analytics are **off unless you
+set a key** — see [`docs/analytics.md`](docs/analytics.md).
 
-For upgrades, backups, migration status, the coupled timeout/upload settings,
-and diagnosing an `ENCRYPTION_KEY` mismatch crash-loop, see
-[`docs/runbooks/deployment.md`](docs/runbooks/deployment.md).
+**TLS is yours.** The shipped compose file does not terminate it. Put your own reverse
+proxy in front of the `web` container, and add that edge to `TRUSTED_PROXIES` so per-IP
+rate limiting stays accurate.
 
-## Releasing (maintainers)
+## Documentation
 
-Versions are driven by git tags: `make release VERSION=X.Y.Z` bumps and tags,
-and pushing the tag publishes GHCR images plus a GitHub Release — but only
-after CI passes on the tagged commit (a gate in the Release workflow blocks
-publishing otherwise). The full process, assumptions, and failure modes are in
-[`docs/runbooks/release.md`](docs/runbooks/release.md).
+|                                                                           |                                                            |
+| ------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| [User guide](https://www.tradr.cloud/docs/user-guide/getting-started/)    | Using Tradr — first trade to performance review            |
+| [Self-hosting](https://www.tradr.cloud/docs/self-hosting/docker-compose/) | Install, upgrade, back up, run behind TLS                  |
+| [`docs/`](docs/)                                                          | Operator and maintainer references that live with the code |
 
-What that version number promises — which surfaces are covered, what counts as
-a breaking change, and when to pin `:X.Y.Z` rather than track `:latest` — is in
-[`docs/versioning.md`](docs/versioning.md).
+## Contributing
+
+Issues and pull requests are welcome. Development setup, code style, the migration policy,
+and the DCO sign-off requirement are in [`CONTRIBUTING.md`](CONTRIBUTING.md) — commits need
+`git commit -s`, and there is no CLA.
+
+To report a vulnerability, follow [`SECURITY.md`](SECURITY.md). Please don't open a public
+issue for security problems.
 
 ## License & Trademark
 
-Tradr is open source under the **[Apache License 2.0](./LICENSE)** — free to use, self-host, modify, and
-redistribute. See [`NOTICE`](./NOTICE) for attribution terms.
+Apache-2.0 — free to use, self-host, modify, and redistribute. See [`LICENSE`](LICENSE) and
+[`NOTICE`](NOTICE).
 
-The Apache-2.0 license covers the **code**, not the **name**. **"Tradr"** and the Tradr logo are trademarks;
-see the [Trademark Policy](./TRADEMARK.md) before using the name or logo in a fork, product, service, or
-domain. Fork the code freely, but a modified or independently hosted version must use a different name.
-
-Contributions are welcome under Apache-2.0 via a [Developer Certificate of Origin](./CONTRIBUTING.md) sign-off
-(no CLA) — see [`CONTRIBUTING.md`](./CONTRIBUTING.md). To report a vulnerability, see [`SECURITY.md`](./SECURITY.md).
+The license covers the **code**, not the **name**. "Tradr" and the Tradr logo are
+trademarks: fork the code freely, but a modified or independently hosted version needs a
+different name. See [`TRADEMARK.md`](TRADEMARK.md).

--- a/apps/api/src/lib/config.test.ts
+++ b/apps/api/src/lib/config.test.ts
@@ -103,6 +103,15 @@ describe('envSchema.ENCRYPTION_KEY_PREVIOUS', () => {
     const result = envSchema.safeParse({ ...baseEnv, ENCRYPTION_KEY_PREVIOUS: 'a'.repeat(63) });
     expect(result.success).toBe(false);
   });
+
+  // .env.example ships `ENCRYPTION_KEY_PREVIOUS=` uncommented and empty, and the
+  // documented install is `cp .env.example .env`. That hands the schema '', which
+  // `.optional()` does NOT cover — it only tolerates undefined. Before the
+  // empty-tolerant preprocess, a stock install crash-looped the api on boot.
+  it('treats an empty value as unset (blank .env line, not a boot crash)', () => {
+    const parsed = envSchema.parse({ ...baseEnv, ENCRYPTION_KEY_PREVIOUS: '' });
+    expect(parsed.ENCRYPTION_KEY_PREVIOUS).toBeUndefined();
+  });
 });
 
 describe('envSchema.ENCRYPTION_KEY_FINGERPRINT', () => {
@@ -120,6 +129,14 @@ describe('envSchema.ENCRYPTION_KEY_FINGERPRINT', () => {
   it('rejects an uppercase fingerprint', () => {
     const result = envSchema.safeParse({ ...baseEnv, ENCRYPTION_KEY_FINGERPRINT: 'A'.repeat(64) });
     expect(result.success).toBe(false);
+  });
+
+  // Same blank-line trap as ENCRYPTION_KEY_PREVIOUS above: shipped uncommented
+  // and empty in .env.example, and documented as optional, so leaving it blank
+  // must mean "unset" rather than "fail validation".
+  it('treats an empty value as unset (blank .env line, not a boot crash)', () => {
+    const parsed = envSchema.parse({ ...baseEnv, ENCRYPTION_KEY_FINGERPRINT: '' });
+    expect(parsed.ENCRYPTION_KEY_FINGERPRINT).toBeUndefined();
   });
 });
 

--- a/apps/api/src/lib/config.ts
+++ b/apps/api/src/lib/config.ts
@@ -25,14 +25,27 @@ export const envSchema = z.object({
     .default('false')
     .transform((v) => v === 'true'),
   ENCRYPTION_KEY: z.string().regex(/^[0-9a-fA-F]{64}$/),
-  ENCRYPTION_KEY_PREVIOUS: z
-    .string()
-    .regex(/^[0-9a-fA-F]{64}$/)
-    .optional(),
-  ENCRYPTION_KEY_FINGERPRINT: z
-    .string()
-    .regex(/^[0-9a-f]{64}$/)
-    .optional(),
+  // Both OPTIONAL keys ship uncommented-and-empty in .env.example, so the
+  // documented `cp .env.example .env` path hands the schema '' — and `.optional()`
+  // only tolerates *undefined*, not ''. Without the empty-tolerant preprocess
+  // (the CHANGELOG_GITHUB_REPO / SEC_USER_AGENT idiom used throughout this file)
+  // a blank line here is a boot crash-loop on a stock install. ENCRYPTION_KEY and
+  // SESSION_SECRET deliberately do NOT get this treatment: they are required, and
+  // an empty value there SHOULD fail fast.
+  ENCRYPTION_KEY_PREVIOUS: z.preprocess(
+    (v) => (v === '' ? undefined : v),
+    z
+      .string()
+      .regex(/^[0-9a-fA-F]{64}$/)
+      .optional(),
+  ),
+  ENCRYPTION_KEY_FINGERPRINT: z.preprocess(
+    (v) => (v === '' ? undefined : v),
+    z
+      .string()
+      .regex(/^[0-9a-f]{64}$/)
+      .optional(),
+  ),
   ADVISOR_STREAM_TIMEOUT_MS: z.coerce.number().int().positive().default(120_000),
   ADVISOR_MAX_IMAGES_PER_MESSAGE: z.coerce.number().int().positive().default(4),
   ADVISOR_BUILTIN_PERSONA_PROMPT_DEFAULT_TRADING_ADVISOR: z.string().optional(),

--- a/apps/web/docs/required-states-audit.md
+++ b/apps/web/docs/required-states-audit.md
@@ -1,18 +1,19 @@
 # Required-States Audit (both themes)
 
-**Supersedes** `docs/dark-mode-audit.md` (retired by visual-design Task 19).
+How every interactive state — hover, focus, active, disabled, selected — is
+expected to render in **both** the light and dark themes, and where each
+expectation is enforced.
 
 Scope: the global chrome plus every interactive component and data surface in
-`apps/web/src`. Spec: visual-design Component 4 + Component 8 (Req 10.1, 10.6,
-8.4, 11.2, 2.1). The audit is anchored to the two machine gates so it stays
-self-checking, not a snapshot:
+`apps/web/src`. The audit is anchored to two machine gates, so it stays
+self-checking rather than a snapshot that rots:
 
 - `apps/web/scripts/check-contrast.mjs` — per-theme WCAG-AA contrast + ΔEOK
   distinctness, **light AND dark**. Reports **0 findings**.
 - `apps/web/scripts/check-design-lint.mjs` — no raw palette classes, on-ladder
   spacing, primitive-bypass guard. Reports **0 findings**.
 
-## 1. Global chrome re-themes via `.dark` (R10.1)
+## 1. Global chrome re-themes via `.dark`
 
 All global chrome is token-clean — it carries no hardcoded color and re-themes
 automatically once `.dark` re-values the tokens (`index.css`).
@@ -26,7 +27,7 @@ automatically once `.dark` re-values the tokens (`index.css`).
 
 No stray classes were found; no chrome fix was required.
 
-## 2. Active/selected navigation = amber primary (R2.1)
+## 2. Active/selected navigation = amber primary
 
 The brand amber (`--color-primary`) is reserved for the primary action **and**
 active/selected nav. All **13** Sidebar nav links (`components/layout/Sidebar.tsx`)
@@ -68,7 +69,7 @@ modified — re-skin is via tokens only.
 
 All states use semantic tokens, so each renders correctly in both themes.
 
-## 4. Disabled / muted legibility — covered by the contrast gate (R10.6)
+## 4. Disabled / muted legibility — covered by the contrast gate
 
 The codebase has **no grey palette classes**. The de-emphasised path is
 `disabled:opacity-50` (~8 `components/ui` sites, all on inactive controls) and
@@ -107,7 +108,7 @@ distinctness — preserved; type-scale/font tokens unchanged):
 | `--color-success`                  | light | `0.52 0.09 190`  | `0.50 0.10 190`  | `text-success` ≥4.5 on its `/10` tint          |
 | `--color-destructive`              | dark  | `0.62 0.21 12`   | `0.58 0.21 12`   | white `destructive-foreground` ≥4.5 (was 3.94) |
 
-## 5. Density registers (R8.4)
+## 5. Density registers
 
 The two registers are a **surface convention**, not a new component variant:
 
@@ -122,7 +123,7 @@ widget's existing `density` prop). Numbers stay tabular-aligned at **both**
 registers because alignment is owned by the `Numeric` primitive, independent of
 the surrounding register.
 
-## 6. Target size ≥24×24px (R8.4 / WCAG 2.5.8)
+## 6. Target size ≥24×24px (WCAG 2.5.8)
 
 Satisfied by the shadcn defaults — verified in `components/ui/button.tsx`; no
 control smaller than 24px exists, and the design adds none:
@@ -137,7 +138,7 @@ control smaller than 24px exists, and the design adds none:
 The Sidebar's collapse toggle and log-out use `icon-sm` (32px) / `sm` (32px).
 No new harness check is added (the shadcn floor + this audit cover it).
 
-## 7. Keyboard / tab-order / ARIA + focus indicator (R11.2)
+## 7. Keyboard / tab-order / ARIA + focus indicator
 
 This spec adds **no** new interactive component — it re-skins via tokens. So the
 keyboard-operability, logical tab order, and ARIA correctness ride on the

--- a/docker/quickstart.sh
+++ b/docker/quickstart.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Tradr self-hosting quickstart — the canonical setup path.
+#
+# This script IS the documentation. The README and the docs site point at it
+# rather than restating the commands, so there is no second copy to drift — the
+# setup story had already diverged across three hand-maintained copies (one used
+# a placeholder clone URL, one documented FEATURE_GATING and one didn't).
+#
+# The `docker-smoke` CI job runs `--env-only`, so the secret-generation recipes
+# below are executed on every push rather than proofread.
+#
+# Usage:
+#   ./docker/quickstart.sh              generate .env (if absent), then start the stack
+#   ./docker/quickstart.sh --env-only   generate .env and stop; start the stack yourself
+#
+# Existing .env files are never overwritten. Values already set in the
+# environment win, so CI can pin them and a human gets fresh random secrets.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ENV_ONLY=false
+[ "${1:-}" = "--env-only" ] && ENV_ONLY=true
+
+# 1. Check prerequisites: Docker with Compose v2, and openssl for the secrets.
+docker compose version >/dev/null 2>&1 || { echo "need Docker with Compose v2"; exit 1; }
+command -v openssl >/dev/null || { echo "need openssl"; exit 1; }
+
+# 2. Generate the three required secrets and write .env.
+#    POSTGRES_PASSWORD is hex so the URL compose builds stays parseable — a
+#    base64 password can contain @ : / ? and silently corrupt DATABASE_URL.
+if [ ! -f .env ]; then
+  cp .env.example .env
+  POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-$(openssl rand -hex 24)}"
+  SESSION_SECRET="${SESSION_SECRET:-$(openssl rand -base64 24)}"
+  ENCRYPTION_KEY="${ENCRYPTION_KEY:-$(openssl rand -hex 32)}"
+
+  sed -i.bak \
+    -e "s|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=${POSTGRES_PASSWORD}|" \
+    -e "s|^SESSION_SECRET=.*|SESSION_SECRET=${SESSION_SECRET}|" \
+    -e "s|^ENCRYPTION_KEY=.*|ENCRYPTION_KEY=${ENCRYPTION_KEY}|" \
+    .env && rm -f .env.bak
+
+  # Pin the encryption key by its fingerprint. Without it, booting with the WRONG
+  # key fails late and quietly — a stored provider key simply won't decrypt. With
+  # it, the api refuses to start and says so. Needs xxd (vim-common); skipped
+  # rather than fatal, since it is a recommendation, not a requirement.
+  if command -v xxd >/dev/null; then
+    ENCRYPTION_KEY_FINGERPRINT="$(printf '%s' "$ENCRYPTION_KEY" | xxd -r -p \
+      | openssl dgst -sha256 -binary | xxd -p -c 32)"
+    sed -i.bak \
+      -e "s|^#* *ENCRYPTION_KEY_FINGERPRINT=.*|ENCRYPTION_KEY_FINGERPRINT=${ENCRYPTION_KEY_FINGERPRINT}|" \
+      .env && rm -f .env.bak
+  fi
+
+  # WEB_PORT is not a secret; honour it only when the caller pinned one.
+  if [ -n "${WEB_PORT:-}" ]; then
+    sed -i.bak -e "s|^WEB_PORT=.*|WEB_PORT=${WEB_PORT}|" .env && rm -f .env.bak
+  fi
+fi
+
+if [ "$ENV_ONLY" = true ]; then
+  echo "wrote .env — start the stack with: docker compose up -d"
+  exit 0
+fi
+
+# 3. Start the stack, then wait for the api to report healthy.
+docker compose up -d
+
+WEB_PORT="$(grep -E '^WEB_PORT=' .env | cut -d= -f2)"
+WEB_PORT="${WEB_PORT:-8080}"
+
+echo "waiting for http://localhost:${WEB_PORT}/api/health ..."
+for _ in $(seq 1 60); do
+  if curl -fsS "http://localhost:${WEB_PORT}/api/health" 2>/dev/null; then
+    echo
+    echo "Tradr is up: http://localhost:${WEB_PORT}"
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "api did not become healthy — check: docker compose logs api" >&2
+exit 1

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,38 @@
+# Tradr in-repo documentation
+
+References that live with the code, so a change to how Tradr is built, configured,
+or operated lands in the same pull request as the change itself.
+
+The polished, task-oriented documentation is on the docs site:
+**[User guide](https://www.tradr.cloud/docs/user-guide/getting-started/)** ·
+**[Self-hosting](https://www.tradr.cloud/docs/self-hosting/docker-compose/)**.
+Start there if you want to _use_ or _install_ Tradr. Start here if you want to know
+how something works, or what it promises.
+
+## For operators
+
+| Document                                           | Answers                                                                                                                                                          |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`versioning.md`](versioning.md)                   | Can I pull the new image and restart without reading anything first? What counts as a breaking change, and when to pin a tag.                                    |
+| [`external-services.md`](external-services.md)     | What does a running instance talk to over the network, and which setting turns each connection on? (Nothing, by default.)                                        |
+| [`analytics.md`](analytics.md)                     | What does Tradr capture if I enable PostHog, and what does it deliberately never capture? Off unless you set a key.                                              |
+| [`runbooks/deployment.md`](runbooks/deployment.md) | Day-two operations: health and migration status, upgrades, backups, the coupled timeout/upload settings, and diagnosing an `ENCRYPTION_KEY` mismatch crash-loop. |
+
+First-time install is not here — it is [`../docker/quickstart.sh`](../docker/quickstart.sh)
+and the [self-hosting guide](https://www.tradr.cloud/docs/self-hosting/docker-compose/).
+
+## For maintainers
+
+| Document                                                                 | Answers                                                                                        |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| [`runbooks/release.md`](runbooks/release.md)                             | How a version gets built, tagged, and published, and what blocks a release.                    |
+| [`runbooks/positions_index_build.md`](runbooks/positions_index_build.md) | Building, deploying, and recovering the `positions_user_status_closed_at_idx` composite index. |
+
+## Conventions
+
+- **Every documented command should be executable.** The quickstart is a script CI runs
+  (`docker-smoke`), not prose. Prefer generating a reference from its source over
+  restating it — `.env.example` is the authority on configuration, and this tree links to
+  it rather than copying it.
+- **One home per topic.** If something is already documented on the docs site or in
+  `.env.example`, link to it instead of writing a second copy that will drift.

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -1,22 +1,21 @@
 # Deployment runbook
 
-Operational reference for self-hosting Tradr with the shipped
-`docker-compose.yml`. For first-time setup see the
-[Self-hosting quickstart](../../README.md#self-hosting-quickstart) in the README.
-For what the containers connect out to (and which keys enable each connection)
-see [External services](../external-services.md).
+**Day-two** operations for a self-hosted instance: health, upgrades, backups, and
+the failure modes worth recognising early.
 
-The stack has three services on one bridge network:
+This is not the install guide. First-time setup is
+[`docker/quickstart.sh`](../../docker/quickstart.sh) — the script CI executes — and
+the [self-hosting guide](https://www.tradr.cloud/docs/self-hosting/docker-compose/)
+covers the three-service layout, prerequisites, and configuration in full. Setup
+instructions used to be restated here as well, and the two copies drifted; this
+page now links rather than repeats.
 
-| Service    | Image                              | Published?             |
-| ---------- | ---------------------------------- | ---------------------- |
-| `postgres` | `postgres:16`                      | no (internal only)     |
-| `api`      | built from `docker/Dockerfile.api` | no (internal only)     |
-| `web`      | built from `docker/Dockerfile.web` | `${WEB_PORT:-8080}:80` |
+For what the containers connect out to, and which keys enable each connection, see
+[External services](../external-services.md).
 
-Only `web` exposes a host port. `DATABASE_URL` for `api` is built from the
-`POSTGRES_*` vars inside `docker-compose.yml`; any `DATABASE_URL` in `.env` is
-ignored by the compose stack.
+Two facts to keep in mind while reading the rest of this page: only `web` exposes a
+host port, and `DATABASE_URL` for `api` is built from the `POSTGRES_*` vars inside
+`docker-compose.yml` — any `DATABASE_URL` in `.env` is ignored by the compose stack.
 
 ## Health and migration status
 
@@ -34,7 +33,15 @@ docker compose exec api tradr migrate --status
 ```
 
 Exit codes: `0` schema current, `1` pending migrations, `2` cannot connect.
-This is the only subcommand the CLI accepts (`tradr migrate --status`).
+The `tradr` CLI ships four subcommands, all runnable with
+`docker compose exec api tradr <subcommand>`:
+
+| Subcommand                                    | Does                                                                                                 |
+| --------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `migrate --status`                            | Reports schema state via the exit codes above.                                                       |
+| `reset-password <email> [--password <value>]` | Resets a user's password from the server — the recovery path on an instance with no SMTP configured. |
+| `storage migrate-to-inline`                   | Moves object-storage-backed uploads back into the database.                                          |
+| `storage gc`                                  | Deletes orphaned upload blobs.                                                                       |
 
 ## Upgrades, migrations, and backups
 

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -128,12 +128,19 @@ BYOK). Key material is loaded once at bootstrap.
 
 Set `ENCRYPTION_KEY_FINGERPRINT` to the `sha256` of the raw key bytes. When set,
 `api` aborts at startup (before migrations) if the loaded key doesn't match —
-turning a silent wrong-key deploy into a fast, clearly logged failure. Generate
-it from your key:
+turning a silent wrong-key deploy into a fast, clearly logged failure.
+
+Derive it from the key you are actually running. `docker/quickstart.sh` does this
+for you; by hand, read `ENCRYPTION_KEY` out of `.env` and hash **that**:
 
 ```bash
-openssl rand -hex 32 | xxd -r -p | openssl dgst -sha256 -binary | xxd -p -c 32
+ENCRYPTION_KEY="$(grep -E '^ENCRYPTION_KEY=' .env | cut -d= -f2)"
+printf '%s' "$ENCRYPTION_KEY" | xxd -r -p | openssl dgst -sha256 -binary | xxd -p -c 32
 ```
+
+Do **not** pipe `openssl rand -hex 32` into that hash: it fingerprints a brand-new
+random key rather than yours, so the value can never match and the api exits on
+every boot.
 
 With the fingerprint **unset** and at least one stored provider key, a wrong key
 instead fails later via the decrypt canary (same crash-loop). With the


### PR DESCRIPTION
## What & why

**Following the documented install produced a crash-looping api.** This fixes that, and changes CI so the same class of bug can't recur silently.

`.env.example` ships `ENCRYPTION_KEY_PREVIOUS=` and `ENCRYPTION_KEY_FINGERPRINT=` uncommented and empty, and the documented first step is `cp .env.example .env`. Both are declared `.regex(...).optional()` — but `.optional()` only tolerates `undefined`, not `''`. A blank `.env` line arrives as an empty string, fails the regex, and exits the process on boot:

```
_ZodError: [ { "validation": "regex", "code": "invalid_string", "path": [ "ENCRYPTION_KEY_PREVIOUS" ] } ]
```

Every other empty-tolerant key in `config.ts` already carries the `'' -> undefined` preprocess (`CHANGELOG_GITHUB_REPO`, `SEC_USER_AGENT`, `POSTHOG_HOST`); these two were missed. `ENCRYPTION_KEY` and `SESSION_SECRET` deliberately keep failing fast on `''` — they are required, and an empty value there *should* stop the boot.

**Why CI didn't catch it:** `docker-smoke` hand-wrote a six-key `.env` that omits both variables. It was testing a path no self-hoster follows.

So this makes the docs the tested path. `docker/quickstart.sh` is now the canonical install — it checks prerequisites, generates the three secrets, derives the fingerprint from the key it just wrote, starts the stack, and waits for health. `docker-smoke` runs it with `--env-only`, so the setup instructions are executed on every push instead of proofread.

Two knock-on effects worth reviewing:
- **The fingerprint startup gate is now exercised in CI**, where it previously wasn't. The derivation was verified against the app's own `sha256(keyBytes)`.
- The recipe the runbook carried piped `openssl rand -hex 32` into the hash, fingerprinting a *fresh* random key — so anyone following it literally pinned a value that could never match. Corrected.

### README

Rewritten as a front door. It was an ops manual: no answer to what Tradr is, no mention that a hosted version exists, and `git clone <repo-url>` — a placeholder — as the first command a visitor copies. It now leads with positioning and a three-command quickstart, and adds a **Status** section (pre-1.0, forward-only migrations, CI-gated releases), because "will this eat my data" is the question a v0.5.0 repo has to answer. Maintainer release process moved out to the runbook.

Also: `docs/README.md` as an index for the in-repo docs; the runbook's claim that the CLI accepts one subcommand corrected (it has four); its duplicated setup preamble dropped; spec-tracker requirement IDs stripped from the required-states audit.

## Verification

- `./docker/quickstart.sh` boots a stack from a clean checkout to `{"status":"ok"}` — confirmed failing before the config fix, passing after.
- `--env-only` produces a correct `.env` under CI's pinned env vars.
- 151 tests in `apps/api/src/lib/config.test.ts` pass, including two new regression tests for the blank-line case.
- `pnpm lint` and `pnpm check-types` clean.

Not run locally: the full test suite. The touched surface is `config.ts`, covered by the file above.

## Checklist

- [x] One focused, logical change (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
- [x] Every commit is signed off (`git commit -s`) — the DCO is required.
- [x] Conventional Commit title (`feat:`, `fix:`, `chore:`, `docs:`, …), first line under 72 characters.
- [x] `pnpm check-types` and `pnpm lint` pass locally; `config.test.ts` passes (full suite not run).
- [x] Tests added or updated for the behavior this PR changes.
- [x] If an API endpoint changed: OpenAPI/Swagger definition and docs updated **in this PR** — n/a, no endpoint changed.