### PR TITLE
fix(config): stop .env erasing the released version, and document v0.5.4

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,10 +55,16 @@ WEB_PORT=8080
 # compose default (the internal `api` service).
 API_BASE_URL=
 
-# Optional version string for the SPA's corner badge (e.g. v0.1.0). Unset ⇒ the
-# badge shows "localdev". The hosted deploy workflows stamp their own value;
-# self-host operators may set one here.
-APP_VERSION=
+# Optional version string (e.g. v0.1.0). LEAVE THIS COMMENTED OUT.
+#
+# The release workflow bakes APP_VERSION into the api image, and GET /api/health
+# reports it. The api reads this file through compose's `env_file:`, and env_file
+# OVERRIDES the image's baked value — so an uncommented, blank APP_VERSION here
+# erases the released version and /api/health silently drops its `version` field.
+# Commented out, the image's own stamp survives.
+#
+# Set it only to override the stamp deliberately.
+# APP_VERSION=
 
 # nginx proxy read timeout for advisor streaming responses. MUST exceed the app
 # ADVISOR_STREAM_TIMEOUT_MS below, or nginx will cut the stream early.

--- a/apps/docs/src/content/docs/self-hosting/backup-restore.mdx
+++ b/apps/docs/src/content/docs/self-hosting/backup-restore.mdx
@@ -258,6 +258,11 @@ server needs different values. Leave the three secrets alone.
 - **The api crash-loops after a restore and names the encryption key** — the
   `.env` on this server carries a different `ENCRYPTION_KEY` than the data was
   written with. Restore the original `.env`.
+- **The api crash-loops with `password authentication failed for user "tradr"`** —
+  you regenerated `.env` against an existing volume. Postgres applies
+  `POSTGRES_PASSWORD` once, when it initialises the data directory, and ignores it
+  on every later start. Put the original password back, or destroy the volume and
+  restore from a dump.
 - **`docker compose exec` reports `no such service: postgres`** — you are not in
   the directory that holds `docker-compose.yml`.
 

--- a/apps/docs/src/content/docs/self-hosting/docker-compose.mdx
+++ b/apps/docs/src/content/docs/self-hosting/docker-compose.mdx
@@ -309,7 +309,7 @@ advisory lock as the first run. Because migrations are forward-only, the policy 
 **back up before every upgrade**.
 
 The pinned-image path, how to verify an upgrade, how far back you can roll, and
-one edit that published releases through v0.5.3 currently need are all in
+one edit that releases through v0.5.3 need are all in
 [Upgrade an instance](/self-hosting/upgrades/).
 
 ## Where your data lives
@@ -395,9 +395,9 @@ building locally, replace the `build:` block on a service with a pinned tag:
 
 ```yaml
   api:
-    image: ghcr.io/madmatt112/tradr-api:0.5.3
+    image: ghcr.io/madmatt112/tradr-api:0.5.4
   web:
-    image: ghcr.io/madmatt112/tradr-web:0.5.3
+    image: ghcr.io/madmatt112/tradr-web:0.5.4
 ```
 
 Pin an explicit version rather than a floating tag, so an upgrade is a decision

--- a/apps/docs/src/content/docs/self-hosting/upgrades.mdx
+++ b/apps/docs/src/content/docs/self-hosting/upgrades.mdx
@@ -26,12 +26,31 @@ schema in a way you cannot undo by starting the old container again.
 3. **Note the version you are on.** You need it to go back.
 
 ```bash
-docker compose exec api printenv APP_VERSION
+curl -fsS http://localhost:8080/api/health
 ```
 
-**Expected result:** the version the running image was built at. An empty value
-means the image was built locally rather than pulled — the SPA shows `localdev` in
-its corner badge in that case.
+**Expected result:** `{"status":"ok","version":"v0.5.4"}` on a pinned release.
+
+The release workflow bakes the version into the api image, and `/api/health`
+reports it. A locally built image has no version to report, so the field is
+omitted and you get `{"status":"ok"}` — check out a release tag if you want a
+version you can name.
+
+Whichever image you run, `docker compose ps` shows the tag it came from:
+
+```bash
+docker compose ps --format '{{.Service}}\t{{.Image}}'
+```
+
+:::note[Do not set `APP_VERSION` in `.env`]
+The api reads `.env` through compose's `env_file:`, and `env_file` overrides the
+value baked into the image. An `APP_VERSION=` line that is present but blank
+therefore erases the released version, and `/api/health` silently drops its
+`version` field.
+
+`.env.example` ships the line commented out. If your `.env` predates that, comment
+it out.
+:::
 
 ### Which version bump matters
 
@@ -39,8 +58,8 @@ Tradr is pre-1.0, so the usual semver reading is inverted:
 
 | Bump | Example | What it means today |
 | --- | --- | --- |
