### PR TITLE
fix(release): regenerate the OpenAPI artifact in the bump commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,13 +67,20 @@ seed-demo: .env
 # Full process + failure modes: docs/runbooks/release.md
 VERSIONED_PKGS := apps/api apps/web packages/shared bench e2e
 
+# The published API reference embeds apps/api's version as `info.version`, and CI
+# gates on the committed artifact matching a fresh generate. Bumping the package
+# versions without regenerating therefore reds CI on the bump commit itself, which
+# blocks release.yml's ci-gate and publishes nothing. Regenerate in the same commit.
+OPENAPI_ARTIFACT := apps/docs/src/openapi/tradr-api.json
+
 .PHONY: release
 release:
 	@test -n "$(VERSION)" || { echo "usage: make release VERSION=1.2.3"; exit 1; }
 	@echo "$(VERSION)" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$$' || { echo "VERSION must be bare semver (1.2.3, no leading v)"; exit 1; }
 	@git diff --quiet HEAD || { echo "working tree not clean — commit or stash first"; exit 1; }
 	@for p in $(VERSIONED_PKGS); do (cd $$p && npm pkg set version=$(VERSION)); done
-	git add $(addsuffix /package.json,$(VERSIONED_PKGS))
+	pnpm --filter @tradr/docs openapi:generate
+	git add $(addsuffix /package.json,$(VERSIONED_PKGS)) $(OPENAPI_ARTIFACT)
 	git commit -m "chore(release): v$(VERSION)"
 	git tag v$(VERSION)
 	@echo "Tagged v$(VERSION). Publish with: git push origin HEAD v$(VERSION)"

--- a/apps/docs/src/openapi/tradr-api.json
+++ b/apps/docs/src/openapi/tradr-api.json
@@ -112,7 +112,7 @@
   "info": {
     "description": "HTTP API for Tradr — the open-source trading journal with an AI advisor.\n\nThis reference is generated from the `@swagger` JSDoc blocks that live next to each route in the API source, so it always matches the endpoints the app actually serves. All routes are mounted under `/api`. The same API backs both the hosted app (`api.tradr.cloud`) and a self-hosted instance (reached through the web container at `/api`). Most endpoints require an authenticated session cookie.",
     "title": "Tradr API",
-    "version": "0.5.3"
+    "version": "0.5.4"
   },
   "openapi": "3.0.3",
   "paths": {

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -84,6 +84,12 @@ The Release workflow runs in three stages:
 
 ## Failure modes
 
+- **The bump commit itself reds CI on the OpenAPI drift gate:** the published
+  API reference embeds `apps/api`'s version as `info.version`, and CI checks the
+  committed artifact against a fresh generate. `make release` regenerates it in
+  the same commit for exactly this reason. Bumping the `package.json` versions
+  by hand without regenerating reds `checks` on a commit that has no other
+  reason to fail, and the gate then blocks the release.
 - **Gate fails (CI red or missing):** nothing was published. Fix the problem
   on `main`. If the fix lands in a new commit, delete and re-cut the tag on
   the new commit (below) — re-running the failed workflow run would still


### PR DESCRIPTION
v0.5.4 failed, **`main` is currently red**, and the cause blocks every future release. Nothing was published — `ci-gate` held the line and `build`/`merge`/`release` were all skipped.

## What happened

`make release` bumps the `version` field in five `package.json` files. The published API reference embeds `apps/api`'s version as `info.version`, and CI gates the committed artifact against a fresh generate:

```
pnpm --filter @tradr/docs openapi:generate
git diff --exit-code apps/docs/src/openapi/tradr-api.json
```

The bump changes what the generator emits but does not regenerate the artifact, so `checks` fails on a one-line diff:

```
-    "version": "0.5.3"
+    "version": "0.5.4"
```

`release.yml`'s `ci-gate` waits for a green CI run on the tagged commit, so a red `checks` publishes nothing. `v0.5.3` is still `Latest` and no `0.5.4` image exists.

The bump commit `d9748b5` is on `main`, so **`main` is red too** — not just the tag.

The drift gate arrived with the docs migration (#19); `make release` predates it. v0.5.4 is the first release cut since the two met.

## Two commits

1. **`fix(release):`** — `make release` now regenerates the artifact and stages it with the version bumps, so future bump commits are self-consistent. Plus a `Failure modes` entry in the release runbook.
2. **`fix(openapi):`** — regenerates the artifact to `0.5.4`, repairing `main`.

## Verified by running it

- Ran the fixed target end to end on a throwaway version, then reset: the bump commit carries **6 files** (5 `package.json` + the artifact), and the exact gate CI runs passes afterwards.
- Confirmed `.prettierignore` still shields the artifact — lint-staged invoked `prettier --write` over it on commit and left it byte-identical, so the gate passes.

## Re-cutting v0.5.4 after this merges

`main` will already be at `0.5.4` in both places, so `make release VERSION=0.5.4` would try to commit nothing and fail. Move the tag instead:

```bash
git push origin :refs/tags/v0.5.4   # delete the remote tag
git tag -d v0.5.4                   # delete the local tag
git pull --ff-only                  # pick up the merge commit
git tag v0.5.4                      # tag the green commit
git push origin v0.5.4
```

Wait for the `main` CI run on the merge commit to go green before pushing the tag — `ci-gate` needs an existing run to find, and tags do not trigger CI.