### PR TITLE
ci: check outbound links with lychee

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,60 @@
+name: Link check
+
+# Checks that OUTBOUND links in this repository's markdown still resolve.
+#
+# `starlightLinksValidator()` already fails the docs build on a broken link
+# BETWEEN doc pages, and that runs in `checks`. Nothing checked links pointing
+# OUT — to the sites, to GitHub, to third-party docs. That is the exact gap that
+# left seven links pointing at a repository that had been renamed: no code
+# changed, so no build broke, and the links rotted in place.
+#
+# Deliberately NOT part of the required `checks` job. An external link check
+# depends on other people's servers, so a required one would block merges on a
+# third party's 503. This runs weekly and on markdown changes, and its failures
+# are read rather than enforced — the same posture the security scanners were
+# introduced with.
+
+on:
+  schedule:
+    # Mondays, 06:00 UTC. Rot is found by the calendar, not by a code change,
+    # so the scheduled run is the one that matters.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '**/*.mdx'
+      - '.github/workflows/link-check.yml'
+      - 'lychee.toml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: link-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lychee:
+    name: lychee
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Restores lychee's response cache so a weekly run re-checks what changed
+      # rather than hammering every host from scratch.
+      - name: Restore lychee cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .lycheecache
+          key: lychee-${{ github.sha }}
+          restore-keys: lychee-
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          args: --config lychee.toml .
+          fail: true
+          jobSummary: true

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ Thumbs.db
 .playwright-mcp/
 
 .codeindex/
+
+# lychee response cache (.github/workflows/link-check.yml)
+.lycheecache

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,70 @@
+# Configuration for the outbound link check (.github/workflows/link-check.yml).
+#
+# Scope is deliberately OUTBOUND only. Links between doc pages are already
+# checked by starlightLinksValidator() during the docs build, which runs in the
+# required `checks` job; duplicating that here would mean two things to keep in
+# step and two places to silence a false positive.
+
+cache = true
+max_cache_age = "2d"
+
+# Other people's servers fail transiently. Retry before calling a link dead, so
+# the signal stays worth reading.
+max_retries = 3
+retry_wait_time = 2
+timeout = 20
+
+# Some hosts reject the default agent outright.
+user_agent = "Mozilla/5.0 (compatible; lychee link checker; +https://github.com/madmatt112/tradr)"
+
+# 429 is rate limiting, not rot. 403 is very often a bot wall (GitHub and
+# Cloudflare both do it) rather than a missing page.
+accept = ["200", "206", "429"]
+
+# Anchor checking stays off (lychee's default). It would need every target page
+# fetched and parsed, multiplying the request count for a class of breakage that
+# is not the one this exists to catch.
+
+exclude_path = [
+  "node_modules",
+  # The docs site's own pages. Their links are root-relative Starlight ROUTES
+  # (`/self-hosting/upgrades/`), not paths on disk, so lychee resolves them as
+  # broken files — 41 false failures for links that are correct.
+  # starlightLinksValidator() already checks these during the docs build and
+  # understands the routing; this job covers what nothing else does.
+  #
+  # Neither `scheme = ["http","https"]` nor an `exclude = ["^/"]` rule fixes it:
+  # the first drops the outbound links this exists to check while keeping the
+  # false failures, and the second never matches because the links are resolved
+  # to file paths before exclusion. Both measured.
+  #
+  # The cost is that outbound links INSIDE the docs pages go unchecked. Checking
+  # them needs the built HTML rather than the MDX source — worth doing, not done
+  # here.
+  "apps/docs/src",
+  "apps/docs/dist",
+  "apps/web/dist",
+  "pnpm-lock.yaml",
+  "CHANGELOG.md",
+]
+
+exclude = [
+  # Local and example hosts that appear throughout the self-hosting docs.
+  "^https?://localhost",
+  "^https?://127\\.0\\.0\\.1",
+  "^https?://0\\.0\\.0\\.0",
+  "^https?://.*\\.example\\.com",
+  "^https?://tradr\\.example\\.com",
+  "^https?://.*\\.local",
+  # Placeholders in configuration snippets.
+  "^https?://<",
+  "your-host",
+  "other-host",
+  "src-host",
+  "staging-host",
+  # The app's own hostname is not public yet — it 404s on purpose.
+  "^https://app\\.tradr\\.cloud",
+  # Vendor endpoints that answer only to an authenticated client.
+  "^https://api\\.github\\.com",
+  "^https://us\\.i\\.posthog\\.com",
+]


### PR DESCRIPTION
R17. `starlightLinksValidator()` fails the docs build on a broken link **between** doc pages, and that runs in `checks`. Nothing checked links pointing **out** — to the sites, to GitHub, to third-party docs.

That is precisely the gap that left seven links pointing at a repository which had been renamed. No code changed, so no build broke, and the links rotted in place until someone read them.

## Posture

Runs **weekly**, on markdown changes, and on demand. Deliberately **not** part of the required `checks` job: an external link check depends on other people's servers, so a required one would block merges on a third party's 503. Same advisory posture the security scanners were introduced with.

## The awkward part, recorded so nobody repeats it

Scope is markdown **outside `apps/docs/src`**. The docs pages' links are root-relative Starlight **routes** (`/self-hosting/upgrades/`), not paths on disk, so lychee resolves them as broken files — **41 false failures for links that are correct**.

Two obvious fixes do not work, and I measured both:

| Attempt | Result |
| --- | --- |
| `scheme = ["http", "https"]` | Excludes the outbound links this job exists to check (54 excluded, 20 OK) **and keeps all 41 false failures** |
| `exclude = ["^/"]` | Never matches — root-relative links are resolved to file paths before exclusion |

So the docs directory is excluded by path, with the reasoning written into `lychee.toml`. The cost is that outbound links **inside** the docs pages go unchecked; doing that properly needs the built HTML rather than the MDX source. Worth doing, not done here.

## Verified by running it

Against the real repository, via the lychee container:

```
🔍 67 Total  🔗 38 Unique  ✅ 60 OK  🚫 0 Errors  👻 3 Excluded
```

~1s cold (cache cleared, genuinely hitting the network).

Then confirmed the check actually **fires** rather than merely passing — added a link to the old renamed repository:

```
[./docs/README.md]:
[404] https://github.com/madmatt112/tradr-v2 (at 44:1) | Rejected status code: 404 Not Found
🚫 1 Error
```

Probe reverted.

Actions are SHA-pinned with least-privilege `permissions:` so the workflow passes the zizmor audit that lints this directory. `.lycheecache` is gitignored.