### PR TITLE
feat(docs): link back to tradr.cloud from the sidebar

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -125,6 +125,12 @@ export default defineConfig({
       // The modes remain an authoring discipline (docs/STYLE.md); they were never
       // useful as navigation. Page paths are unchanged.
       sidebar: [
+        // The way back to the marketing site. The docs are their own host now,
+        // so without this a reader who arrives from a search result has no route
+        // to the rest of the project — the site title only returns them here.
+        // Navigates in place rather than opening a tab: www links here with
+        // target="_blank", so the page they came from is usually still open.
+        { label: '← tradr.cloud', link: 'https://www.tradr.cloud/' },
         { label: 'Start here', slug: 'index' },
         {
           label: 'User guide',


### PR DESCRIPTION
The docs are their own host now, so a reader arriving from a search result had no route to the rest of the project. The site title only returns them to the docs index, and the GitHub icon goes to the repository — neither leads to tradr.cloud.

Adds it as the **first sidebar entry**, above "Start here", so it is present on every page and reads as an exit rather than a section:

```
← tradr.cloud
Start here
User guide
  Getting started
  …
```

It navigates in place rather than opening a tab. The marketing site links here with `target="_blank"` (see `madmatt112/tradr-hosted#17`), so the page the reader came from is usually still open, and a third tab would be noise.

Verified in a browser against the built site: the link is the first sidebar item, visible, points at `https://www.tradr.cloud/`, and carries no `target`. Lint, `astro check`, the OpenAPI drift gate and the docs build (links validator) all pass.
