### PR TITLE
fix(pnl): restore single-pass rounding for realizedPnl

### DIFF
--- a/apps/api/src/features/positions/pnl.test.ts
+++ b/apps/api/src/features/positions/pnl.test.ts
@@ -281,3 +281,41 @@ describe('computePnlFromTotals', () => {
     expect(result.returnPercentage).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Rounding regression: realizedPnl must round ONCE, at the end
+// ---------------------------------------------------------------------------
+//
+// A refactor that computed `round(gross) − round(fees)` instead shifted the
+// result by a minor unit. It survived the whole suite because every other case
+// here uses figures with no sub-cent residue, and it reached CI green before
+// being caught by hand. This is the counter-example.
+
+describe('computePnlFromTotals — rounding', () => {
+  // entry 1000 @ 100 (no fees); exit 1000 @ 100.100006 with 0.004 recorded fees.
+  // gross unrounded = 100.006, fees = 0.004.
+  //   round(100.006 − 0.004) = 100.00   ← correct, one rounding
+  //   round(100.006) − round(0.004) = 100.01   ← the bug
+  const totals = {
+    entryQty: '1000',
+    exitQty: '1000',
+    entryCost: '100000',
+    exitCost: '100100.006',
+    entryFees: '0',
+    exitFees: '0.004',
+  };
+
+  it('rounds once at the end, not per component', () => {
+    const pnl = computePnlFromTotals(totals, 'long', 'stock', 2);
+    expect(pnl.realizedPnl).toBe(100);
+  });
+
+  it('keeps grossPnl − fees === realizedPnl exactly', () => {
+    const pnl = computePnlFromTotals(totals, 'long', 'stock', 2);
+    // The breakdown absorbs the rounding residue so the invariant still holds:
+    // gross rounds to 100.01, so fees must report 0.01 rather than 0.00.
+    expect(pnl.grossPnl).toBe(100.01);
+    expect(pnl.fees).toBe(0.01);
+    expect(pnl.grossPnl! - pnl.fees!).toBeCloseTo(pnl.realizedPnl!, 10);
+  });
+});

--- a/apps/api/src/features/positions/pnl.ts
+++ b/apps/api/src/features/positions/pnl.ts
@@ -120,6 +120,22 @@ export function computePnlFromTotals(
     .times(exitQty.div(entryQty))
     .toDecimalPlaces(currencyMinorUnits, Decimal.ROUND_HALF_UP);
 
+  // `realizedPnl` rounds ONCE, at the end, over the fully-unrounded expression.
+  // Do not refactor this into `round(gross) − round(fees)`: rounding twice and
+  // then subtracting is NOT equivalent and shifts the result by a minor unit.
+  // Worked counter-example — gross 100.006, exit fees 0.004, USD:
+  //   round(100.006 − 0.004) = 100.00      (this expression)
+  //   round(100.006) − round(0.004) = 100.01
+  // Pinned by "rounds once at the end" in pnl.test.ts.
+  const realizedPnl = avgExitPrice!
+    .minus(avgEntryPrice)
+    .times(exitQty)
+    .times(sideMultiplier)
+    .times(contractMultiplier)
+    .minus(exitFees)
+    .minus(allocatedEntryFees)
+    .toDecimalPlaces(currencyMinorUnits, Decimal.ROUND_HALF_UP);
+
   const grossPnl = avgExitPrice!
     .minus(avgEntryPrice)
     .times(exitQty)
@@ -127,14 +143,11 @@ export function computePnlFromTotals(
     .times(contractMultiplier)
     .toDecimalPlaces(currencyMinorUnits, Decimal.ROUND_HALF_UP);
 
-  // Total fees recorded on the fills that this realization bears.
-  const totalFees = exitFees
-    .plus(allocatedEntryFees)
-    .toDecimalPlaces(currencyMinorUnits, Decimal.ROUND_HALF_UP);
-
-  // Derived from the rounded components so `grossPnl − fees === realizedPnl`
-  // holds exactly, rather than rounding the unrounded expression separately.
-  const realizedPnl = grossPnl.minus(totalFees);
+  // Derived as `gross − net`, NOT summed independently, so
+  // `grossPnl − fees === realizedPnl` holds exactly without perturbing
+  // `realizedPnl`. The breakdown absorbs the rounding residue; the money figure
+  // does not. This is the same convention `performance.service` already used.
+  const totalFees = grossPnl.minus(realizedPnl);
 
   // Return percentage denominator: avgEntryPrice × exitQty × contractMultiplier + allocatedEntryFees.
   // For short positions, this represents gross sale proceeds (notional sold), not margin requirement.


### PR DESCRIPTION
Follow-up to #20. That PR's fee-unification commit (`3115eab`) carried a rounding regression that reached `main`; this restores the original behaviour.

## The bug

`3115eab` refactored `realizedPnl` from rounding **once at the end** into `round(gross) − round(fees)`. Those are not equivalent — rounding twice and then subtracting shifts the result by a minor unit.

Counter-example, USD, gross unrounded `100.006` with `0.004` of exit fees:

```
round(100.006 − 0.004)        = 100.00   ← original, correct
round(100.006) − round(0.004) = 100.01   ← what shipped
```

So a commit whose entire purpose was making three surfaces agree on one number was itself changing that number, in a fourth way. It bites any trade whose average entry/exit prices leave sub-cent residue — a division of cost by quantity, so not rare.

Impact is bounded: one minor unit per affected realization, on realized P&L and everything derived from it (account balance, equity curve, tax summary).

## The fix

`realizedPnl` is computed exactly as it was before `3115eab` — one rounding, at the end, over the fully-unrounded expression. **Bit-identical to pre-refactor behaviour.**

The `grossPnl`/`fees` breakdown that `3115eab` added is kept and still useful; `fees` is now derived as `gross − net` rather than summed independently, so the invariant

```
grossPnl − fees === realizedPnl
```

holds exactly without perturbing `realizedPnl`. The breakdown absorbs the rounding residue; the money figure does not. This is the convention `performance.service` already used before `3115eab` touched it.

## Why the suite missed it

Every case in `pnl.test.ts` used figures with no sub-cent residue, so all 20 passed. The bug cleared local runs and a fully green CI. Green meant *uncovered*, not *correct*.

This adds the counter-example as two tests — one pinning `realizedPnl === 100`, one pinning the invariant — and I verified they **discriminate**: reintroduced the bug temporarily, confirmed both fail, then reverted. A comment at the call site now spells out why the expression must not be refactored into per-component rounding.

## Verification

Typecheck and lint clean. **2,768 tests** passing (243 files) against current `main`.

## No data repair needed

Nothing is deployed and no historical rows are affected: `realizedPnl` is derived from fills on every read, not stored. Ledger rows written while the bug was live could be off by a minor unit, but the ledger has only ever been written locally.