-| **Minor** | `0.5.3` → `0.6.0` | A breaking change. Read the release notes before upgrading. |
-| **Patch** | `0.5.2` → `0.5.3` | Everything else — features, fixes, UI. |
+| **Minor** | `0.5.4` → `0.6.0` | A breaking change. Read the release notes before upgrading. |
+| **Patch** | `0.5.3` → `0.5.4` | Everything else — features, fixes, UI. |
 
 The full policy, and what counts as a breaking change, is in
 [`docs/versioning.md`](https://github.com/madmatt112/tradr/blob/main/docs/versioning.md).
@@ -66,7 +85,7 @@ a specific version:
 
 ```bash
 git fetch --tags
-git checkout v0.5.3
+git checkout v0.5.4
 docker compose up -d --build
 ```
 
@@ -80,9 +99,9 @@ Replace each service's `build:` block in `docker-compose.yml` with an image:
 ```yaml
 services:
   api:
-    image: ghcr.io/madmatt112/tradr-api:0.5.3
+    image: ghcr.io/madmatt112/tradr-api:0.5.4
   web:
-    image: ghcr.io/madmatt112/tradr-web:0.5.3
+    image: ghcr.io/madmatt112/tradr-web:0.5.4
 ```
 
 Then upgrade by editing the tag and pulling:
@@ -98,14 +117,16 @@ data survives — the volume is not part of the image.
 Pin an exact version. `:latest` moves on every release, which turns an upgrade
 into something that happens to you.
 
-:::caution[Published releases up to v0.5.3 need one edit to `.env`]
-Every published release through **v0.5.3** fails to start against the `.env` that
+:::caution[Pinning v0.5.3 or earlier needs one edit to `.env`]
+**v0.5.4 and later need nothing.** Skip this if you pin a current release.
+
+Every release through **v0.5.3** fails to start against the `.env` that
 `.env.example` and `docker/quickstart.sh` produce. The api exits immediately with a
 Zod error naming `ENCRYPTION_KEY_PREVIOUS`, and Compose restarts it in a loop. The
 `web` container answers `502 Bad Gateway` throughout.
 
-`.env.example` ships the key present but blank, and the released schema rejects a
-blank value. Comment the line out before you start a pinned release:
+Those releases shipped the key present but blank, and their config schema rejected
+a blank value. Comment the line out before you start one:
 
 ```bash
 # ENCRYPTION_KEY_PREVIOUS=
@@ -113,9 +134,8 @@ blank value. Comment the line out before you start a pinned release:
 
 **Expected result:** the api reaches `healthy` within about 30 seconds.
 
-The fix is on `main` and will ship in the next release. Building from source
-(path 1) is unaffected. `ENCRYPTION_KEY_PREVIOUS` is only used during key
-rotation, so commenting it out costs nothing.
+`ENCRYPTION_KEY_PREVIOUS` is only read during key rotation, so commenting it out
+costs nothing. Upgrading to v0.5.4 is the better fix.
 :::
 
 ## What happens on restart
@@ -151,8 +171,9 @@ docker compose ps
 curl -fsS http://localhost:8080/api/health
 ```
 
-**Expected result:** `{"status":"ok"}`. A `503` with `{"status":"error"}` means the
-api is up but cannot reach the database.
+**Expected result:** `{"status":"ok","version":"v0.5.4"}`, naming the version you
+just moved to. A `503` with `{"status":"error"}` means the api is up but cannot
+reach the database.
 
 ```bash
 docker compose exec api tradr migrate --status
@@ -192,7 +213,7 @@ docker compose pull
 docker compose up -d
 
 # built from source
-git checkout v0.5.2
+git checkout v0.5.3
 docker compose up -d --build
 ```
 
@@ -227,7 +248,7 @@ setting exists for operators who run migrations out of band from a source checko
   running. Allow the full 180 seconds, and watch it with
   `docker compose logs -f api`.
 - **`api` restarts in a loop, naming `ENCRYPTION_KEY_PREVIOUS`** — you are on a
-  published release through v0.5.3. Comment the line out in `.env`, as above.
+  release through v0.5.3. Comment the line out in `.env`, or upgrade to v0.5.4.
 - **`api` restarts in a loop, naming the encryption key** — `ENCRYPTION_KEY`
   changed, or `ENCRYPTION_KEY_FINGERPRINT` no longer matches it. Restore the
   original value.


### PR DESCRIPTION
Verifying the published v0.5.4 image against a stock `.env` turned up a third defect in the same area as the other two, plus the docs updates the release makes due.

## The defect: `.env` erases the released version

The release workflow bakes `APP_VERSION` into the api image, and `GET /api/health` is written to report it. But `.env.example` shipped `APP_VERSION=` present and blank, and the api reads `.env` through compose's `env_file:` — which **overrides** the image's baked value.

So every self-hosted instance running the stock `.env` erased its own version. Measured against the published `ghcr.io/madmatt112/tradr-api:0.5.4`, whose baked env reads `APP_VERSION=v0.5.4`:

| | `/api/health` |
| --- | --- |
| before | `{"status":"ok"}` |
| after | `{"status":"ok","version":"v0.5.4"}` |

The fix is to comment the line out, so the image's own stamp survives. Setting it deliberately still works.

### Not fixed here: the web half

`docker-compose.yml` never passes `APP_VERSION` to the `web` container, and the release does not bake it into the web image. Confirmed on the running stack — `APP_VERSION` is unset inside `web`, `config.js` carries no `appVersion`, and the image has nothing baked. So the SPA corner badge reads `localdev` on every self-hosted instance no matter which release is running.

That needs a compose change plus a decision about what a locally-built SPA should display, so it is left alone and called out rather than patched blind.

## Docs following the release

- The `ENCRYPTION_KEY_PREVIOUS` caution is rescoped from "every published release" to **v0.5.3 and earlier** — v0.5.4 ships the fix, verified by booting the published image against a stock `.env` (healthy in ~25s).
- Pinned-image examples move to `0.5.4`, in both the upgrade and Compose guides.
- The "note the version you are on" step now uses `/api/health` instead of `printenv APP_VERSION`. The old command returned empty on published images — that is how the defect above surfaced.
- New troubleshooting entry for `password authentication failed for user "tradr"` after regenerating `.env` against an existing volume. Postgres applies `POSTGRES_PASSWORD` only at initdb. I hit this while testing.

## Verified

- Published v0.5.4 image boots healthy against a stock quickstart `.env`; `/api/health` reports the version after the fix.
- `pnpm --filter @tradr/docs build` green, links validator passes, `check-types` 0 errors.
- `config.test.ts`, `app.self-host-parity.test.ts`, `health` — 158 tests pass.