### PR TITLE
fix(positions): stop the double-fee warning firing without a brokerage

### DIFF
--- a/apps/web/src/features/positions/components/PositionDetail.doubleFee.test.tsx
+++ b/apps/web/src/features/positions/components/PositionDetail.doubleFee.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+//
+// The double-fee warning must depend on an ACTUAL brokerage being attached, not
+// merely on `brokerageFees` being non-zero. That field carries the fee attributed
+// to the realized portion whatever its source, so on a brokerage-less account it
+// is just the manual fill fees pro-rated — and the warning would fire for every
+// position that has a fee, telling the user to delete the only fee data they have.
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { usePosition } from '../hooks/usePosition';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...rest }: { children: React.ReactNode }) => <a {...rest}>{children}</a>,
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('../hooks/usePosition', () => ({
+  usePosition: vi.fn(),
+  useDeletePosition: vi.fn(() => ({ mutateAsync: vi.fn() })),
+  useOpenPosition: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useClosePosition: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useReopenPosition: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+vi.mock('./FillDialog', () => ({ FillDialog: () => null }));
+vi.mock('./FillTable', () => ({ FillTable: () => null }));
+vi.mock('./PositionEditDialog', () => ({ PositionEditDialog: () => null }));
+
+import { PositionDetailView } from './PositionDetail';
+
+type PositionResult = ReturnType<typeof usePosition>;
+
+const WARNING = /both manual fill fees and brokerage-calculated fees/;
+
+function mountWith(ui: React.ReactElement): { container: HTMLElement; root: Root } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+  return { container, root };
+}
+
+function unmount(container: HTMLElement, root: Root): void {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function mockDetail({
+  fillFees,
+  brokerageName,
+  brokerageFees,
+}: {
+  fillFees: string;
+  brokerageName: string | null;
+  brokerageFees: number;
+}) {
+  vi.mocked(usePosition).mockReturnValue({
+    data: {
+      id: '00000000-0000-0000-0000-000000000001',
+      userId: '00000000-0000-0000-0000-000000000100',
+      accountId: '00000000-0000-0000-0000-000000000010',
+      accountTimezone: 'America/New_York',
+      symbol: 'AAPL',
+      side: 'long',
+      assetType: 'stock',
+      status: 'closed',
+      notes: null,
+      openedAt: '2026-05-01T12:00:00.000Z',
+      closedAt: '2026-05-02T12:00:00.000Z',
+      createdAt: '2026-05-01T12:00:00.000Z',
+      updatedAt: '2026-05-02T12:00:00.000Z',
+      fills: [
+        {
+          id: '00000000-0000-0000-0000-0000000000f1',
+          positionId: '00000000-0000-0000-0000-000000000001',
+          type: 'exit',
+          price: '160',
+          quantity: '100',
+          fees: fillFees,
+          notes: null,
+          filledAt: '2026-05-02T12:00:00.000Z',
+          createdAt: '2026-05-02T12:00:00.000Z',
+        },
+      ],
+      avgEntryPrice: 150,
+      avgExitPrice: 160,
+      totalEntryQuantity: 100,
+      totalExitQuantity: 100,
+      realizedPnl: 1000,
+      returnPercentage: 6.7,
+      brokerageName,
+      grossPnl: 1000,
+      brokerageFees,
+      netPnl: 1000 - brokerageFees,
+      targetPrice: null,
+      stopLoss: null,
+      targetRR: null,
+      actualRR: null,
+      openUnits: 0,
+      closedUnits: 100,
+    },
+    isLoading: false,
+  } as unknown as PositionResult);
+}
+
+describe('PositionDetail — double-fee warning', () => {
+  it('stays hidden when no brokerage is attached, however large the fill fees', () => {
+    // The regression: brokerageFees is non-zero here because it is the manual
+    // fill fee attributed to the realized portion, NOT a calculated fee.
+    mockDetail({ fillFees: '1.80', brokerageName: null, brokerageFees: 1.8 });
+    const { container, root } = mountWith(<PositionDetailView positionId="p1" />);
+
+    expect(container.textContent).not.toMatch(WARNING);
+
+    unmount(container, root);
+  });
+
+  it('shows when a brokerage is attached and the position also carries manual fees', () => {
+    mockDetail({ fillFees: '1.00', brokerageName: 'Interactive Brokers', brokerageFees: 2.5 });
+    const { container, root } = mountWith(<PositionDetailView positionId="p1" />);
+
+    expect(container.textContent).toMatch(WARNING);
+
+    unmount(container, root);
+  });
+
+  it('stays hidden with a brokerage but no manual fill fees', () => {
+    mockDetail({ fillFees: '0', brokerageName: 'Interactive Brokers', brokerageFees: 2.5 });
+    const { container, root } = mountWith(<PositionDetailView positionId="p1" />);
+
+    expect(container.textContent).not.toMatch(WARNING);
+
+    unmount(container, root);
+  });
+});

--- a/apps/web/src/features/positions/components/PositionDetail.tsx
+++ b/apps/web/src/features/positions/components/PositionDetail.tsx
@@ -94,7 +94,14 @@ export function PositionDetailView({ positionId }: Props) {
   const currency = 'USD'; // The list endpoint has accountCurrency; detail doesn't. This is a known limitation.
 
   const hasManualFillFees = position.fills.some((f) => parseFloat(f.fees) > 0);
-  const hasDoubleFeeRisk = hasManualFillFees && position.brokerageFees > 0;
+  // `brokerageFees` is the fee attributed to the realized portion whatever its
+  // source, so on an account with no brokerage it is simply the manual fill fees
+  // pro-rated. Without the brokerageName guard this warning fires for every
+  // position carrying a fee — advising the user to zero out the only fees they
+  // have, which would overstate net P&L. The metric card above already gates on
+  // brokerageName for the same reason.
+  const hasDoubleFeeRisk =
+    hasManualFillFees && position.brokerageName !== null && position.brokerageFees > 0;
 
   const handleDelete = async () => {
     await deletePosition.mutateAsync();


### PR DESCRIPTION
Found while writing the positions guide (#27). The detail page shows this to users who have no brokerage at all:

> This position has both manual fill fees and brokerage-calculated fees. Consider zeroing out manual fees to avoid double-counting.

Following that advice deletes the only fee data they have, and overstates net P&L.

## Why it fires

```ts
const hasDoubleFeeRisk = hasManualFillFees && position.brokerageFees > 0;
```

`brokerageFees` is not "fees the brokerage calculated" — it is the fee attributed to the **realized portion**, whatever its source. With no brokerage attached it is just the manual fill fees pro-rated, so the second clause reduces to the first and the warning fires for **every position carrying a fee**.

## Observed

On a live instance, an account with `brokerageName: null`, two entry fills and two exit fills at 1.00 each:

```
brokerageName: None
brokerageFees: 1.8
fill fees    : ['1.00000000', '1.00000000', '1.00000000']

exited 60 of 150 entry units
entry fees allocated: 2.00 * 60/150 = 0.8
plus exit fee 1.00                  = 1.8
```

The **Brokerage Fees** card directly above rendered `—`, because it already gates on `brokerageName === null`. The warning below it did not.

## The fix

Add the same guard the card uses:

```ts
const hasDoubleFeeRisk =
  hasManualFillFees && position.brokerageName !== null && position.brokerageFees > 0;
```

## Tests

New `PositionDetail.doubleFee.test.tsx`, three cases: no brokerage + fees (the regression), brokerage + manual fees (should warn), brokerage + no manual fees.

Checked the test is meaningful rather than merely passing — reverted the fix and re-ran:

```
× stays hidden when no brokerage is attached, however large the fill fees
✓ shows when a brokerage is attached and the position also carries manual fees
✓ stays hidden with a brokerage but no manual fill fees
```

Exactly the intended case fails on the old condition. With the fix, `src/features/positions` is 17 files / 162 tests green, `check-types` and `pnpm lint` clean.