### PR TITLE
docs: add an STE-derived house style and a declared vocabulary

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,3 +14,4 @@ Closes #
 - [ ] `pnpm test`, `pnpm check-types`, and `pnpm lint` pass locally.
 - [ ] Tests added or updated for the behavior this PR changes.
 - [ ] If an API endpoint changed: OpenAPI/Swagger definition and docs updated **in this PR**.
+- [ ] If this changes documentation: it follows [`docs/STYLE.md`](../docs/STYLE.md) and uses the terms in [`docs/TERMS.md`](../docs/TERMS.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,9 +118,16 @@ Tradr favors **simple, boring, readable code over clever abstractions.** A few g
 
 ## API and documentation changes
 
-If you add, remove, or modify an API endpoint, update its OpenAPI/Swagger definition **in the same pull
-request**, and update the relevant documentation. Docs live in the repo — changes to how the app is built,
-configured, or self-hosted should land alongside the code that changes them.
+If you add, remove, or modify an API endpoint, update its `@swagger` JSDoc block **in the same pull
+request**, and update the relevant documentation. Operator and maintainer references live in
+[`docs/`](docs/) — changes to how the app is built, configured, or self-hosted should land alongside the
+code that changes them.
+
+Documentation has a house style: [`docs/STYLE.md`](docs/STYLE.md), with the declared vocabulary in
+[`docs/TERMS.md`](docs/TERMS.md). It is a simplified-English standard that applies to procedural and
+reference writing — how-to pages, runbooks, README setup steps, and `.env.example` comments — and
+deliberately **not** to narrative or marketing prose. The short version: one instruction per sentence,
+imperative mood, active voice, one term per meaning, and don't document a command you haven't run.
 
 ## Database migrations
 

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -1,0 +1,109 @@
+# Documentation style
+
+Tradr's procedural and reference documentation follows a **simplified-English**
+house standard derived from ASD-STE100, the controlled-language specification used
+in aerospace maintenance manuals. The goal is documentation that is unambiguous on
+first reading, uniform between authors, and mechanically checkable.
+
+Declared terminology lives in [`TERMS.md`](TERMS.md). Read that first — most style
+mistakes are really vocabulary mistakes.
+
+## Why "derived", and not ASD-STE100 itself
+
+Three practical constraints, stated plainly so nobody re-litigates them:
+
+1. **The approved dictionary is not redistributable.** ASD-STE100 cannot be checked
+   into an Apache-2.0 repository, so a contributor cannot look up whether a word is
+   approved. Rules we can state ourselves; the dictionary we cannot ship.
+2. **Its vocabulary has no entry for our domain.** No _commit_, _container_,
+   _repository_, _migration_, _webhook_, _brokerage_, _equity curve_, or
+   _expectancy_. STE handles this through declared Technical Names and Technical
+   Verbs — that declaration is [`TERMS.md`](TERMS.md), and it is the part that
+   actually earns its keep here.
+3. **Certified STE checkers are enterprise-priced.** There is no credible free one.
+
+So: adopt the rules, declare the vocabulary, enforce what a linter can enforce, and
+call the result **STE-derived** rather than claiming compliance we do not verify.
+
+For everything STE is silent on — heading capitalisation, code-block conventions,
+UI-element formatting, admonitions, lists — follow the
+[Google developer documentation style guide](https://developers.google.com/style).
+STE overrides it only on procedural sentence construction.
+
+## Scope — by audience, not by document type
+
+The split is **who reads it**, not which Diátaxis mode it sits in. A security or
+architecture page is exposition, but it is read by someone deciding whether to trust
+Tradr with their trading history, and it should be the most precise prose we write.
+
+**In scope — anything an operator or contributor reads to do something:**
+
+- Every how-to and reference page
+- The runbooks in `docs/runbooks/`
+- Security, architecture, and migration explanations
+- README setup steps
+- Comments in `.env.example` and `docker-compose.yml`
+- The **steps** of a tutorial
+
+**Out of scope — trader-facing narrative:**
+
+- Marketing copy
+- "Why journaling improves your trading", "How the advisor reasons"
+- The **introduction** of a tutorial, where a human voice earns attention
+
+Do not retrofit. The best existing pages were written before this guide and are
+better than a mechanical rewrite would make them. Apply this to new and
+substantially-revised content.
+
+## The rules
+
+**1. One instruction per sentence.** This is the rule that changes writing most.
+
+> ✗ Copy the file and edit the three secrets, then restart the stack.
+> ✓ Copy the file. Edit the three secrets. Restart the stack.
+
+**2. Keep procedural sentences under 20 words**, descriptive ones under 25. If a
+sentence needs a semicolon, it is two sentences.
+
+**3. Use the imperative for instructions.** "Run the migration", not "The migration
+should be run" or "You will want to run".
+
+**4. Use the active voice.** Name the actor. "The api runs migrations on startup",
+not "migrations are run on startup".
+
+**5. Use the present tense for what the system does.** "The advisor reads your trade
+history", not "will read".
+
+**6. One term per meaning.** Use [`TERMS.md`](TERMS.md). Never vary a term for
+elegance — a synonym reads as a different thing.
+
+**7. Say what happens, then what to do about it.** Lead a troubleshooting section
+with the symptom the reader is looking at, not the cause they do not know yet.
+
+**8. State the expected result.** A step the reader cannot verify is not a step.
+"**Expected result:** the account appears with a balance of $10,000.00."
+
+**9. Prefer a tested artifact to prose.** If a procedure can be a script that CI
+runs, make it one and link to it. `docker/quickstart.sh` is the pattern: the README
+points at it rather than restating the commands, so there is no second copy to
+drift. Likewise, generate a reference from its source rather than transcribing it.
+
+**10. Do not document what you have not run.** Every command in this repository's
+documentation should have been executed, ideally by CI.
+
+## Hosted vs self-hosted
+
+Do not fork a page to cover both. Mark the divergent step inline. On the docs site
+that is the `<HostedOnly>` / `<SelfHosted>` components; in this repository, a bold
+lead-in:
+
+> **Self-hosted only:** feature gating ships off, so plan limits do not apply.
+
+## Checklist before you open the pull request
+
+- [ ] Every term matches [`TERMS.md`](TERMS.md).
+- [ ] Every procedural sentence gives one instruction, in the imperative, under 20 words.
+- [ ] Every command has been run, not just typed.
+- [ ] Steps state their expected result.
+- [ ] Nothing here duplicates a page that already exists — it links instead.
+- [ ] No _simply_, _just_, _easily_, or _obviously_.

--- a/docs/TERMS.md
+++ b/docs/TERMS.md
@@ -1,0 +1,51 @@
+# Tradr terminology
+
+One meaning per term, one term per meaning. This is the declared vocabulary the
+documentation uses; [`STYLE.md`](STYLE.md) explains the rules around it.
+
+Terminology drift is the cheapest documentation defect to prevent and the most
+expensive to fix later, because every page has to change at once. Pick the
+approved term below and use only that one.
+
+## Product and deployment
+
+| Use | Not | Why |
+| --- | --- | --- |
+| **instance** | deployment, stack, install, box | One running copy of Tradr. "Stack" means the three containers specifically; an instance is the thing an operator owns. |
+| **the stack** | the containers, the compose stack | The three services (`web`, `api`, `postgres`) started by one compose file. |
+| **self-hosted** | on-prem, on-premise, local install | Tradr run by the reader on their own infrastructure. |
+| **hosted** | cloud, SaaS, managed platform | `app.tradr.cloud`, run by us. |
+| **operator** | admin, sysadmin, self-hoster | The person who runs an instance. May or may not be the person trading on it. |
+| **contributor** | developer, dev | Someone changing the code. |
+
+## Trading domain
+
+| Use | Not | Why |
+| --- | --- | --- |
+| **position** | trade | A position is the record Tradr stores: one symbol, one direction, its whole lifecycle. Do not use "trade" for it. |
+| **trade** | — | Only in the general sense of the activity ("your trading", "before you take the trade"). Never as a synonym for a stored position. |
+| **fill** | execution, transaction | One buy or sell that moves a position. A position has one or more fills. |
+| **account** | brokerage account, broker account | A brokerage account inside Tradr, with a currency and a balance. Always qualify on first use per page: "a brokerage account (an **account** in Tradr)". |
+| **advisor** | AI, the AI, assistant, chatbot | The conversational feature. "AI advisor" is allowed once, for introduction; thereafter "the advisor". |
+| **BYOK** | bring-your-own-key, own key | Spell it out on first use per page, then abbreviate. |
+| **equity curve** | balance chart, P&L chart | The account-value-over-time chart. |
+| **realized P&L** | profit, gains, returns | Money from closed positions. Always write "P&L", never "PnL" or "P/L". |
+
+## Configuration
+
+| Use | Not | Why |
+| --- | --- | --- |
+| **environment variable** | env var, setting, config value | Spell it out in prose. `env var` is acceptable in a table header where space is tight. |
+| **required** | mandatory, must-have | Reserved for the three values with no working default. |
+| **optional** | not required | Everything else. An optional integration is **absent when unconfigured, not broken** — say it that way. |
+| **feature gating** | paywall, plan limits, tiers | The `FEATURE_GATING` mechanism. Off by default; self-hosted instances have no tiers at all. |
+
+## Words to avoid entirely
+
+| Avoid | Instead |
+| --- | --- |
+| simply, just, easily, obviously | Delete. If a step is easy, the reader will notice; if it isn't, you have lied. |
+| should work, ought to | State what happens, or test it and then state it. |
+| leverage, utilise | use |
+| in order to | to |
+| please (in instructions) | Delete. "Please run" → "Run". |


### PR DESCRIPTION
## What & why

Four voices had grown across the documentation and only one was deliberate. The gap that matters is the operator-facing writing — `versioning.md`, `external-services.md`, the runbooks — which is read by people deciding whether to trust Tradr with their trading history, and was written as though the reader already shared the maintainer's context.

**`docs/STYLE.md`** states ten enforceable rules derived from ASD-STE100 (the controlled-language spec used in aerospace maintenance manuals), and is explicit about why it says *derived* rather than claiming compliance:

- the approved dictionary is **not redistributable**, so it can't ship in an Apache-2.0 repo where a contributor could consult it;
- it has no entry for *commit*, *container*, *migration*, or *equity curve* — STE handles that through declared Technical Names, which is the half that actually earns its keep here;
- certified STE checkers are enterprise-priced, and there is no credible free one.

Scope is **by audience, not by document type**. A security or architecture page is exposition, but its reader is an operator, so it's in scope; a tutorial's *introduction* isn't, because a human voice earns attention there. Anything STE is silent on — headings, code blocks, UI elements, admonitions — defers to the Google developer documentation style guide.

Retrofitting is explicitly ruled out. The best existing pages predate this, and a mechanical rewrite would make them worse.

**`docs/TERMS.md`** is the more valuable half: one meaning per term for collisions already present in the docs — *position* vs *trade*, *fill* vs *execution*, *instance* vs *stack* vs *deployment*, *advisor* vs *the AI*, *operator* vs *self-hoster*.

Also points `CONTRIBUTING.md` and the PR template at both, and corrects CONTRIBUTING's description of the API contract: it's a hand-authored `@swagger` JSDoc block, not an OpenAPI definition a contributor edits directly.

## Checklist

- [x] One focused, logical change (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
- [x] Every commit is signed off (`git commit -s`) — the DCO is required.
- [x] Conventional Commit title (`feat:`, `fix:`, `chore:`, `docs:`, …), first line under 72 characters.
- [x] `pnpm test`, `pnpm check-types`, and `pnpm lint` pass locally — documentation only, no code touched.
- [ ] Tests added or updated for the behavior this PR changes — n/a, prose only.
- [ ] If an API endpoint changed: OpenAPI/Swagger definition and docs updated **in this PR** — n/a.