### PR TITLE
test(csv-import): pin exactly one ledger row per imported whole trade

### DIFF
--- a/apps/api/src/features/csv-import/csv-import.commit.test.ts
+++ b/apps/api/src/features/csv-import/csv-import.commit.test.ts
@@ -216,8 +216,16 @@ describe('POST /api/csv-import/commit — replay lifecycle', () => {
     const posFills = await db.select().from(fills).where(eq(fills.positionId, posId));
     expect(posFills).toHaveLength(2);
 
+    // EXACTLY one, not merely non-zero. Realized P&L posts per fill now
+    // (ledger-balances Req 9), so a bulk import could in principle write a row
+    // per fill — but a whole trade realizes nothing on its entry and its full
+    // P&L on the balancing exit, leaving the close with a zero delta. One row,
+    // same as before per-fill posting. That equivalence is what keeps import
+    // volume and its rollback semantics unchanged; a regression here would show
+    // up as extra rows rather than as a failure elsewhere.
     const ledger = await db.select().from(ledgerEntries).where(eq(ledgerEntries.positionId, posId));
-    expect(ledger.length).toBeGreaterThan(0); // close hook fired inside the bulk tx
+    expect(ledger).toHaveLength(1); // close hook fired inside the bulk tx
+    expect(ledger[0]!.entryType).toBe('position_pnl');
 
     const staged = await db.select().from(csvImportStaging).where(eq(csvImportStaging.id, token));
     expect(staged[0]!.status).toBe('committed');


### PR DESCRIPTION
Closes the last outstanding bullet from the per-fill posting work.

The assertion in `csv-import.commit.test.ts` was `toBeGreaterThan(0)`, which cannot tell the guarantee from a regression: if per-fill posting ever started writing a row per fill inside a bulk import, that assertion would still pass.

A whole trade realizes nothing on its entry and its full P&L on the balancing exit, so the close deltas to zero — **exactly one row**, same as before per-fill posting. That equivalence is what keeps bulk-import volume and its rollback semantics unchanged, so it is worth asserting exactly rather than loosely.

Also asserts the row's `entryType`.

142 csv-import tests pass; lint clean.