### PR TITLE
feat: split account balance into cash and position value

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -19,7 +19,9 @@ import passwordResetRouter from '@/features/auth/password-reset.route';
 import verificationRouter from '@/features/auth/verification.route';
 import { billingRouter, billingWebhookRouter } from '@/features/billing/billing.route';
 import brokeragesRouter from '@/features/brokerages/brokerages.route';
-import calculatorRouter from '@/features/calculator/calculator.route';
+import calculatorRouter, {
+  calculatorPreferencesRouter,
+} from '@/features/calculator/calculator.route';
 import { changelogRouter } from '@/features/changelog/changelog.route';
 import { initChangelogCache } from '@/features/changelog/changelog.service';
 import csvImport from '@/features/csv-import/csv-import.route';
@@ -97,6 +99,9 @@ app.route('/api/positions', positions);
 app.route('/api/positions', fillsRouter);
 app.route('/api/performance', performance);
 app.route('/api/symbols', symbolsRouter);
+// Mounted bare at /api so it can own the absolute /api/users/me/buying-power-basis
+// path, matching the accounting and expenses preference routes below.
+app.route('/api', calculatorPreferencesRouter);
 app.route('/api', accountingRouter);
 app.route('/api', expensesRouter);
 

--- a/apps/api/src/db/migrations/0024_user_buying_power_basis.sql
+++ b/apps/api/src/db/migrations/0024_user_buying_power_basis.sql
@@ -1,0 +1,14 @@
+-- Which account figure the position-sizing calculator caps position size against
+-- (calculator-balance-sizing). See users.schema.ts.
+--
+-- DEFAULT 'cash' applies to existing rows too, via PostgreSQL's fast default —
+-- no backfill statement, no table rewrite. This is a deliberate behaviour change
+-- for existing users, not only new ones: capping against total equity tells
+-- anyone with capital already deployed to open a position larger than the
+-- account can fund, and they find out at the broker. Capping against cash is at
+-- worst conservative, so the safe value is the one everybody lands on. Margin
+-- traders can opt back to 'balance'.
+--
+-- This does NOT change the risk budget, which stays `riskPercent × balance`.
+ALTER TABLE "users" ADD COLUMN "buying_power_basis" varchar(7) DEFAULT 'cash' NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_buying_power_basis_chk" CHECK ("users"."buying_power_basis" IN ('cash','balance'));

--- a/apps/api/src/db/migrations/meta/0024_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0024_snapshot.json
@@ -1,0 +1,3417 @@
+{
+  "id": "d987836c-738a-4f6a-ba36-34a6199d491e",
+  "prevId": "fe91f00f-2a36-4fd5-910b-08d7c4363906",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.exchange_rates": {
+      "name": "exchange_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_currency": {
+          "name": "base_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_currency": {
+          "name": "quote_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(24, 12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exchange_rates_user_pair_date_unique": {
+          "name": "exchange_rates_user_pair_date_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "base_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exchange_rates_user_id_users_id_fk": {
+          "name": "exchange_rates_user_id_users_id_fk",
+          "tableFrom": "exchange_rates",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "exchange_rates_distinct_currencies_chk": {
+          "name": "exchange_rates_distinct_currencies_chk",
+          "value": "\"exchange_rates\".\"base_currency\" <> \"exchange_rates\".\"quote_currency\""
+        },
+        "exchange_rates_rate_positive_chk": {
+          "name": "exchange_rates_rate_positive_chk",
+          "value": "\"exchange_rates\".\"rate\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ledger_entries": {
+      "name": "ledger_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_id": {
+          "name": "position_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reverses_group_id": {
+          "name": "reverses_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ledger_user_id_idx": {
+          "name": "ledger_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_account_id_idx": {
+          "name": "ledger_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_user_account_occurred_pnl_idx": {
+          "name": "ledger_user_account_occurred_pnl_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"occurred_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ledger_entries\".\"entry_type\" IN ('position_pnl', 'position_pnl_reversal', 'balance_adjustment')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_user_account_direction_amount_pnl_idx": {
+          "name": "ledger_user_account_direction_amount_pnl_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ledger_entries\".\"entry_type\" IN ('position_pnl', 'position_pnl_reversal', 'balance_adjustment')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_reverses_group_id_idx": {
+          "name": "ledger_reverses_group_id_idx",
+          "columns": [
+            {
+              "expression": "reverses_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ledger_entries\".\"reverses_group_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ledger_entries_user_id_users_id_fk": {
+          "name": "ledger_entries_user_id_users_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ledger_entries_account_id_accounts_id_fk": {
+          "name": "ledger_entries_account_id_accounts_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "ledger_entries_position_id_positions_id_fk": {
+          "name": "ledger_entries_position_id_positions_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "positions",
+          "columnsFrom": ["position_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ledger_amount_nonneg_chk": {
+          "name": "ledger_amount_nonneg_chk",
+          "value": "\"ledger_entries\".\"amount\" >= 0"
+        },
+        "ledger_direction_chk": {
+          "name": "ledger_direction_chk",
+          "value": "\"ledger_entries\".\"direction\" IN ('credit', 'debit')"
+        },
+        "ledger_entry_type_chk": {
+          "name": "ledger_entry_type_chk",
+          "value": "\"ledger_entries\".\"entry_type\" IN ('position_pnl', 'position_pnl_reversal', 'balance_adjustment')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "brokerage_id": {
+          "name": "brokerage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_balance": {
+          "name": "starting_balance",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_id_name_unique": {
+          "name": "accounts_user_id_name_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_brokerage_id_idx": {
+          "name": "accounts_brokerage_id_idx",
+          "columns": [
+            {
+              "expression": "brokerage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_brokerage_id_brokerages_id_fk": {
+          "name": "accounts_brokerage_id_brokerages_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "brokerages",
+          "columnsFrom": ["brokerage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_email": {
+          "name": "target_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_created_idx": {
+          "name": "admin_audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_actor_user_id_users_id_fk": {
+          "name": "admin_audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_users_id_fk": {
+          "name": "admin_audit_log_target_user_id_users_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["target_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "admin_audit_log_action_chk": {
+          "name": "admin_audit_log_action_chk",
+          "value": "\"admin_audit_log\".\"action\" IN ('admin_toggle')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.advisor_image_counters": {
+      "name": "advisor_image_counters",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_count": {
+          "name": "image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "advisor_image_counters_user_id_users_id_fk": {
+          "name": "advisor_image_counters_user_id_users_id_fk",
+          "tableFrom": "advisor_image_counters",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "advisor_image_counters_user_id_period_key_pk": {
+          "name": "advisor_image_counters_user_id_period_key_pk",
+          "columns": ["user_id", "period_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_turn_counters": {
+      "name": "advisor_turn_counters",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "allowance_turns": {
+          "name": "allowance_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "advisor_turn_counters_user_id_users_id_fk": {
+          "name": "advisor_turn_counters_user_id_users_id_fk",
+          "tableFrom": "advisor_turn_counters",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "advisor_turn_counters_user_id_period_key_pk": {
+          "name": "advisor_turn_counters_user_id_period_key_pk",
+          "columns": ["user_id", "period_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_conversations": {
+      "name": "advisor_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_conversations_user_updated_idx": {
+          "name": "advisor_conversations_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_conversations_user_id_users_id_fk": {
+          "name": "advisor_conversations_user_id_users_id_fk",
+          "tableFrom": "advisor_conversations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "advisor_conversations_persona_id_advisor_personas_id_fk": {
+          "name": "advisor_conversations_persona_id_advisor_personas_id_fk",
+          "tableFrom": "advisor_conversations",
+          "tableTo": "advisor_personas",
+          "columnsFrom": ["persona_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_messages": {
+      "name": "advisor_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_parts": {
+          "name": "content_parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_message_id": {
+          "name": "client_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_messages_conv_created_idx": {
+          "name": "advisor_messages_conv_created_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "advisor_messages_idem": {
+          "name": "advisor_messages_idem",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "role = 'user' AND client_message_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "advisor_messages_assistant_pair_uniq": {
+          "name": "advisor_messages_assistant_pair_uniq",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "role = 'assistant' AND client_message_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_messages_conversation_id_advisor_conversations_id_fk": {
+          "name": "advisor_messages_conversation_id_advisor_conversations_id_fk",
+          "tableFrom": "advisor_messages",
+          "tableTo": "advisor_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "advisor_messages_role_chk": {
+          "name": "advisor_messages_role_chk",
+          "value": "\"advisor_messages\".\"role\" IN ('user', 'assistant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.advisor_personas": {
+      "name": "advisor_personas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_personas_one_default_per_user": {
+          "name": "advisor_personas_one_default_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true AND user_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_personas_user_id_users_id_fk": {
+          "name": "advisor_personas_user_id_users_id_fk",
+          "tableFrom": "advisor_personas",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_provider_keys": {
+      "name": "advisor_provider_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hint_tail": {
+          "name": "key_hint_tail",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_provider_keys_user_provider_uniq": {
+          "name": "advisor_provider_keys_user_provider_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_provider_keys_user_id_users_id_fk": {
+          "name": "advisor_provider_keys_user_id_users_id_fk",
+          "tableFrom": "advisor_provider_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_summaries": {
+      "name": "advisor_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prose": {
+          "name": "prose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trade_data_figures": {
+          "name": "trade_data_figures",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered_through_message_id": {
+          "name": "covered_through_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered_through_created_at": {
+          "name": "covered_through_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_summaries_conversation_uniq": {
+          "name": "advisor_summaries_conversation_uniq",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_summaries_conversation_id_advisor_conversations_id_fk": {
+          "name": "advisor_summaries_conversation_id_advisor_conversations_id_fk",
+          "tableFrom": "advisor_summaries",
+          "tableTo": "advisor_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_api_keys": {
+      "name": "external_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hint_tail": {
+          "name": "key_hint_tail",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_api_keys_user_provider_uniq": {
+          "name": "external_api_keys_user_provider_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_api_keys_user_id_users_id_fk": {
+          "name": "external_api_keys_user_id_users_id_fk",
+          "tableFrom": "external_api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brokerages": {
+      "name": "brokerages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brokerages_user_id_idx": {
+          "name": "brokerages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brokerages_user_id_name_unique": {
+          "name": "brokerages_user_id_name_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"brokerages\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brokerages_system_name_unique": {
+          "name": "brokerages_system_name_unique",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"brokerages\".\"is_system\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brokerages_user_id_users_id_fk": {
+          "name": "brokerages_user_id_users_id_fk",
+          "tableFrom": "brokerages",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_schedules": {
+      "name": "fee_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "brokerage_id": {
+          "name": "brokerage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_per_share_commission": {
+          "name": "stock_per_share_commission",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "stock_min_per_fill": {
+          "name": "stock_min_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "stock_max_per_fill": {
+          "name": "stock_max_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_per_contract_commission": {
+          "name": "options_per_contract_commission",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_per_contract_exchange_fee": {
+          "name": "options_per_contract_exchange_fee",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_min_per_fill": {
+          "name": "options_min_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_max_per_fill": {
+          "name": "options_max_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_schedules_brokerage_id_brokerages_id_fk": {
+          "name": "fee_schedules_brokerage_id_brokerages_id_fk",
+          "tableFrom": "fee_schedules",
+          "tableTo": "brokerages",
+          "columnsFrom": ["brokerage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_schedules_brokerage_id_unique": {
+          "name": "fee_schedules_brokerage_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["brokerage_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.csv_import_counters": {
+      "name": "csv_import_counters",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "committed_count": {
+          "name": "committed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "csv_import_counters_user_id_users_id_fk": {
+          "name": "csv_import_counters_user_id_users_id_fk",
+          "tableFrom": "csv_import_counters",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.csv_import_staging": {
+      "name": "csv_import_staging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'staged'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committed_result": {
+          "name": "committed_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "csv_import_staging_one_active_per_user_idx": {
+          "name": "csv_import_staging_one_active_per_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"csv_import_staging\".\"status\" IN ('staged', 'committing')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "csv_import_staging_user_id_idx": {
+          "name": "csv_import_staging_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "csv_import_staging_expires_at_idx": {
+          "name": "csv_import_staging_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "csv_import_staging_user_id_users_id_fk": {
+          "name": "csv_import_staging_user_id_users_id_fk",
+          "tableFrom": "csv_import_staging",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "csv_import_staging_account_id_accounts_id_fk": {
+          "name": "csv_import_staging_account_id_accounts_id_fk",
+          "tableFrom": "csv_import_staging",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_layouts": {
+      "name": "dashboard_layouts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgets": {
+          "name": "widgets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_layouts_user_id_users_id_fk": {
+          "name": "dashboard_layouts_user_id_users_id_fk",
+          "tableFrom": "dashboard_layouts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_tokens": {
+      "name": "email_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_tokens_user_purpose_idx": {
+          "name": "email_tokens_user_purpose_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_tokens_one_live_per_user_purpose": {
+          "name": "email_tokens_one_live_per_user_purpose",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "consumed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_tokens_user_id_users_id_fk": {
+          "name": "email_tokens_user_id_users_id_fk",
+          "tableFrom": "email_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_tokens_token_hash_unique": {
+          "name": "email_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_tokens_purpose_chk": {
+          "name": "email_tokens_purpose_chk",
+          "value": "\"email_tokens\".\"purpose\" IN ('password_reset','email_verification')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.expenses": {
+      "name": "expenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "expenses_user_id_idx": {
+          "name": "expenses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "expenses_user_occurred_idx": {
+          "name": "expenses_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"occurred_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "expenses_user_id_users_id_fk": {
+          "name": "expenses_user_id_users_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "expenses_amount_positive_chk": {
+          "name": "expenses_amount_positive_chk",
+          "value": "\"expenses\".\"amount\" > 0"
+        },
+        "expenses_category_chk": {
+          "name": "expenses_category_chk",
+          "value": "category IN ('data_subscription', 'platform_fee', 'software', 'education', 'hardware', 'other')"
+        },
+        "expenses_currency_chk": {
+          "name": "expenses_currency_chk",
+          "value": "currency IN ('USD', 'EUR', 'GBP', 'CAD', 'AUD', 'JPY', 'CHF', 'HKD', 'SGD', 'NZD', 'SEK', 'NOK', 'DKK', 'MXN', 'BRL', 'INR', 'KRW', 'TWD', 'ZAR')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public._post_migrations_journal": {
+      "name": "_post_migrations_journal",
+      "schema": "",
+      "columns": {
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fills": {
+      "name": "fills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "position_id": {
+          "name": "position_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fees": {
+          "name": "fees",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filled_at": {
+          "name": "filled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fills_position_id_idx": {
+          "name": "fills_position_id_idx",
+          "columns": [
+            {
+              "expression": "position_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fills_position_id_positions_id_fk": {
+          "name": "fills_position_id_positions_id_fk",
+          "tableFrom": "fills",
+          "tableTo": "positions",
+          "columnsFrom": ["position_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.positions": {
+      "name": "positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_price": {
+          "name": "target_price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_loss": {
+          "name": "stop_loss",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_flat_at": {
+          "name": "last_flat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_flat_net_pnl": {
+          "name": "last_flat_net_pnl",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "positions_user_id_idx": {
+          "name": "positions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "positions_account_id_idx": {
+          "name": "positions_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "positions_user_id_status_updated_at_idx": {
+          "name": "positions_user_id_status_updated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "positions_user_status_closed_at_idx": {
+          "name": "positions_user_status_closed_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "positions_user_id_users_id_fk": {
+          "name": "positions_user_id_users_id_fk",
+          "tableFrom": "positions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "positions_account_id_accounts_id_fk": {
+          "name": "positions_account_id_accounts_id_fk",
+          "tableFrom": "positions",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "positions_closed_at_when_closed_chk": {
+          "name": "positions_closed_at_when_closed_chk",
+          "value": "\"positions\".\"status\" <> 'closed' OR \"positions\".\"closed_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.symbol_sync_state": {
+      "name": "symbol_sync_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "smallint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncing": {
+          "name": "syncing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "syncing_started_at": {
+          "name": "syncing_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "symbol_count": {
+          "name": "symbol_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "symbol_sync_state_singleton": {
+          "name": "symbol_sync_state_singleton",
+          "value": "\"symbol_sync_state\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.symbols": {
+      "name": "symbols",
+      "schema": "",
+      "columns": {
+        "ticker": {
+          "name": "ticker",
+          "type": "varchar(16)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exchange": {
+          "name": "exchange",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cik": {
+          "name": "cik",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "symbols_ticker_prefix_idx": {
+          "name": "symbols_ticker_prefix_idx",
+          "columns": [
+            {
+              "expression": "ticker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "varchar_pattern_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed": {
+          "name": "last_accessed",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_currency": {
+          "name": "display_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_jurisdiction": {
+          "name": "tax_jurisdiction",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "buying_power_basis": {
+          "name": "buying_power_basis",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cash'"
+        },
+        "advisor_default_persona_id": {
+          "name": "advisor_default_persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advisor_trade_data_consent": {
+          "name": "advisor_trade_data_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "writable_account_id": {
+          "name": "writable_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changelog_viewed_at": {
+          "name": "changelog_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_tax_jurisdiction_chk": {
+          "name": "users_tax_jurisdiction_chk",
+          "value": "\"users\".\"tax_jurisdiction\" IS NULL OR \"users\".\"tax_jurisdiction\" IN ('US', 'CA', 'other')"
+        },
+        "users_theme_chk": {
+          "name": "users_theme_chk",
+          "value": "\"users\".\"theme\" IN ('light','dark','system')"
+        },
+        "users_buying_power_basis_chk": {
+          "name": "users_buying_power_basis_chk",
+          "value": "\"users\".\"buying_power_basis\" IN ('cash','balance')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_customers": {
+      "name": "billing_customers",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_customers_user_id_users_id_fk": {
+          "name": "billing_customers_user_id_users_id_fk",
+          "tableFrom": "billing_customers",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_customers_stripe_customer_id_unique": {
+          "name": "billing_customers_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_customer_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_unit_amount": {
+          "name": "price_unit_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_currency": {
+          "name": "price_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_created_at": {
+          "name": "stripe_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entered_past_due_at": {
+          "name": "entered_past_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_created": {
+          "name": "last_event_created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_subscription_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_cost": {
+          "name": "credit_cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_cost": {
+          "name": "raw_cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_records_user_created_idx": {
+          "name": "usage_records_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_records_created_idx": {
+          "name": "usage_records_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_user_id_users_id_fk": {
+          "name": "usage_records_user_id_users_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_records_conversation_id_advisor_conversations_id_fk": {
+          "name": "usage_records_conversation_id_advisor_conversations_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "advisor_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "usage_records_message_id_advisor_messages_id_fk": {
+          "name": "usage_records_message_id_advisor_messages_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "advisor_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_transactions": {
+      "name": "wallet_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_record_id": {
+          "name": "usage_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_transactions_user_created_idx": {
+          "name": "wallet_transactions_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transactions_payment_intent_idx": {
+          "name": "wallet_transactions_payment_intent_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_transactions_user_id_users_id_fk": {
+          "name": "wallet_transactions_user_id_users_id_fk",
+          "tableFrom": "wallet_transactions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_transactions_usage_record_id_usage_records_id_fk": {
+          "name": "wallet_transactions_usage_record_id_usage_records_id_fk",
+          "tableFrom": "wallet_transactions",
+          "tableTo": "usage_records",
+          "columnsFrom": ["usage_record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "wallet_transactions_kind_chk": {
+          "name": "wallet_transactions_kind_chk",
+          "value": "\"wallet_transactions\".\"kind\" IN ('credit', 'debit', 'reversal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "reserved": {
+          "name": "reserved",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallets_user_id_users_id_fk": {
+          "name": "wallets_user_id_users_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "wallets_reserved_nonneg_chk": {
+          "name": "wallets_reserved_nonneg_chk",
+          "value": "\"wallets\".\"reserved\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_events_stripe_event_id_unique": {
+          "name": "webhook_events_stripe_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_event_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webhook_events_status_chk": {
+          "name": "webhook_events_status_chk",
+          "value": "\"webhook_events\".\"status\" IN ('received', 'processed', 'ignored', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1785526351101,
       "tag": "0023_position_last_flat_snapshot",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1785871256384,
+      "tag": "0024_user_buying_power_basis",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema/users.schema.ts
+++ b/apps/api/src/db/schema/users.schema.ts
@@ -23,6 +23,14 @@ export const users = pgTable(
     displayCurrency: varchar('display_currency', { length: 3 }),
     taxJurisdiction: varchar('tax_jurisdiction', { length: 8 }),
     theme: varchar('theme', { length: 8 }).notNull().default('system'),
+    // Which account figure the position-sizing calculator's buying-power cap is
+    // computed against (calculator-balance-sizing). Defaults to 'cash' — including
+    // for existing rows, via PostgreSQL's fast default — because sizing the cap
+    // against total equity tells a user with capital already deployed to open a
+    // position they cannot fund. 'balance' restores the pre-existing behaviour for
+    // margin traders. Does NOT affect the risk budget, which is always a percent
+    // of the balance.
+    buyingPowerBasis: varchar('buying_power_basis', { length: 7 }).notNull().default('cash'),
     // FK to advisor_personas.id (ON DELETE SET NULL) enforced in the migration only;
     // a TS .references() here would create a circular import with advisor.schema.ts.
     advisorDefaultPersonaId: text('advisor_default_persona_id'),
@@ -42,6 +50,7 @@ export const users = pgTable(
       sql`${t.taxJurisdiction} IS NULL OR ${t.taxJurisdiction} IN ('US', 'CA', 'other')`,
     ),
     check('users_theme_chk', sql`${t.theme} IN ('light','dark','system')`),
+    check('users_buying_power_basis_chk', sql`${t.buyingPowerBasis} IN ('cash','balance')`),
   ],
 );
 

--- a/apps/api/src/features/accounts/accounts.cash-split.test.ts
+++ b/apps/api/src/features/accounts/accounts.cash-split.test.ts
@@ -1,0 +1,575 @@
+/**
+ * Cash / position-value split (ledger-balances Req 10).
+ *
+ * The account balance is partitioned into `cash` and `positionValue`:
+ *
+ *     cash = balance − Σ (open positions at cost basis)
+ *
+ * This became derivable only once per-fill P&L posting landed (Req 9, commit
+ * 234d091). Before that the ledger held a position's realized P&L back until it
+ * went flat, so mid-trade the subtraction was short by exactly the unposted
+ * amount — $4,500 against a true $4,550 in the worked example below. Half of
+ * these tests exist to keep that gap closed.
+ *
+ * Every expectation here is a real cash figure, computed independently of the
+ * app: what a broker's cash column would read after the same fills. If a test
+ * says $4,540, that is 5000 − 1000 − 10 + 550, not whatever the query returned.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+import app, { bootstrap } from '@/app';
+import { unregisterCloseHook } from '@/features/positions/positions.service';
+
+beforeAll(() => {
+  // See accounting.test.ts — .catch swallows the async advisor-startup tail,
+  // whose fire-and-forget canary rejects against the per-test mocked db.
+  bootstrap().catch(() => {});
+});
+
+afterAll(() => {
+  unregisterCloseHook('ledger');
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures (mirrors accounting.test.ts)
+// ---------------------------------------------------------------------------
+
+let testCounter = 0;
+const testRunId = Date.now();
+let ipCounter = 900;
+
+function uniqueIp() {
+  return `10.9.${Math.floor(++ipCounter / 256)}.${ipCounter % 256}`;
+}
+
+function getCookieValue(res: Response, name: string): string | undefined {
+  for (const header of res.headers.getSetCookie()) {
+    const match = header.match(new RegExp(`${name}=([^;]*)`));
+    if (match) return match[1];
+  }
+  return undefined;
+}
+
+async function registerAndGetCookie(): Promise<string> {
+  const res = await app.request('/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-Forwarded-For': uniqueIp() },
+    body: JSON.stringify({
+      email: `cashsplit${testRunId}-${++testCounter}@example.com`,
+      password: 'password123',
+    }),
+  });
+  expect(res.status).toBe(201);
+  return getCookieValue(res, 'session')!;
+}
+
+function authedRequest(method: string, path: string, cookie: string, body?: unknown) {
+  const headers: Record<string, string> = {
+    Cookie: `session=${cookie}`,
+    'X-Forwarded-For': uniqueIp(),
+  };
+  if (body !== undefined) headers['Content-Type'] = 'application/json';
+  return app.request(path, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+async function createAccount(cookie: string, startingBalance: string, currency = 'USD') {
+  const res = await authedRequest('POST', '/api/accounts', cookie, {
+    name: `Cash Split ${++testCounter}`,
+    currency,
+    startingBalance,
+  });
+  expect(res.status).toBe(201);
+  return res.json();
+}
+
+/** The account's derived balance and its two halves, as numbers. */
+async function split(cookie: string, accountId: string) {
+  const res = await authedRequest('GET', `/api/accounts/${accountId}`, cookie);
+  expect(res.status).toBe(200);
+  const account = await res.json();
+  return {
+    balance: Number(account.balance),
+    cash: Number(account.cash),
+    positionValue: Number(account.positionValue),
+  };
+}
+
+async function listPositions(cookie: string, query = '') {
+  const res = await authedRequest('GET', `/api/positions${query}`, cookie);
+  expect(res.status).toBe(200);
+  return res.json();
+}
+
+async function addFill(
+  cookie: string,
+  positionId: string,
+  data: {
+    type: 'entry' | 'exit';
+    price: string;
+    quantity: string;
+    fees?: string;
+    filledAt: string;
+  },
+) {
+  const res = await authedRequest('POST', `/api/positions/${positionId}/fills`, cookie, {
+    fees: '0',
+    ...data,
+  });
+  expect(res.status).toBe(201);
+  return res.json();
+}
+
+/** Create a position, give it one entry fill, and open it. */
+async function openWithEntry(
+  cookie: string,
+  accountId: string,
+  o: {
+    price: string;
+    quantity: string;
+    fees?: string;
+    side?: 'long' | 'short';
+    assetType?: 'stock' | 'option';
+    symbol?: string;
+  },
+) {
+  const created = await authedRequest('POST', '/api/positions', cookie, {
+    accountId,
+    symbol: o.symbol ?? 'AAPL',
+    side: o.side ?? 'long',
+    assetType: o.assetType ?? 'stock',
+  });
+  expect(created.status).toBe(201);
+  const position = await created.json();
+
+  await addFill(cookie, position.id, {
+    type: 'entry',
+    price: o.price,
+    quantity: o.quantity,
+    fees: o.fees ?? '0',
+    filledAt: '2026-01-01T00:00:00Z',
+  });
+
+  const opened = await authedRequest('POST', `/api/positions/${position.id}/open`, cookie, {
+    openedAt: '2026-01-01T00:00:00Z',
+  });
+  expect(opened.status).toBe(200);
+  return position;
+}
+
+// ---------------------------------------------------------------------------
+// The invariant
+// ---------------------------------------------------------------------------
+
+describe('cash + positionValue === balance', () => {
+  it('holds through the full open → partial exit → flat lifecycle', async () => {
+    const cookie = await registerAndGetCookie();
+    const account = await createAccount(cookie, '5000');
+
+    // Flat account: everything is cash.
+    expect(await split(cookie, account.id)).toEqual({
+      balance: 5000,
+      cash: 5000,
+      positionValue: 0,
+    });
+
+    // $5,000 cash → open a $1,000 position (10 @ $100).
+    const position = await openWithEntry(cookie, account.id, { price: '100', quantity: '10' });
+    expect(await split(cookie, account.id)).toEqual({
+      balance: 5000,
+      cash: 4000,
+      positionValue: 1000,
+    });
+
+    // Partially close at a profit: 5 @ $110 realizes $50.
+    // THIS is the assertion the whole feature turns on. Before per-fill posting
+    // the balance would still read $5,000 here, making cash $4,000 — short by
+    // the $50 that had been realized but not yet posted.
+    await addFill(cookie, position.id, {
+      type: 'exit',
+      price: '110',
+      quantity: '5',
+      filledAt: '2026-01-02T00:00:00Z',
+    });
+    expect(await split(cookie, account.id)).toEqual({
+      balance: 5050,
+      cash: 4550,
+      positionValue: 500,
+    });
+
+    // Close the rest: the position value returns to cash.
+    await addFill(cookie, position.id, {
+      type: 'exit',
+      price: '110',
+      quantity: '5',
+      filledAt: '2026-01-03T00:00:00Z',
+    });
+    expect(await split(cookie, account.id)).toEqual({
+      balance: 5100,
+      cash: 5100,
+      positionValue: 0,
+    });
+  });
+
+  it('survives a fill edit that retroactively reprices the position', async () => {
+    const cookie = await registerAndGetCookie();
+    const account = await createAccount(cookie, '5000');
+    const position = await openWithEntry(cookie, account.id, { price: '100', quantity: '10' });
+
+    const exit = await addFill(cookie, position.id, {
+      type: 'exit',
+      price: '110',
+      quantity: '5',
+      filledAt: '2026-01-02T00:00:00Z',
+    });
+    expect(await split(cookie, account.id)).toEqual({
+      balance: 5050,
+      cash: 4550,
+      positionValue: 500,
+    });
+
+    // Correct the exit price down to $105 — realized P&L drops to $25 and the
+    // ledger posts a compensating debit.
+    const edited = await authedRequest(
+      'PUT',
+      `/api/positions/${position.id}/fills/${exit.id}`,
+      cookie,
+      { price: '105' },
+    );
+    expect(edited.status).toBe(200);
+
+    expect(await split(cookie, account.id)).toEqual({
+      balance: 5025,
+      cash: 4525,
+      positionValue: 500,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Entry fees — the term that makes the derivation exact rather than close
+// ---------------------------------------------------------------------------
+
+describe('entry fees', () => {
+  it('rides with the open portion so cash matches the broker to the cent', async () => {
+    const cookie = await registerAndGetCookie();
+    const account = await createAccount(cookie, '5000');
+
+    // 10 @ $100 with a $10 commission. Real cash out is $1,010, not $1,000.
+    const position = await openWithEntry(cookie, account.id, {
+      price: '100',
+      quantity: '10',
+      fees: '10',
+    });
+
+    // Nothing realized yet, so the balance has not moved — but the whole $10
+    // commission is already out of cash, carried on the position.
+    expect(await split(cookie, account.id)).toEqual({
+      balance: 5000,
+      cash: 3990,
+      positionValue: 1010,
+    });
+
+    await addFill(cookie, position.id, {
+      type: 'exit',
+      price: '110',
+      quantity: '5',
+      filledAt: '2026-01-02T00:00:00Z',
+    });
+
+    // Broker's cash: 5000 − (10 × 100) − 10 + (5 × 110) = 4540.
+    //
+    // The ledger charged $5 of the commission against the realized half
+    // (prorated exitQty/entryQty), so the balance is 5045. The remaining $5
+    // rides on the open half. Omit that term — as the old display-only cost
+    // basis did — and cash reads 4545, overstated for as long as any part of
+    // the position stays open.
+    expect(await split(cookie, account.id)).toEqual({
+      balance: 5045,
+      cash: 4540,
+      positionValue: 505,
+    });
+  });
+
+  it('is fully spent once the position is flat', async () => {
+    const cookie = await registerAndGetCookie();
+    const account = await createAccount(cookie, '5000');
+    const position = await openWithEntry(cookie, account.id, {
+      price: '100',
+      quantity: '10',
+      fees: '10',
+    });
+    await addFill(cookie, position.id, {
+      type: 'exit',
+      price: '110',
+      quantity: '10',
+      fees: '4',
+      filledAt: '2026-01-02T00:00:00Z',
+    });
+
+    // 5000 − 1000 − 10 + 1100 − 4 = 5086, all of it cash.
+    expect(await split(cookie, account.id)).toEqual({
+      balance: 5086,
+      cash: 5086,
+      positionValue: 0,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shorts and options
+// ---------------------------------------------------------------------------
+
+describe('shorts', () => {
+  it('carry a NEGATIVE position value, so cash exceeds the balance', async () => {
+    const cookie = await registerAndGetCookie();
+    const account = await createAccount(cookie, '5000');
+
+    // Short 10 @ $100: the broker credits $1,000 of proceeds against 10 shares
+    // owed. Cash goes UP; the position is a liability.
+    const position = await openWithEntry(cookie, account.id, {
+      side: 'short',
+      price: '100',
+      quantity: '10',
+    });
+    expect(await split(cookie, account.id)).toEqual({
+      balance: 5000,
+      cash: 6000,
+      positionValue: -1000,
+    });
+
+    // Cover 5 @ $90 → $50 realized, $450 of cash out.
+    await addFill(cookie, position.id, {
+      type: 'exit',
+      price: '90',
+      quantity: '5',
+      filledAt: '2026-01-02T00:00:00Z',
+    });
+
+    // Broker's cash: 5000 + 1000 − 450 = 5550. An unsigned position value would
+    // report 4550 here — wrong by twice the remaining proceeds.
+    expect(await split(cookie, account.id)).toEqual({
+      balance: 5050,
+      cash: 5550,
+      positionValue: -500,
+    });
+  });
+
+  it('take their entry fee toward zero, not away from it', async () => {
+    const cookie = await registerAndGetCookie();
+    const account = await createAccount(cookie, '5000');
+    await openWithEntry(cookie, account.id, {
+      side: 'short',
+      price: '100',
+      quantity: '10',
+      fees: '10',
+    });
+
+    // Proceeds received are $1,000 less the $10 commission = $990 of cash in.
+    // The fee is an outflow on both sides of the book, so it shrinks the
+    // magnitude of a short's negative position value.
+    expect(await split(cookie, account.id)).toEqual({
+      balance: 5000,
+      cash: 5990,
+      positionValue: -990,
+    });
+  });
+});
+
+describe('options', () => {
+  it('apply the 100x contract multiplier to the price leg only', async () => {
+    const cookie = await registerAndGetCookie();
+    const account = await createAccount(cookie, '5000');
+
+    // 2 contracts @ $3.00 with $1.30 of fees = 2 × 3 × 100 + 1.30 of capital.
+    await openWithEntry(cookie, account.id, {
+      assetType: 'option',
+      symbol: 'AAPL260116C00150000',
+      price: '3',
+      quantity: '2',
+      fees: '1.30',
+    });
+
+    expect(await split(cookie, account.id)).toEqual({
+      balance: 5000,
+      cash: 4398.7,
+      positionValue: 601.3,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// What does and does not count
+// ---------------------------------------------------------------------------
+
+describe('scope of the position-value aggregate', () => {
+  it('counts only open positions — drafts are invisible', async () => {
+    const cookie = await registerAndGetCookie();
+    const account = await createAccount(cookie, '5000');
+
+    // A draft with an entry fill. Drafts cannot take exit fills, so they never
+    // realize anything and never touch the ledger; counting them here would
+    // move cash against a balance that never moved.
+    const created = await authedRequest('POST', '/api/positions', cookie, {
+      accountId: account.id,
+      symbol: 'MSFT',
+      side: 'long',
+      assetType: 'stock',
+    });
+    expect(created.status).toBe(201);
+    await addFill(cookie, (await created.json()).id, {
+      type: 'entry',
+      price: '100',
+      quantity: '10',
+      filledAt: '2026-01-01T00:00:00Z',
+    });
+
+    expect(await split(cookie, account.id)).toEqual({
+      balance: 5000,
+      cash: 5000,
+      positionValue: 0,
+    });
+  });
+
+  it('puts reconciliation adjustments in cash, not in position value', async () => {
+    const cookie = await registerAndGetCookie();
+    const account = await createAccount(cookie, '5000');
+    await openWithEntry(cookie, account.id, { price: '100', quantity: '10' });
+
+    // A $500 deposit, recorded by reconciling to the new target. This is the
+    // `balance_adjustment` entry type — a cash movement, and it needs no
+    // special handling: it is already in `balance` and is not position value,
+    // so the subtraction routes it to cash on its own.
+    const reconciled = await authedRequest('POST', `/api/ledger/${account.id}/reconcile`, cookie, {
+      targetBalance: '5500',
+    });
+    expect(reconciled.status).toBe(201);
+
+    expect(await split(cookie, account.id)).toEqual({
+      balance: 5500,
+      cash: 4500,
+      positionValue: 1000,
+    });
+  });
+
+  it('scopes position value to the owning account', async () => {
+    const cookie = await registerAndGetCookie();
+    const a = await createAccount(cookie, '5000');
+    const b = await createAccount(cookie, '2000');
+
+    await openWithEntry(cookie, a.id, { price: '100', quantity: '10' });
+    await openWithEntry(cookie, b.id, { price: '50', quantity: '4', symbol: 'MSFT' });
+
+    expect(await split(cookie, a.id)).toEqual({ balance: 5000, cash: 4000, positionValue: 1000 });
+    expect(await split(cookie, b.id)).toEqual({ balance: 2000, cash: 1800, positionValue: 200 });
+  });
+
+  it('does not leak another user’s positions into the aggregate', async () => {
+    const owner = await registerAndGetCookie();
+    const account = await createAccount(owner, '5000');
+    await openWithEntry(owner, account.id, { price: '100', quantity: '10' });
+
+    const stranger = await registerAndGetCookie();
+    const denied = await authedRequest('GET', `/api/accounts/${account.id}`, stranger);
+    expect(denied.status).toBe(404);
+
+    // And the owner's own figures are unchanged by the stranger existing.
+    expect(await split(owner, account.id)).toEqual({
+      balance: 5000,
+      cash: 4000,
+      positionValue: 1000,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SQL / TypeScript parity
+// ---------------------------------------------------------------------------
+
+describe('parity between the SQL aggregate and computeOpenCostBasis', () => {
+  // `positionValue` on the account is a SQL LATERAL in accounts.query.ts;
+  // `openCostBasis` on each position is `computeOpenCostBasis` in pnl.ts. They
+  // encode the same rule in two languages because the account aggregate cannot
+  // be TypeScript (it would be an N+1 across accounts) and the per-row display
+  // cannot be SQL. Nothing but this test stops them drifting apart.
+  it('agrees across long, short, option, partial exits and fees', async () => {
+    const cookie = await registerAndGetCookie();
+    const account = await createAccount(cookie, '10000');
+
+    // Long, partially exited, with fees on both legs.
+    const long = await openWithEntry(cookie, account.id, {
+      price: '100',
+      quantity: '10',
+      fees: '7.50',
+    });
+    await addFill(cookie, long.id, {
+      type: 'exit',
+      price: '112.34',
+      quantity: '3',
+      fees: '1.25',
+      filledAt: '2026-01-02T00:00:00Z',
+    });
+
+    // Short, partially covered, with an entry fee.
+    const short = await openWithEntry(cookie, account.id, {
+      side: 'short',
+      symbol: 'TSLA',
+      price: '243.17',
+      quantity: '7',
+      fees: '3.10',
+    });
+    await addFill(cookie, short.id, {
+      type: 'exit',
+      price: '230.05',
+      quantity: '2',
+      filledAt: '2026-01-02T00:00:00Z',
+    });
+
+    // Option, untouched since entry.
+    await openWithEntry(cookie, account.id, {
+      assetType: 'option',
+      symbol: 'AAPL260116C00150000',
+      price: '4.35',
+      quantity: '3',
+      fees: '1.95',
+    });
+
+    // A flat position, which must contribute nothing to either side.
+    const flat = await openWithEntry(cookie, account.id, {
+      symbol: 'NVDA',
+      price: '80',
+      quantity: '5',
+      fees: '2',
+    });
+    await addFill(cookie, flat.id, {
+      type: 'exit',
+      price: '85',
+      quantity: '5',
+      fees: '2',
+      filledAt: '2026-01-02T00:00:00Z',
+    });
+
+    const open = await listPositions(cookie, '?status=open');
+    expect(open).toHaveLength(3);
+
+    const summed = open.reduce(
+      (total: number, p: { openCostBasis: number }) => total + p.openCostBasis,
+      0,
+    );
+    const { balance, cash, positionValue } = await split(cookie, account.id);
+
+    // Rounded to cents: the SQL sums unrounded per-position terms and rounds
+    // once at the end, while the TypeScript rounds each position. They agree to
+    // the cent, which is the contract — not bit-for-bit.
+    expect(positionValue).toBeCloseTo(summed, 2);
+    expect(cash + positionValue).toBeCloseTo(balance, 4);
+
+    // The flat position reports zero on the TypeScript side too.
+    const all = await listPositions(cookie);
+    const flatRow = all.find((p: { id: string }) => p.id === flat.id);
+    expect(flatRow.openCostBasis).toBe(0);
+  });
+});

--- a/apps/api/src/features/accounts/accounts.query.ts
+++ b/apps/api/src/features/accounts/accounts.query.ts
@@ -24,6 +24,58 @@ const balanceLateral = sql`LATERAL (
     AND le.entry_type IN ('position_pnl', 'position_pnl_reversal', 'balance_adjustment')
 ) bal`;
 
+// LATERAL aggregate over the account's OPEN positions computing the capital
+// currently tied up in them, at cost (ledger-balances Req 10). Same inlined raw
+// SQL LATERAL pattern as `balanceLateral` above.
+//
+//   sideSign · openQty · avgEntryPrice · multiplier   (capital deployed)
+// + entryFees · openQty / entryQty                    (unallocated entry fee)
+//
+// This reads `positions`/`fills`, NEVER `ledger_entries` — so it is deliberately
+// NOT another copy of the entry-type list, and `balance_adjustment` rows need no
+// handling here. Reconciliation adjustments are cash movements: they land in
+// `balance`, are not position value, and so flow into `cash` for free.
+//
+// SIGNED. A short's entry fills are sells, so its unexited size is proceeds
+// received against shares still owed — a liability, hence negative. Without the
+// sign, `cash` for a short lands on the wrong number entirely.
+//
+// Only `status = 'open'` contributes. Drafts are excluded: they never post to the
+// ledger (exits are blocked while draft, so they realize nothing), so counting
+// them here would move cash against a balance that never moved.
+//
+// MIRRORS `computeOpenCostBasis` in `positions/pnl.ts`, which applies the same
+// rule to one position for the per-row display. The two are pinned together by
+// the parity test in `accounts.cash-split.test.ts` — change one, change both.
+//
+// The inner `ON agg.entry_qty > 0` guards the two divisions: a position with no
+// entry fills drops out of the aggregate instead of contributing NULL and
+// poisoning the SUM. Unreachable for status='open' (opening requires at least
+// one entry fill), but the join condition is cheaper than trusting that
+// invariant from here.
+//
+// Backed by `positions_account_id_idx` and `fills_position_id_idx`.
+const positionValueLateral = sql`LATERAL (
+  SELECT COALESCE(SUM(
+    CASE WHEN p.side = 'long' THEN 1 ELSE -1 END
+      * (agg.entry_qty - agg.exit_qty)
+      * (agg.entry_cost / agg.entry_qty)
+      * CASE WHEN p.asset_type = 'option' THEN 100 ELSE 1 END
+    + agg.entry_fees * (agg.entry_qty - agg.exit_qty) / agg.entry_qty
+  ), 0)::numeric(18,4) AS position_value
+  FROM positions p
+  JOIN LATERAL (
+    SELECT
+      COALESCE(SUM(CASE WHEN f.type = 'entry' THEN f.quantity END), 0) AS entry_qty,
+      COALESCE(SUM(CASE WHEN f.type = 'exit'  THEN f.quantity END), 0) AS exit_qty,
+      COALESCE(SUM(CASE WHEN f.type = 'entry' THEN f.price * f.quantity END), 0) AS entry_cost,
+      COALESCE(SUM(CASE WHEN f.type = 'entry' THEN f.fees END), 0) AS entry_fees
+    FROM fills f WHERE f.position_id = p.id
+  ) agg ON agg.entry_qty > 0
+  WHERE p.account_id = ${accounts.id}
+    AND p.status = 'open'
+) pos`;
+
 // Derived balance = user-entered starting_balance + ledger aggregate, emitted
 // at scale-4 precision (e.g. '0.0000') to match ledger_entries.amount. The
 // COALESCE handles the LEFT JOIN producing no rows (impossible in practice
@@ -31,6 +83,21 @@ const balanceLateral = sql`LATERAL (
 const balanceProjection =
   sql<string>`(${accounts.startingBalance} + COALESCE(bal.balance, 0))::numeric(18,4)::text`.as(
     'balance',
+  );
+
+// The two halves of `balance`. `cash` is derived by SUBTRACTION rather than
+// summed independently, so `cash + positionValue = balance` holds exactly by
+// construction — the split is a partition of the existing number and can never
+// disagree with it.
+//
+// Cost basis only. Neither figure moves with the market; there is no quote
+// source. `positionValue` is what was paid (or, for shorts, received), full stop.
+const positionValueProjection =
+  sql<string>`COALESCE(pos.position_value, 0)::numeric(18,4)::text`.as('positionValue');
+
+const cashProjection =
+  sql<string>`(${accounts.startingBalance} + COALESCE(bal.balance, 0) - COALESCE(pos.position_value, 0))::numeric(18,4)::text`.as(
+    'cash',
   );
 
 export function findAccountsByUser(db: Database | Transaction, userId: string) {
@@ -46,10 +113,13 @@ export function findAccountsByUser(db: Database | Transaction, userId: string) {
       createdAt: accounts.createdAt,
       updatedAt: accounts.updatedAt,
       balance: balanceProjection,
+      cash: cashProjection,
+      positionValue: positionValueProjection,
     })
     .from(accounts)
     .leftJoin(brokerages, eq(accounts.brokerageId, brokerages.id))
     .leftJoin(balanceLateral, sql`true`)
+    .leftJoin(positionValueLateral, sql`true`)
     .where(eq(accounts.userId, userId));
 }
 
@@ -66,10 +136,13 @@ export function findAccountById(db: Database | Transaction, id: string, userId: 
       createdAt: accounts.createdAt,
       updatedAt: accounts.updatedAt,
       balance: balanceProjection,
+      cash: cashProjection,
+      positionValue: positionValueProjection,
     })
     .from(accounts)
     .leftJoin(brokerages, eq(accounts.brokerageId, brokerages.id))
     .leftJoin(balanceLateral, sql`true`)
+    .leftJoin(positionValueLateral, sql`true`)
     .where(and(eq(accounts.id, id), eq(accounts.userId, userId)))
     .limit(1);
 }
@@ -123,6 +196,10 @@ export interface AccountSummary {
   currency: string;
   brokerageName: string | null;
   balance: string;
+  /** Balance minus the cost basis of open positions — deployable funds. */
+  cash: string;
+  /** Cost basis of open positions; negative for shorts. Never mark-to-market. */
+  positionValue: string;
 }
 
 /** Accounts + derived balances for a user. Read-only, userId-scoped. */
@@ -137,10 +214,13 @@ export function selectAccountSummaries(
       currency: accounts.currency,
       brokerageName: brokerages.name,
       balance: balanceProjection,
+      cash: cashProjection,
+      positionValue: positionValueProjection,
     })
     .from(accounts)
     .leftJoin(brokerages, eq(accounts.brokerageId, brokerages.id))
     .leftJoin(balanceLateral, sql`true`)
+    .leftJoin(positionValueLateral, sql`true`)
     .where(eq(accounts.userId, userId));
 }
 

--- a/apps/api/src/features/advisor/tools/trade-data.test.ts
+++ b/apps/api/src/features/advisor/tools/trade-data.test.ts
@@ -70,7 +70,9 @@ describe('trade-data tool definitions', () => {
     }
     expect(openPositionsTool.maxEstTokens).toBe(3000);
     expect(recentClosedTool.maxEstTokens).toBe(1500);
-    expect(accountSummaryTool.maxEstTokens).toBe(1500);
+    // Raised from 1500 when the cash/position split widened each account row
+    // from five fields to seven (ledger-balances Req 10).
+    expect(accountSummaryTool.maxEstTokens).toBe(2000);
     expect(pnlSummaryTool.maxEstTokens).toBe(800);
   });
 
@@ -244,6 +246,6 @@ describe('trade-data pre-call egress cap (REQ-9.5)', () => {
     );
     expect(result.status).toBe('ok');
     expect(selectAccountSummaries).toHaveBeenCalledWith(expect.anything(), 'owner-1');
-    expect(ts.tradeDataTokens).toBe(1500);
+    expect(ts.tradeDataTokens).toBe(2000);
   });
 });

--- a/apps/api/src/features/advisor/tools/trade-data.ts
+++ b/apps/api/src/features/advisor/tools/trade-data.ts
@@ -7,8 +7,14 @@
 //
 //   trade_data_open_positions  → 3000
 //   trade_data_recent_closed   → 1500
-//   trade_data_account_summary → 1500
+//   trade_data_account_summary → 2000
 //   trade_data_pnl_summary     →  800
+//
+// account_summary was raised 1500 → 2000 when the cash/position split
+// (ledger-balances Req 10) added `cash` and `positionValue` to every account
+// row — five fields became seven, so the worst-case payload grew with it. The
+// bound is a budget declaration, not a truncation limit, so leaving it at 1500
+// would have quietly under-charged the per-turn trade-data budget.
 //
 // Trade-data contexts carry NO Unusual Whales client (REQ-1.4): handlers read
 // the `db` singleton and run the task-14 summary queries scoped to `ctx.userId`
@@ -39,7 +45,7 @@ import type { ToolDefinition, ToolResult } from './types';
 
 const OPEN_POSITIONS_MAX_EST_TOKENS = 3000;
 const RECENT_CLOSED_MAX_EST_TOKENS = 1500;
-const ACCOUNT_SUMMARY_MAX_EST_TOKENS = 1500;
+const ACCOUNT_SUMMARY_MAX_EST_TOKENS = 2000;
 const PNL_SUMMARY_MAX_EST_TOKENS = 800;
 
 // --- Input schemas (flat objects; scalar fields only) ------------------------
@@ -97,7 +103,12 @@ export const recentClosedTool: ToolDefinition = {
 
 export const accountSummaryTool: ToolDefinition = {
   name: 'trade_data_account_summary',
-  description: "Get a summary of the user's own trading accounts and their current balances.",
+  description:
+    "Get a summary of the user's own trading accounts. Each account reports its balance " +
+    'split into cash (deployable funds) and positionValue (open positions at COST BASIS, ' +
+    'not market value — there is no quote feed). positionValue is negative for short ' +
+    'positions, where the unexited size is proceeds received against shares still owed. ' +
+    'cash + positionValue always equals balance.',
   category: 'trade-data',
   requires: 'trade-data-consent',
   maxEstTokens: ACCOUNT_SUMMARY_MAX_EST_TOKENS,

--- a/apps/api/src/features/calculator/calculator.query.ts
+++ b/apps/api/src/features/calculator/calculator.query.ts
@@ -1,0 +1,40 @@
+import { eq } from 'drizzle-orm';
+
+import type { BuyingPowerBasis } from '@tradr/shared';
+
+import type { Database, Transaction } from '@/db';
+import { users } from '@/db/schema';
+
+/**
+ * The user's buying-power basis — which account figure the calculator caps
+ * position size against (calculator-balance-sizing).
+ *
+ * The column is `NOT NULL DEFAULT 'cash'`, so the fallback here is unreachable
+ * for an existing user and exists only for the missing-row case (a deleted user
+ * racing a request). It matches the column default deliberately: a read that
+ * silently returned 'balance' would reintroduce the overshoot the default is
+ * there to prevent.
+ */
+export async function getBuyingPowerBasis(
+  db: Database | Transaction,
+  userId: string,
+): Promise<BuyingPowerBasis> {
+  const rows = await db
+    .select({ buyingPowerBasis: users.buyingPowerBasis })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  return (rows[0]?.buyingPowerBasis as BuyingPowerBasis | undefined) ?? 'cash';
+}
+
+/** Persist the buying-power basis. Value validity is the route's Zod duty. */
+export async function setBuyingPowerBasis(
+  db: Database | Transaction,
+  userId: string,
+  basis: BuyingPowerBasis,
+): Promise<void> {
+  await db
+    .update(users)
+    .set({ buyingPowerBasis: basis, updatedAt: new Date() })
+    .where(eq(users.id, userId));
+}

--- a/apps/api/src/features/calculator/calculator.route.ts
+++ b/apps/api/src/features/calculator/calculator.route.ts
@@ -1,10 +1,13 @@
 import { Hono } from 'hono';
 
-import { CalculatorInputSchema, calculateTrade } from '@tradr/shared';
+import { BuyingPowerBasisBodySchema, CalculatorInputSchema, calculateTrade } from '@tradr/shared';
 
+import { db } from '@/db';
 import { ValidationError } from '@/lib/errors';
 import { validate } from '@/lib/validation';
 import { authMiddleware } from '@/middleware/auth.middleware';
+
+import { getBuyingPowerBasis, setBuyingPowerBasis } from './calculator.query';
 
 type AuthEnv = {
   Variables: {
@@ -30,13 +33,15 @@ calculatorRouter.use(authMiddleware);
  *       basis: a direct `dollarRisk`, OR a `balance` + `riskPercent` (the dollar
  *       risk is then derived as `balance × riskPercent ÷ 100` at full precision).
  *       Supplying both bases, or neither, is a 400. In the percent basis the
- *       position size is also capped to what the balance can fund at entry
- *       (`floor(balance ÷ (entry × multiplier))`); the three percent-only response
- *       fields (`derivedDollarRisk`, `sizingStatus`, `buyingPowerLimited`) are
- *       absent from dollar-basis results. Non-sizing outcomes (non-positive
- *       balance, derived risk over the ceiling, insufficient risk, balance funds
- *       zero units) are valid **200**s with `positionSize: 0` and a `sizingStatus`
- *       discriminator — not 400s.
+ *       position size is also capped to what the account can fund at entry —
+ *       `floor(buyingPower ÷ (entry × multiplier))`, falling back to `balance`
+ *       when `buyingPower` is omitted. The risk budget is always a percent of
+ *       `balance`; only the cap consults `buyingPower`. The three percent-only
+ *       response fields (`derivedDollarRisk`, `sizingStatus`,
+ *       `buyingPowerLimited`) are absent from dollar-basis results. Non-sizing
+ *       outcomes (non-positive balance, derived risk over the ceiling,
+ *       insufficient risk, cap basis funds zero units) are valid **200**s with
+ *       `positionSize: 0` and a `sizingStatus` discriminator — not 400s.
  *     tags: [Calculator]
  *     requestBody:
  *       required: true
@@ -60,13 +65,26 @@ calculatorRouter.use(authMiddleware);
  *               balance:
  *                 type: string
  *                 description: >
- *                   Percent-basis balance to size against and cap against.
- *                   Sign-agnostic finite decimal within the account-balance domain
- *                   (a losing account's balance can be ≤ 0). Percent basis requires
- *                   both `balance` and `riskPercent`.
+ *                   Percent-basis balance the RISK BUDGET is derived from, and the
+ *                   default basis for the buying-power cap. Sign-agnostic finite
+ *                   decimal within the account-balance domain (a losing account's
+ *                   balance can be ≤ 0). Percent basis requires both `balance` and
+ *                   `riskPercent`.
+ *               buyingPower:
+ *                 type: string
+ *                 description: >
+ *                   Optional percent-basis figure the BUYING-POWER CAP is computed
+ *                   against, when it should not be `balance`. Absent ⇒ the cap uses
+ *                   `balance` (the original behaviour). Supply an account's `cash`
+ *                   here to stop the calculator sizing a position the account
+ *                   cannot fund: total equity overstates fundable capital by
+ *                   whatever is already deployed. Sign-agnostic — a fully-deployed
+ *                   or margined account can present ≤ 0 cash, which yields
+ *                   `sizingStatus: buying-power-zero`. Never affects the risk
+ *                   budget.
  *               riskPercent:
  *                 type: string
- *                 description: Percent of balance to risk (0 < p ≤ 100).
+ *                 description: Percent of `balance` to risk (0 < p ≤ 100). Always a percent of balance, never of `buyingPower`.
  *               targetPrice: { type: string, description: Optional positive decimal for R:R. }
  *               feeSchedule: { type: object, description: Optional brokerage fee schedule (mutually exclusive with manualFees). }
  *               manualFees: { type: string, description: Optional flat fee estimate (mutually exclusive with feeSchedule). }
@@ -94,5 +112,90 @@ calculatorRouter.post('/', validate('json', CalculatorInputSchema), async (c) =>
     throw new ValidationError(message);
   }
 });
+
+// ---------------------------------------------------------------------------
+// User buying-power basis
+//
+// A stored preference, unlike POST /api/calculator above, which stays a pure
+// function of its request body. The preference decides which account figure a
+// CLIENT sends as `buyingPower`; the calculation itself never reads it. Keeping
+// the sizing endpoint stateless means an API consumer picks its own basis
+// explicitly rather than inheriting a setting it cannot see.
+//
+// It gets its OWN router because the per-preference convention is an absolute
+// `/api/users/me/<preference>` path — as with `/users/me/display-currency`
+// (accounting) and `/users/me/tax-jurisdiction` (expenses) — and those live on
+// routers mounted bare at `/api`. `calculatorRouter` is mounted at
+// `/api/calculator`, so a `/users/me/...` path declared on it would resolve to
+// `/api/calculator/users/me/...`. Mounted at `/api` in app.ts.
+// ---------------------------------------------------------------------------
+
+export const calculatorPreferencesRouter = new Hono<AuthEnv>();
+
+calculatorPreferencesRouter.use(authMiddleware);
+
+/**
+ * @swagger
+ * /api/users/me/buying-power-basis:
+ *   get:
+ *     summary: Get the calculator's buying-power basis.
+ *     description: >
+ *       Authed. Which account figure the position-sizing calculator caps position
+ *       size against — `cash` (balance less the cost basis of open positions) or
+ *       `balance` (total equity). Never null; the column defaults to `cash`.
+ *     tags: [Calculator]
+ *     responses:
+ *       200:
+ *         description: The stored basis.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 basis: { type: string, enum: [cash, balance], example: cash }
+ *       401: { description: Authentication required. }
+ */
+calculatorPreferencesRouter.get('/users/me/buying-power-basis', async (c) => {
+  const userId = c.get('userId');
+  const basis = await getBuyingPowerBasis(db, userId);
+  return c.json({ basis }, 200);
+});
+
+/**
+ * @swagger
+ * /api/users/me/buying-power-basis:
+ *   put:
+ *     summary: Set the calculator's buying-power basis.
+ *     description: >
+ *       Authed. `cash` caps position size at what the account can actually deploy;
+ *       `balance` caps at total equity, which overstates fundable capital by
+ *       whatever is already tied up in open positions. Affects only the cap — the
+ *       risk budget stays `riskPercent × balance` either way. Changes nothing
+ *       stored beyond the preference itself.
+ *     tags: [Calculator]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [basis]
+ *             properties:
+ *               basis: { type: string, enum: [cash, balance] }
+ *     responses:
+ *       200: { description: The stored basis. }
+ *       400: { description: Not one of cash | balance. }
+ *       401: { description: Authentication required. }
+ */
+calculatorPreferencesRouter.put(
+  '/users/me/buying-power-basis',
+  validate('json', BuyingPowerBasisBodySchema),
+  async (c) => {
+    const userId = c.get('userId');
+    const { basis } = c.req.valid('json');
+    await setBuyingPowerBasis(db, userId, basis);
+    return c.json({ basis }, 200);
+  },
+);
 
 export default calculatorRouter;

--- a/apps/api/src/features/calculator/calculator.route.ts
+++ b/apps/api/src/features/calculator/calculator.route.ts
@@ -32,16 +32,18 @@ calculatorRouter.use(authMiddleware);
  *       (`entryPrice`, `stopLoss`, `direction`, `mode`) plus **exactly one** risk
  *       basis: a direct `dollarRisk`, OR a `balance` + `riskPercent` (the dollar
  *       risk is then derived as `balance × riskPercent ÷ 100` at full precision).
- *       Supplying both bases, or neither, is a 400. In the percent basis the
- *       position size is also capped to what the account can fund at entry —
- *       `floor(buyingPower ÷ (entry × multiplier))`, falling back to `balance`
- *       when `buyingPower` is omitted. The risk budget is always a percent of
- *       `balance`; only the cap consults `buyingPower`. The three percent-only
- *       response fields (`derivedDollarRisk`, `sizingStatus`,
- *       `buyingPowerLimited`) are absent from dollar-basis results. Non-sizing
- *       outcomes (non-positive balance, derived risk over the ceiling,
- *       insufficient risk, cap basis funds zero units) are valid **200**s with
- *       `positionSize: 0` and a `sizingStatus` discriminator — not 400s.
+ *       Supplying both bases, or neither, is a 400. The position size is also
+ *       capped to what the account can fund at entry —
+ *       `floor(capBasis ÷ (entry × multiplier))` — where `capBasis` is
+ *       `buyingPower` when supplied (**either** risk basis), else `balance` on
+ *       the percent basis, else no cap at all on the dollar basis. The risk
+ *       budget is always a percent of `balance`; only the cap consults
+ *       `buyingPower`. `derivedDollarRisk` remains percent-only, but
+ *       `sizingStatus` and `buyingPowerLimited` can now appear on a dollar-basis
+ *       result whenever `buyingPower` is supplied. Non-sizing outcomes
+ *       (non-positive balance, derived risk over the ceiling, insufficient risk,
+ *       cap basis funds zero units) are valid **200**s with `positionSize: 0`
+ *       and a `sizingStatus` discriminator — not 400s.
  *     tags: [Calculator]
  *     requestBody:
  *       required: true
@@ -73,12 +75,14 @@ calculatorRouter.use(authMiddleware);
  *               buyingPower:
  *                 type: string
  *                 description: >
- *                   Optional percent-basis figure the BUYING-POWER CAP is computed
- *                   against, when it should not be `balance`. Absent ⇒ the cap uses
- *                   `balance` (the original behaviour). Supply an account's `cash`
- *                   here to stop the calculator sizing a position the account
- *                   cannot fund: total equity overstates fundable capital by
- *                   whatever is already deployed. Sign-agnostic — a fully-deployed
+ *                   Optional figure the BUYING-POWER CAP is computed against, valid
+ *                   in EITHER risk basis. Absent ⇒ the percent basis caps against
+ *                   `balance` (the original behaviour) and the dollar basis is
+ *                   uncapped (likewise). Supply an account's `cash` here to stop
+ *                   the calculator sizing a position the account cannot fund:
+ *                   total equity overstates fundable capital by whatever is
+ *                   already deployed, and a direct dollar risk overshoots just as
+ *                   readily as a percentage one. Sign-agnostic — a fully-deployed
  *                   or margined account can present ≤ 0 cash, which yields
  *                   `sizingStatus: buying-power-zero`. Never affects the risk
  *                   budget.
@@ -95,10 +99,12 @@ calculatorRouter.use(authMiddleware);
  *           `actualDollarRisk`, `totalPositionValue`; `perUnitReward` /
  *           `riskRewardRatio` when a target is set, and the fee fields when fees
  *           are supplied. Percent basis additionally echoes `derivedDollarRisk`
- *           (2dp, when balance > 0), `sizingStatus`
+ *           (2dp, when balance > 0). `sizingStatus`
  *           (`nothing-to-size-against` | `exceeds-maximum` | `buying-power-zero`)
- *           on the zero-position outcomes, and `buyingPowerLimited: true` when the
- *           buying-power cap set the size.
+ *           on the zero-position outcomes and `buyingPowerLimited: true` when the
+ *           cap set the size appear on EITHER basis — the latter two require only
+ *           that a cap basis existed, which on the dollar basis means
+ *           `buyingPower` was supplied.
  *       400: { description: 'Validation error — both/neither risk basis, riskPercent ∉ (0,100], bad balance/price format, or a structural price error.' }
  *       401: { description: Authentication required. }
  */

--- a/apps/api/src/features/calculator/calculator.test.ts
+++ b/apps/api/src/features/calculator/calculator.test.ts
@@ -409,3 +409,167 @@ describe('POST /api/calculator', () => {
     expect(body.actualDollarRisk).toBe('100.00');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Buying-power basis — the stored preference
+// ---------------------------------------------------------------------------
+
+describe('GET/PUT /api/users/me/buying-power-basis', () => {
+  async function getBasis(cookie: string) {
+    const res = await authedRequest('GET', '/api/users/me/buying-power-basis', cookie);
+    expect(res.status).toBe(200);
+    return (await res.json()).basis;
+  }
+
+  it('defaults a brand-new user to cash', async () => {
+    // The default is load-bearing, not cosmetic: 'balance' would let the
+    // calculator size a position the account cannot fund.
+    const { cookie } = await registerAndGetCookie();
+    expect(await getBasis(cookie)).toBe('cash');
+  });
+
+  it('round-trips a change to balance and back', async () => {
+    const { cookie } = await registerAndGetCookie();
+
+    const toBalance = await authedRequest('PUT', '/api/users/me/buying-power-basis', cookie, {
+      basis: 'balance',
+    });
+    expect(toBalance.status).toBe(200);
+    expect((await toBalance.json()).basis).toBe('balance');
+    expect(await getBasis(cookie)).toBe('balance');
+
+    const toCash = await authedRequest('PUT', '/api/users/me/buying-power-basis', cookie, {
+      basis: 'cash',
+    });
+    expect(toCash.status).toBe(200);
+    expect(await getBasis(cookie)).toBe('cash');
+  });
+
+  it('rejects a value outside the enum', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const res = await authedRequest('PUT', '/api/users/me/buying-power-basis', cookie, {
+      basis: 'equity',
+    });
+    expect(res.status).toBe(400);
+    // The rejected write must not have landed.
+    expect(await getBasis(cookie)).toBe('cash');
+  });
+
+  it('rejects a missing body field', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const res = await authedRequest('PUT', '/api/users/me/buying-power-basis', cookie, {});
+    expect(res.status).toBe(400);
+  });
+
+  it('requires authentication on both verbs', async () => {
+    const get = await app.request('/api/users/me/buying-power-basis', {
+      headers: { 'X-Forwarded-For': uniqueIp() },
+    });
+    expect(get.status).toBe(401);
+
+    const put = await app.request('/api/users/me/buying-power-basis', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', 'X-Forwarded-For': uniqueIp() },
+      body: JSON.stringify({ basis: 'balance' }),
+    });
+    expect(put.status).toBe(401);
+  });
+
+  it('is scoped per user', async () => {
+    const a = await registerAndGetCookie();
+    const b = await registerAndGetCookie();
+
+    await authedRequest('PUT', '/api/users/me/buying-power-basis', a.cookie, {
+      basis: 'balance',
+    });
+
+    expect(await getBasis(a.cookie)).toBe('balance');
+    expect(await getBasis(b.cookie)).toBe('cash');
+  });
+});
+
+describe('POST /api/calculator — buyingPower', () => {
+  it('caps against buyingPower while the risk budget stays on balance', async () => {
+    const { cookie } = await registerAndGetCookie();
+    // $5,000 equity, $4,000 deployed ⇒ $1,000 cash. Budget 1% = $50 → 25
+    // shares; cap = floor(1000 / 50) = 20 binds.
+    const res = await authedRequest('POST', '/api/calculator', cookie, {
+      entryPrice: '50',
+      stopLoss: '48',
+      balance: '5000',
+      buyingPower: '1000',
+      riskPercent: '1',
+      direction: 'long',
+      mode: 'stock',
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.positionSize).toBe(20);
+    expect(body.buyingPowerLimited).toBe(true);
+    expect(body.derivedDollarRisk).toBe('50.00');
+  });
+
+  it('falls back to balance when buyingPower is omitted', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const res = await authedRequest('POST', '/api/calculator', cookie, {
+      entryPrice: '50',
+      stopLoss: '48',
+      balance: '5000',
+      riskPercent: '1',
+      direction: 'long',
+      mode: 'stock',
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.positionSize).toBe(25);
+    expect(body.buyingPowerLimited).toBeUndefined();
+  });
+
+  it('reports buying-power-zero for a fully-deployed account, not a 400', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const res = await authedRequest('POST', '/api/calculator', cookie, {
+      entryPrice: '50',
+      stopLoss: '48',
+      balance: '5000',
+      buyingPower: '0',
+      riskPercent: '1',
+      direction: 'long',
+      mode: 'stock',
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.positionSize).toBe(0);
+    expect(body.sizingStatus).toBe('buying-power-zero');
+  });
+
+  it('accepts a negative buyingPower and zeroes the size', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const res = await authedRequest('POST', '/api/calculator', cookie, {
+      entryPrice: '50',
+      stopLoss: '48',
+      balance: '5000',
+      buyingPower: '-500',
+      riskPercent: '1',
+      direction: 'long',
+      mode: 'stock',
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.positionSize).toBe(0);
+    expect(body.sizingStatus).toBe('buying-power-zero');
+  });
+
+  it('400s on an unparseable buyingPower', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const res = await authedRequest('POST', '/api/calculator', cookie, {
+      entryPrice: '50',
+      stopLoss: '48',
+      balance: '5000',
+      buyingPower: 'lots',
+      riskPercent: '1',
+      direction: 'long',
+      mode: 'stock',
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/src/features/calculator/calculator.test.ts
+++ b/apps/api/src/features/calculator/calculator.test.ts
@@ -573,3 +573,53 @@ describe('POST /api/calculator — buyingPower', () => {
     expect(res.status).toBe(400);
   });
 });
+
+describe('POST /api/calculator — buyingPower on the dollar basis', () => {
+  const dollarTrade = {
+    entryPrice: '50',
+    stopLoss: '48',
+    dollarRisk: '1000',
+    direction: 'long',
+    mode: 'stock',
+  };
+
+  it('caps a dollar-basis size and flags it', async () => {
+    const { cookie } = await registerAndGetCookie();
+    // 1000 / 2 = 500 shares uncapped; floor(10000 / 50) = 200 binds.
+    const res = await authedRequest('POST', '/api/calculator', cookie, {
+      ...dollarTrade,
+      buyingPower: '10000',
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.positionSize).toBe(200);
+    expect(body.buyingPowerLimited).toBe(true);
+    // Percent-only echo stays absent even though the cap fired.
+    expect(body.derivedDollarRisk).toBeUndefined();
+  });
+
+  it('leaves the dollar basis uncapped when buyingPower is omitted', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const res = await authedRequest('POST', '/api/calculator', cookie, dollarTrade);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.positionSize).toBe(500);
+    expect(body.buyingPowerLimited).toBeUndefined();
+  });
+
+  it('returns buying-power-zero on the dollar basis as a 200, not a 500', async () => {
+    // Guards the `to2dp(null!)` crash: the percent path echoes derivedDollarRisk
+    // on this outcome, and there is none to echo here.
+    const { cookie } = await registerAndGetCookie();
+    const res = await authedRequest('POST', '/api/calculator', cookie, {
+      ...dollarTrade,
+      entryPrice: '100',
+      buyingPower: '50',
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.positionSize).toBe(0);
+    expect(body.sizingStatus).toBe('buying-power-zero');
+    expect(body.derivedDollarRisk).toBeUndefined();
+  });
+});

--- a/apps/api/src/features/positions/pnl.test.ts
+++ b/apps/api/src/features/positions/pnl.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { aggregateFills, computePnlFromTotals } from './pnl';
+import { aggregateFills, computeOpenCostBasis, computePnlFromTotals } from './pnl';
 import type { FillTotals } from './pnl';
 
 // ---------------------------------------------------------------------------
@@ -317,5 +317,115 @@ describe('computePnlFromTotals — rounding', () => {
     expect(pnl.grossPnl).toBe(100.01);
     expect(pnl.fees).toBe(0.01);
     expect(pnl.grossPnl! - pnl.fees!).toBeCloseTo(pnl.realizedPnl!, 10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeOpenCostBasis — the "position value" half of the cash/position split
+// ---------------------------------------------------------------------------
+
+describe('computeOpenCostBasis', () => {
+  function totals(o: Partial<FillTotals>): FillTotals {
+    return {
+      entryQty: '0',
+      exitQty: '0',
+      entryCost: '0',
+      exitCost: '0',
+      entryFees: '0',
+      exitFees: '0',
+      ...o,
+    };
+  }
+
+  it('is the full cost basis before any exit', () => {
+    const t = totals({ entryQty: '10', entryCost: '1000' });
+    expect(computeOpenCostBasis(t, 'long', 'stock', 2)).toBe(1000);
+  });
+
+  it('shrinks to the unexited portion after a partial exit', () => {
+    const t = totals({ entryQty: '10', exitQty: '5', entryCost: '1000', exitCost: '550' });
+    expect(computeOpenCostBasis(t, 'long', 'stock', 2)).toBe(500);
+  });
+
+  it('is zero once fully exited', () => {
+    const t = totals({ entryQty: '10', exitQty: '10', entryCost: '1000', exitCost: '1100' });
+    expect(computeOpenCostBasis(t, 'long', 'stock', 2)).toBe(0);
+  });
+
+  it('is zero for an entry-less position rather than dividing by zero', () => {
+    expect(computeOpenCostBasis(totals({}), 'long', 'stock', 2)).toBe(0);
+  });
+
+  it('allocates entry fees by openQty / entryQty', () => {
+    // $10 commission on 10 shares, half still open → $5 rides with the open half.
+    const t = totals({
+      entryQty: '10',
+      exitQty: '5',
+      entryCost: '1000',
+      exitCost: '550',
+      entryFees: '10',
+    });
+    expect(computeOpenCostBasis(t, 'long', 'stock', 2)).toBe(505);
+  });
+
+  it('complements the realized fee proration exactly — together they spend the fee once', () => {
+    const t = totals({
+      entryQty: '10',
+      exitQty: '5',
+      entryCost: '1000',
+      exitCost: '550',
+      entryFees: '10',
+    });
+    // computePnlFromTotals charged 10 × 5/10 = $5 against the realized half;
+    // computeOpenCostBasis carries the other $5 on the open half.
+    const realizedFeeShare = computeOpenCostBasis(t, 'long', 'stock', 2) - 500;
+    const pnl = computePnlFromTotals(t, 'long', 'stock', 2);
+    expect(realizedFeeShare).toBe(5);
+    expect(pnl.grossPnl! - pnl.realizedPnl!).toBe(5);
+    expect(realizedFeeShare + (pnl.grossPnl! - pnl.realizedPnl!)).toBe(10);
+  });
+
+  it('is NEGATIVE for a short — remaining proceeds are a liability', () => {
+    // Short 10 @ $100, covered 5 @ $90. Five shares still owed.
+    const t = totals({ entryQty: '10', exitQty: '5', entryCost: '1000', exitCost: '450' });
+    expect(computeOpenCostBasis(t, 'short', 'stock', 2)).toBe(-500);
+  });
+
+  it('moves a short toward zero with its entry fee, not away from it', () => {
+    // The fee is a cash outflow either way, so it always reduces the magnitude
+    // of a short's negative position value.
+    const t = totals({
+      entryQty: '10',
+      exitQty: '5',
+      entryCost: '1000',
+      exitCost: '450',
+      entryFees: '10',
+    });
+    expect(computeOpenCostBasis(t, 'short', 'stock', 2)).toBe(-495);
+  });
+
+  it('applies the 100x contract multiplier for options', () => {
+    // 2 contracts @ $3.00 = $600 of capital.
+    const t = totals({ entryQty: '2', entryCost: '6' });
+    expect(computeOpenCostBasis(t, 'long', 'option', 2)).toBe(600);
+  });
+
+  it('does NOT multiply fees by the contract multiplier', () => {
+    // Fees are already absolute currency; only the price leg is per-contract.
+    const t = totals({ entryQty: '2', entryCost: '6', entryFees: '1.30' });
+    expect(computeOpenCostBasis(t, 'long', 'option', 2)).toBe(601.3);
+  });
+
+  it('rounds once at the end, not per component', () => {
+    // Deployed capital 33.335 unrounded; fee share 0.005 unrounded.
+    //   round(33.335 + 0.005) = 33.34   ← this expression
+    //   round(33.335) + round(0.005) = 33.34 + 0.01 = 33.35   ← the bug
+    const t = totals({ entryQty: '3', exitQty: '0', entryCost: '33.335', entryFees: '0.005' });
+    expect(computeOpenCostBasis(t, 'long', 'stock', 2)).toBe(33.34);
+  });
+
+  it('honours zero-decimal currencies', () => {
+    const t = totals({ entryQty: '10', entryCost: '1000.4' });
+    expect(computeOpenCostBasis(t, 'long', 'stock', 0)).toBe(1000);
   });
 });

--- a/apps/api/src/features/positions/pnl.ts
+++ b/apps/api/src/features/positions/pnl.ts
@@ -173,6 +173,64 @@ export function computePnlFromTotals(
   };
 }
 
+/**
+ * Capital currently tied up in a position's UNEXITED portion, at cost.
+ *
+ *     sideSign · openQty · avgEntryPrice · multiplier   (capital deployed)
+ *   + entryFees · openQty / entryQty                    (unallocated entry fee)
+ *
+ * This is the "position value" half of the account cash/position split
+ * (ledger-balances). Cost basis only — there is no quote source, so it never
+ * moves with the market.
+ *
+ * **Signed.** A short's entry fills are sells, so its remaining size is proceeds
+ * received against shares still owed — a liability, and therefore negative. That
+ * sign is what makes `cash = balance − Σ positionValue` land on the cash a broker
+ * would actually show: short 10 @ $100 then cover 5 @ $90 gives cash $5,550, not
+ * $4,550.
+ *
+ * **Entry fees are included**, allocated by `openQty / entryQty` — the exact
+ * complement of the `exitQty / entryQty` proration `computePnlFromTotals` applies
+ * to the realized side, so between them every entry fee is accounted for exactly
+ * once. Without this term the derived cash overstates by the unallocated entry
+ * fee for as long as any part of the position stays open: an entry commission
+ * leaves cash immediately, but the ledger only posts it slice by slice as the
+ * position exits. This also makes the figure the correct tax cost basis.
+ *
+ * Returns 0 for an entry-less position and for a fully-exited one; a
+ * fully-exited position has `openQty = 0`, which zeroes both terms.
+ *
+ * MIRRORED IN SQL by `positionValueLateral` in `accounts.query.ts`, which
+ * aggregates this same rule across an account's open positions. The two are
+ * pinned together by the parity test in `accounts.cash-split.test.ts` — change
+ * one and you must change the other.
+ */
+export function computeOpenCostBasis(
+  totals: FillTotals,
+  side: 'long' | 'short',
+  assetType: 'stock' | 'option',
+  currencyMinorUnits: number,
+): number {
+  const entryQty = new Decimal(totals.entryQty);
+  if (entryQty.isZero()) return 0;
+
+  const openQty = entryQty.minus(totals.exitQty);
+  const avgEntryPrice = new Decimal(totals.entryCost).div(entryQty);
+  const sideMultiplier = side === 'long' ? 1 : -1;
+  const contractMultiplier = assetType === 'option' ? 100 : 1;
+
+  // Rounds ONCE over the whole expression, matching `realizedPnl`'s convention
+  // in `computePnlFromTotals` — rounding the deployed-capital and fee terms
+  // separately and then adding shifts the result by a minor unit.
+  return avgEntryPrice
+    .times(openQty)
+    .times(sideMultiplier)
+    .times(contractMultiplier)
+    .plus(new Decimal(totals.entryFees).times(openQty).div(entryQty))
+    .toDecimalPlaces(currencyMinorUnits, Decimal.ROUND_HALF_UP)
+    .toNumber();
+}
+
 export interface RealizationEvent {
   occurredAt: Date;
   grossPnl: Decimal;

--- a/apps/api/src/features/positions/positions.service.ts
+++ b/apps/api/src/features/positions/positions.service.ts
@@ -21,7 +21,7 @@ import { captureServerEvent } from '@/lib/posthog';
 import { withTransaction } from '@/lib/transaction';
 
 import { insertFill, findFillById, updateFill, deleteFill } from './fills.query';
-import { aggregateFills, computePnlFromTotals } from './pnl';
+import { aggregateFills, computeOpenCostBasis, computePnlFromTotals } from './pnl';
 import type { FillTotals } from './pnl';
 import {
   insertPosition,
@@ -535,6 +535,12 @@ export async function listPositions(
       actualRR,
       openUnits: pnl.totalEntryQuantity - pnl.totalExitQuantity,
       closedUnits: pnl.totalExitQuantity,
+      openCostBasis: computeOpenCostBasis(
+        totals,
+        row.side as 'long' | 'short',
+        row.asset_type as 'stock' | 'option',
+        currencyMinorUnits,
+      ),
     };
   });
 }
@@ -608,6 +614,12 @@ export async function getPositionDetail(db: Database, id: string, userId: string
     actualRR,
     openUnits: pnl.totalEntryQuantity - pnl.totalExitQuantity,
     closedUnits: pnl.totalExitQuantity,
+    openCostBasis: computeOpenCostBasis(
+      totals,
+      position.side as 'long' | 'short',
+      position.assetType as 'stock' | 'option',
+      currencyMinorUnits,
+    ),
   };
 }
 

--- a/apps/docs/src/content/docs/self-hosting/reference/db-schema.mdx
+++ b/apps/docs/src/content/docs/self-hosting/reference/db-schema.mdx
@@ -6,9 +6,9 @@ description: Every table Tradr creates, its columns, and how they reference each
 {/* GENERATED FILE — do not edit.
     Source: apps/api/src/db/migrations/meta/ (latest snapshot) · Generator: apps/docs/scripts/gen-db-schema.mjs */}
 
-Tradr's schema is **32 tables**, created by **24 migrations** that run
+Tradr's schema is **32 tables**, created by **25 migrations** that run
 automatically when the api boots. This page is generated from the Drizzle snapshot
-for the latest migration (`0023_position_last_flat_snapshot`), so it describes the schema the migrations
+for the latest migration (`0024_user_buying_power_basis`), so it describes the schema the migrations
 actually produce.
 
 You do not need any of this to run Tradr. It is here for writing queries against
@@ -34,6 +34,7 @@ a query you write against these tables may need updating on any release.
 | `display_currency` | `varchar(3)` | — |
 | `tax_jurisdiction` | `varchar(8)` | — |
 | `theme` | `varchar(8)` | not null, default `'system'` |
+| `buying_power_basis` | `varchar(7)` | not null, default `'cash'` |
 | `advisor_default_persona_id` | `text` | — |
 | `advisor_trade_data_consent` | `boolean` | not null, default `false` |
 | `writable_account_id` | `uuid` | — |

--- a/apps/docs/src/openapi/tradr-api.json
+++ b/apps/docs/src/openapi/tradr-api.json
@@ -2306,7 +2306,7 @@
     },
     "/api/calculator": {
       "post": {
-        "description": "Authed and stateless — the whole calculation is a pure function of the request body (no DB read, no account id). Supply the trade shape (`entryPrice`, `stopLoss`, `direction`, `mode`) plus **exactly one** risk basis: a direct `dollarRisk`, OR a `balance` + `riskPercent` (the dollar risk is then derived as `balance × riskPercent ÷ 100` at full precision). Supplying both bases, or neither, is a 400. In the percent basis the position size is also capped to what the balance can fund at entry (`floor(balance ÷ (entry × multiplier))`); the three percent-only response fields (`derivedDollarRisk`, `sizingStatus`, `buyingPowerLimited`) are absent from dollar-basis results. Non-sizing outcomes (non-positive balance, derived risk over the ceiling, insufficient risk, balance funds zero units) are valid **200**s with `positionSize: 0` and a `sizingStatus` discriminator — not 400s.\n",
+        "description": "Authed and stateless — the whole calculation is a pure function of the request body (no DB read, no account id). Supply the trade shape (`entryPrice`, `stopLoss`, `direction`, `mode`) plus **exactly one** risk basis: a direct `dollarRisk`, OR a `balance` + `riskPercent` (the dollar risk is then derived as `balance × riskPercent ÷ 100` at full precision). Supplying both bases, or neither, is a 400. The position size is also capped to what the account can fund at entry — `floor(capBasis ÷ (entry × multiplier))` — where `capBasis` is `buyingPower` when supplied (**either** risk basis), else `balance` on the percent basis, else no cap at all on the dollar basis. The risk budget is always a percent of `balance`; only the cap consults `buyingPower`. `derivedDollarRisk` remains percent-only, but `sizingStatus` and `buyingPowerLimited` can now appear on a dollar-basis result whenever `buyingPower` is supplied. Non-sizing outcomes (non-positive balance, derived risk over the ceiling, insufficient risk, cap basis funds zero units) are valid **200**s with `positionSize: 0` and a `sizingStatus` discriminator — not 400s.\n",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2314,7 +2314,11 @@
                 "description": "Provide exactly one risk basis — `dollarRisk`, or `balance` + `riskPercent`.",
                 "properties": {
                   "balance": {
-                    "description": "Percent-basis balance to size against and cap against. Sign-agnostic finite decimal within the account-balance domain (a losing account's balance can be ≤ 0). Percent basis requires both `balance` and `riskPercent`.\n",
+                    "description": "Percent-basis balance the RISK BUDGET is derived from, and the default basis for the buying-power cap. Sign-agnostic finite decimal within the account-balance domain (a losing account's balance can be ≤ 0). Percent basis requires both `balance` and `riskPercent`.\n",
+                    "type": "string"
+                  },
+                  "buyingPower": {
+                    "description": "Optional figure the BUYING-POWER CAP is computed against, valid in EITHER risk basis. Absent ⇒ the percent basis caps against `balance` (the original behaviour) and the dollar basis is uncapped (likewise). Supply an account's `cash` here to stop the calculator sizing a position the account cannot fund: total equity overstates fundable capital by whatever is already deployed, and a direct dollar risk overshoots just as readily as a percentage one. Sign-agnostic — a fully-deployed or margined account can present ≤ 0 cash, which yields `sizingStatus: buying-power-zero`. Never affects the risk budget.\n",
                     "type": "string"
                   },
                   "direction": {
@@ -2348,7 +2352,7 @@
                     "type": "string"
                   },
                   "riskPercent": {
-                    "description": "Percent of balance to risk (0 < p ≤ 100).",
+                    "description": "Percent of `balance` to risk (0 < p ≤ 100). Always a percent of balance, never of `buyingPower`.",
                     "type": "string"
                   },
                   "stopLoss": {
@@ -2374,7 +2378,7 @@
         },
         "responses": {
           "200": {
-            "description": "A CalculatorOutput. Always carries `positionSize`, `perUnitRisk`, `actualDollarRisk`, `totalPositionValue`; `perUnitReward` / `riskRewardRatio` when a target is set, and the fee fields when fees are supplied. Percent basis additionally echoes `derivedDollarRisk` (2dp, when balance > 0), `sizingStatus` (`nothing-to-size-against` | `exceeds-maximum` | `buying-power-zero`) on the zero-position outcomes, and `buyingPowerLimited: true` when the buying-power cap set the size.\n"
+            "description": "A CalculatorOutput. Always carries `positionSize`, `perUnitRisk`, `actualDollarRisk`, `totalPositionValue`; `perUnitReward` / `riskRewardRatio` when a target is set, and the fee fields when fees are supplied. Percent basis additionally echoes `derivedDollarRisk` (2dp, when balance > 0). `sizingStatus` (`nothing-to-size-against` | `exceeds-maximum` | `buying-power-zero`) on the zero-position outcomes and `buyingPowerLimited: true` when the cap set the size appear on EITHER basis — the latter two require only that a cap basis existed, which on the dollar basis means `buyingPower` was supplied.\n"
           },
           "400": {
             "description": "Validation error — both/neither risk basis, riskPercent ∉ (0,100], bad balance/price format, or a structural price error."
@@ -4140,6 +4144,80 @@
         "summary": "Delayed spot last-price for a symbol.",
         "tags": [
           "Symbols"
+        ]
+      }
+    },
+    "/api/users/me/buying-power-basis": {
+      "get": {
+        "description": "Authed. Which account figure the position-sizing calculator caps position size against — `cash` (balance less the cost basis of open positions) or `balance` (total equity). Never null; the column defaults to `cash`.\n",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "basis": {
+                      "enum": [
+                        "cash",
+                        "balance"
+                      ],
+                      "example": "cash",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The stored basis."
+          },
+          "401": {
+            "description": "Authentication required."
+          }
+        },
+        "summary": "Get the calculator's buying-power basis.",
+        "tags": [
+          "Calculator"
+        ]
+      },
+      "put": {
+        "description": "Authed. `cash` caps position size at what the account can actually deploy; `balance` caps at total equity, which overstates fundable capital by whatever is already tied up in open positions. Affects only the cap — the risk budget stays `riskPercent × balance` either way. Changes nothing stored beyond the preference itself.\n",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "basis": {
+                    "enum": [
+                      "cash",
+                      "balance"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "basis"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The stored basis."
+          },
+          "400": {
+            "description": "Not one of cash | balance."
+          },
+          "401": {
+            "description": "Authentication required."
+          }
+        },
+        "summary": "Set the calculator's buying-power basis.",
+        "tags": [
+          "Calculator"
         ]
       }
     },

--- a/apps/web/src/features/accounting/components/AccountBalance.test.tsx
+++ b/apps/web/src/features/accounting/components/AccountBalance.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Account } from '@tradr/shared';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// The reconcile dialog drags in Radix + a mutation hook; this file is about the
+// balance card's own rendering, so stub it out entirely.
+vi.mock('./ReconcileBalanceDialog', () => ({
+  ReconcileBalanceDialog: () => null,
+}));
+
+import { AccountBalance } from './AccountBalance';
+
+function mountWith(ui: React.ReactElement): { container: HTMLElement; root: Root } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+  return { container, root };
+}
+
+function unmount(container: HTMLElement, root: Root): void {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+function makeAccount(over: Partial<Account> = {}): Account {
+  return {
+    id: 'acct-1',
+    userId: 'user-1',
+    name: 'Test Account',
+    currency: 'USD',
+    timezone: 'America/New_York',
+    brokerageId: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    balance: '5050.0000',
+    cash: '4550.0000',
+    positionValue: '500.0000',
+    ...over,
+  } as Account;
+}
+
+const mounted: { container: HTMLElement; root: Root }[] = [];
+function render(account: Account) {
+  const m = mountWith(<AccountBalance account={account} />);
+  mounted.push(m);
+  return m.container;
+}
+
+afterEach(() => {
+  while (mounted.length) {
+    const m = mounted.pop()!;
+    unmount(m.container, m.root);
+  }
+});
+
+describe('AccountBalance — cash / position split', () => {
+  it('renders both halves alongside the balance', () => {
+    const container = render(makeAccount());
+
+    expect(container.querySelector('[data-testid="account-balance"]')?.textContent).toContain(
+      '5,050.00',
+    );
+    expect(container.querySelector('[data-testid="account-cash"]')?.textContent).toContain(
+      '4,550.00',
+    );
+    expect(
+      container.querySelector('[data-testid="account-position-value"]')?.textContent,
+    ).toContain('500.00');
+  });
+
+  it('says the position figure is cost basis, so it does not read as a market value', () => {
+    const container = render(makeAccount());
+    expect(container.textContent).toContain('cost basis');
+    expect(container.textContent).toContain('not market value');
+  });
+
+  it('shows a negative position value for a shorting account', () => {
+    // Short 10 @ $100, covered 5 @ $90: cash sits ABOVE the balance because the
+    // proceeds are in hand while the shares are still owed.
+    const container = render(
+      makeAccount({ balance: '5050.0000', cash: '5550.0000', positionValue: '-500.0000' }),
+    );
+
+    const positionValue =
+      container.querySelector('[data-testid="account-position-value"]')?.textContent ?? '';
+    expect(positionValue).toContain('500.00');
+    expect(positionValue).toMatch(/[-−(]/);
+    expect(container.querySelector('[data-testid="account-cash"]')?.textContent).toContain(
+      '5,550.00',
+    );
+  });
+
+  it('omits the split entirely when the API did not supply it', () => {
+    // The fields are optional on AccountSchema so older fixtures still parse.
+    const container = render(
+      makeAccount({ cash: undefined, positionValue: undefined } as Partial<Account>),
+    );
+
+    expect(container.querySelector('[data-testid="account-balance"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="account-cash"]')).toBeNull();
+    expect(container.querySelector('[data-testid="account-position-value"]')).toBeNull();
+  });
+
+  it('still renders a zero position value rather than hiding it', () => {
+    // A flat account is all cash — but the split is still meaningful, and
+    // hiding it would make the card flicker between two layouts as positions
+    // open and close.
+    const container = render(
+      makeAccount({ balance: '5000.0000', cash: '5000.0000', positionValue: '0.0000' }),
+    );
+    expect(
+      container.querySelector('[data-testid="account-position-value"]')?.textContent,
+    ).toContain('0.00');
+  });
+});

--- a/apps/web/src/features/accounting/components/AccountBalance.tsx
+++ b/apps/web/src/features/accounting/components/AccountBalance.tsx
@@ -41,6 +41,36 @@ export function AccountBalance({ account }: Props) {
           {account.balance !== undefined ? formatMoney(account.balance, account.currency) : '—'}
         </div>
         <div className="mt-1 text-sm text-muted-foreground">{account.currency}</div>
+        {/*
+          The two halves of the balance (ledger-balances Req 10). Rendered only
+          when both are present — they arrive together from accounts LIST/GET,
+          and the schema keeps them optional for fixtures that predate them.
+
+          `positionValue` is COST BASIS, never mark-to-market: there is no quote
+          source, so it moves only when fills change. The caption says so, or
+          the number reads as a stale market value. It is negative for shorts,
+          where the unexited size is proceeds received against shares still owed
+          — which is why a shorting account can show cash above its balance.
+        */}
+        {account.cash !== undefined && account.positionValue !== undefined && (
+          <div className="mt-4 space-y-1 border-t pt-3">
+            <div className="flex items-baseline justify-between">
+              <span className="text-sm text-muted-foreground">Cash</span>
+              <span className="text-sm font-medium" data-testid="account-cash">
+                {formatMoney(account.cash, account.currency)}
+              </span>
+            </div>
+            <div className="flex items-baseline justify-between">
+              <span className="text-sm text-muted-foreground">Positions</span>
+              <span className="text-sm font-medium" data-testid="account-position-value">
+                {formatMoney(account.positionValue, account.currency)}
+              </span>
+            </div>
+            <p className="pt-1 text-xs text-muted-foreground">
+              Open positions at cost basis — not market value.
+            </p>
+          </div>
+        )}
       </CardContent>
       <ReconcileBalanceDialog
         account={account}

--- a/apps/web/src/features/calculator/components/BuyingPowerBasisSelect.test.tsx
+++ b/apps/web/src/features/calculator/components/BuyingPowerBasisSelect.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  query: { current: { data: { basis: 'cash' }, isLoading: false } as Record<string, unknown> },
+  mutate: vi.fn(),
+}));
+
+vi.mock('@/features/calculator/hooks/useBuyingPowerBasis', () => ({
+  useBuyingPowerBasisQuery: () => state.query.current,
+  useBuyingPowerBasisMutation: () => ({ mutate: state.mutate, isPending: false }),
+}));
+
+// Native <select> stand-in for the shadcn primitive — Radix's pointer-capture
+// machinery is browser-only (same approach as CalculatorForm.test.tsx).
+vi.mock('@/components/ui/select', () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value?: string;
+    onValueChange?: (v: string) => void;
+    children: React.ReactNode;
+  }) => (
+    <select
+      data-testid="basis-select"
+      value={value ?? ''}
+      onChange={(e) => onValueChange?.(e.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
+import { BuyingPowerBasisSelect } from './BuyingPowerBasisSelect';
+
+beforeEach(() => {
+  state.query.current = { data: { basis: 'cash' }, isLoading: false };
+  state.mutate.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('BuyingPowerBasisSelect', () => {
+  it('reflects the stored basis', () => {
+    render(<BuyingPowerBasisSelect />);
+    expect(screen.getByTestId<HTMLSelectElement>('basis-select').value).toBe('cash');
+  });
+
+  it('saves a change', () => {
+    render(<BuyingPowerBasisSelect />);
+    fireEvent.change(screen.getByTestId('basis-select'), { target: { value: 'balance' } });
+    expect(state.mutate).toHaveBeenCalledWith('balance');
+  });
+
+  it('states that the risk percentage is unaffected', () => {
+    // The single most likely misreading of this setting is that it changes how
+    // much you risk. It does not — it changes only the size ceiling.
+    render(<BuyingPowerBasisSelect />);
+    expect(document.body.textContent).toMatch(/percentage of the account balance/i);
+  });
+
+  it('warns about the overshoot when the balance basis is selected', () => {
+    state.query.current = { data: { basis: 'balance' }, isLoading: false };
+    render(<BuyingPowerBasisSelect />);
+    expect(document.body.textContent).toMatch(/larger than your available cash/i);
+  });
+
+  it('explains the protection when cash is selected', () => {
+    render(<BuyingPowerBasisSelect />);
+    expect(document.body.textContent).toMatch(/will not suggest a position you cannot fund/i);
+  });
+
+  it('renders a skeleton instead of a wrong value while loading', () => {
+    state.query.current = { data: undefined, isLoading: true };
+    render(<BuyingPowerBasisSelect />);
+    expect(screen.queryByTestId('basis-select')).toBeNull();
+  });
+});

--- a/apps/web/src/features/calculator/components/BuyingPowerBasisSelect.tsx
+++ b/apps/web/src/features/calculator/components/BuyingPowerBasisSelect.tsx
@@ -1,0 +1,71 @@
+import type { BuyingPowerBasis } from '@tradr/shared';
+
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  useBuyingPowerBasisMutation,
+  useBuyingPowerBasisQuery,
+} from '@/features/calculator/hooks/useBuyingPowerBasis';
+
+/**
+ * Which account figure the position-sizing calculator caps position size against.
+ *
+ * Mounted on the settings Profile tab beside `DisplayCurrencySelect`, following
+ * the same query/mutation shape.
+ *
+ * The copy has to carry the asymmetry, because the two options are not equally
+ * safe. Capping against total equity double-counts capital already deployed and
+ * will size a position the account cannot fund — the user finds out at the
+ * broker. Capping against cash is at worst conservative. Hence the default, and
+ * hence naming the consequence rather than describing the mechanism.
+ */
+export function BuyingPowerBasisSelect() {
+  const { data, isLoading } = useBuyingPowerBasisQuery();
+  const mutation = useBuyingPowerBasisMutation();
+
+  const selected = data?.basis;
+
+  return (
+    <div className="space-y-4 rounded-md border p-4">
+      <div>
+        <h2 className="text-lg font-semibold">Position sizing</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Which figure the calculator caps position size against. Your risk percentage is always a
+          percentage of the account balance — this changes only the size ceiling.
+        </p>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="buyingPowerBasis">Cap sizing by</Label>
+        {isLoading ? (
+          <Skeleton className="h-9 w-64" />
+        ) : (
+          <Select
+            value={selected}
+            onValueChange={(val) => mutation.mutate(val as BuyingPowerBasis)}
+            disabled={mutation.isPending}
+          >
+            <SelectTrigger id="buyingPowerBasis" className="w-64 cursor-pointer">
+              <SelectValue placeholder="Select a basis" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="cash">Cash — what you can deploy</SelectItem>
+              <SelectItem value="balance">Balance — total equity</SelectItem>
+            </SelectContent>
+          </Select>
+        )}
+        <p className="text-sm text-muted-foreground">
+          {selected === 'balance'
+            ? 'Sizing against total equity can suggest a position larger than your available cash when you already hold open positions.'
+            : 'Cash is your balance less the cost basis of open positions, so the calculator will not suggest a position you cannot fund.'}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/calculator/components/CalculatorForm.test.tsx
+++ b/apps/web/src/features/calculator/components/CalculatorForm.test.tsx
@@ -732,3 +732,131 @@ describe('CalculatorForm — buying-power cap basis', () => {
     expect(screen.queryByTestId('cap-basis-note')).toBeNull();
   });
 });
+
+// -----------------------------------------------------------------------------
+// Account picker on the dollar basis
+//
+// Same DEPLOYED_ACCOUNT: $5,000 equity, $1,000 cash. Entry $50 / stop $48 with a
+// $1,000 dollar risk gives a 500-share budget ($25,000) — a direct dollar risk
+// overshoots exactly as readily as a percentage one.
+// -----------------------------------------------------------------------------
+
+describe('CalculatorForm — dollar basis account sourcing', () => {
+  it('offers the account picker on the dollar basis', async () => {
+    const user = userEvent.setup();
+    setAccounts({ data: [DEPLOYED_ACCOUNT] });
+    await mount();
+    await switchBasis(user, 'Dollar');
+
+    expect(selectByOptionValue(DEPLOYED_ACCOUNT.id)).toBeTruthy();
+  });
+
+  it('caps a dollar-basis size at the account cash', async () => {
+    const user = userEvent.setup();
+    setAccounts({ data: [DEPLOYED_ACCOUNT] });
+    await mount();
+    await switchBasis(user, 'Dollar');
+
+    fill('Entry price', '50');
+    fill('Stop loss', '48');
+    fill('Dollar risk', '1000');
+    fireEvent.change(selectByOptionValue(DEPLOYED_ACCOUNT.id), {
+      target: { value: DEPLOYED_ACCOUNT.id },
+    });
+    fireEvent.blur(input('Dollar risk'));
+
+    // floor($1,000 cash / $50) = 20, not the 500 the risk alone allows.
+    expect(await screen.findByText('20', undefined, { timeout: 2000 })).toBeTruthy();
+    expect(screen.getByText(/limited by account buying power/i)).toBeTruthy();
+  });
+
+  it('stays uncapped on the dollar basis with no account selected', async () => {
+    const user = userEvent.setup();
+    setAccounts({ data: [DEPLOYED_ACCOUNT] });
+    await mount();
+    await results(user, 'Dollar', {
+      'Entry price': '50',
+      'Stop loss': '48',
+      'Dollar risk': '1000',
+    });
+
+    expect(await screen.findByText('500', undefined, { timeout: 2000 })).toBeTruthy();
+    expect(screen.queryByText(/limited by account buying power/i)).toBeNull();
+  });
+
+  it('does NOT put a balance on the form in dollar mode', async () => {
+    // A balance here would be a second risk basis. The schema's "exactly one
+    // basis" refine would then reject the input the moment a risk percent
+    // appeared, so the account must contribute only the cap and the currency.
+    const user = userEvent.setup();
+    setAccounts({ data: [DEPLOYED_ACCOUNT] });
+    await mount();
+    await switchBasis(user, 'Dollar');
+
+    fireEvent.change(selectByOptionValue(DEPLOYED_ACCOUNT.id), {
+      target: { value: DEPLOYED_ACCOUNT.id },
+    });
+    expect(screen.queryByLabelText('Balance')).toBeNull();
+
+    // And the dollar basis still computes — proof the refine is satisfied.
+    fill('Entry price', '50');
+    fill('Stop loss', '48');
+    fill('Dollar risk', '1000');
+    fireEvent.blur(input('Dollar risk'));
+    expect(await screen.findByText('20', undefined, { timeout: 2000 })).toBeTruthy();
+  });
+
+  it('keeps the account across a basis switch and re-seeds the balance', async () => {
+    // Dropping the account on switch would silently remove the cap from someone
+    // who only changed how they express risk.
+    const user = userEvent.setup();
+    setAccounts({ data: [DEPLOYED_ACCOUNT] });
+    await mount();
+    await switchBasis(user, 'Dollar');
+
+    fireEvent.change(selectByOptionValue(DEPLOYED_ACCOUNT.id), {
+      target: { value: DEPLOYED_ACCOUNT.id },
+    });
+    await switchBasis(user, 'Percent');
+
+    // Still selected, and the Balance field is populated rather than left blank
+    // next to a visibly-chosen account.
+    expect(selectByOptionValue(DEPLOYED_ACCOUNT.id).value).toBe(DEPLOYED_ACCOUNT.id);
+    expect(input('Balance').value).toBe('5000');
+  });
+
+  it('follows the account currency on the dollar basis', async () => {
+    const user = userEvent.setup();
+    setAccounts({ data: [{ ...CAD_ACCOUNT, cash: '50000' }] });
+    await mount();
+    await switchBasis(user, 'Dollar');
+
+    fill('Entry price', '50');
+    fill('Stop loss', '48');
+    fill('Dollar risk', '1000');
+    fireEvent.change(selectByOptionValue(CAD_ACCOUNT.id), { target: { value: CAD_ACCOUNT.id } });
+    fireEvent.blur(input('Dollar risk'));
+
+    // Actual dollar risk 2 × 500 = 1000, rendered in CAD — showing a CAD
+    // account's figures in USD would misstate them.
+    await screen.findByText('Position Sizing', undefined, { timeout: 2000 });
+    expect(screen.getAllByText(fmtMoney(1000, 'CAD')).length).toBeGreaterThan(0);
+  });
+
+  it('words the cap note for the dollar basis', async () => {
+    const user = userEvent.setup();
+    setAccounts({ data: [DEPLOYED_ACCOUNT] });
+    await mount();
+    await switchBasis(user, 'Dollar');
+
+    fireEvent.change(selectByOptionValue(DEPLOYED_ACCOUNT.id), {
+      target: { value: DEPLOYED_ACCOUNT.id },
+    });
+
+    const note = screen.getByTestId('cap-basis-note');
+    expect(note.textContent).toContain(fmtMoney(1000));
+    // Not the percent-basis reassurance — there is no risk percentage here.
+    expect(note.textContent).toMatch(/dollar risk is unchanged/i);
+    expect(note.textContent).not.toMatch(/percent of the balance/i);
+  });
+});

--- a/apps/web/src/features/calculator/components/CalculatorForm.test.tsx
+++ b/apps/web/src/features/calculator/components/CalculatorForm.test.tsx
@@ -23,6 +23,10 @@ const state = vi.hoisted(() => ({
   brokerages: {
     current: { data: [], isLoading: false, isError: false } as Record<string, unknown>,
   },
+  // Which account figure the buying-power cap sizes against. Mocked rather than
+  // left to fall through, so the two bases are both reachable and neither test
+  // depends on an unresolved query defaulting.
+  buyingPowerBasis: { current: { data: { basis: 'cash' } } as Record<string, unknown> },
 }));
 
 vi.mock('@/features/accounts/hooks/useAccounts', () => ({
@@ -30,6 +34,9 @@ vi.mock('@/features/accounts/hooks/useAccounts', () => ({
 }));
 vi.mock('@/features/brokerages/hooks/useBrokerages', () => ({
   useBrokerages: () => state.brokerages.current,
+}));
+vi.mock('@/features/calculator/hooks/useBuyingPowerBasis', () => ({
+  useBuyingPowerBasisQuery: () => state.buyingPowerBasis.current,
 }));
 
 // Stub the shadcn Select primitive as a native <select> so options are clickable
@@ -254,6 +261,7 @@ async function fillPercentBasis(
 beforeEach(() => {
   setAccounts({ data: [] });
   state.brokerages.current = { data: [], isLoading: false, isError: false };
+  state.buyingPowerBasis.current = { data: { basis: 'cash' } };
 });
 
 afterEach(() => {
@@ -623,5 +631,104 @@ describe('CalculatorForm — option contract hand-off (REQ-6.3/6.5)', () => {
 
     expect(screen.getByText('no-occ-row')).toBeTruthy();
     expect(screen.queryByRole('button', { name: /Use/ })).toBeNull();
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Buying-power cap basis (calculator-balance-sizing)
+//
+// The account below is the shape the whole feature exists for: $5,000 of equity
+// with $4,000 already deployed, so only $1,000 is actually fundable. Entry $50 /
+// stop $48 at 1% risk gives a 25-share budget ($1,250) that the balance would
+// happily fund and the cash would not.
+// -----------------------------------------------------------------------------
+
+const DEPLOYED_ACCOUNT = {
+  id: 'acc-deployed',
+  name: 'Mostly Deployed',
+  currency: 'USD',
+  balance: '5000',
+  cash: '1000',
+  positionValue: '4000',
+};
+
+async function sizeAgainst(user: User, account: Record<string, unknown>): Promise<void> {
+  setAccounts({ data: [account] });
+  await mount();
+  await switchBasis(user, 'Percent');
+  fill('Entry price', '50');
+  fill('Stop loss', '48');
+  fill('Risk percent', '1');
+  fireEvent.change(selectByOptionValue(account.id as string), {
+    target: { value: account.id as string },
+  });
+  fireEvent.blur(input('Risk percent'));
+}
+
+describe('CalculatorForm — buying-power cap basis', () => {
+  it('caps at the account cash under the default basis', async () => {
+    const user = userEvent.setup();
+    await sizeAgainst(user, DEPLOYED_ACCOUNT);
+
+    await screen.findByText('Derived Dollar Risk', undefined, { timeout: 2000 });
+    // 20 shares = floor($1,000 cash / $50), not the 25 the budget alone allows.
+    expect(screen.getByText('20')).toBeTruthy();
+    expect(screen.getByText(/limited by account buying power/i)).toBeTruthy();
+    // The risk budget is untouched — still 1% of the BALANCE, not of cash.
+    expect(screen.getAllByText(fmtMoney(50)).length).toBeGreaterThan(0);
+  });
+
+  it('caps at the balance under the balance basis, funding more than the cash', async () => {
+    const user = userEvent.setup();
+    state.buyingPowerBasis.current = { data: { basis: 'balance' } };
+    await sizeAgainst(user, DEPLOYED_ACCOUNT);
+
+    await screen.findByText('Derived Dollar Risk', undefined, { timeout: 2000 });
+    // The full 25-share budget: $1,250 of stock against $1,000 of cash.
+    expect(screen.getByText('25')).toBeTruthy();
+    expect(screen.queryByText(/limited by account buying power/i)).toBeNull();
+  });
+
+  it('explains the cap on the form so it is not an unexplained smaller number', async () => {
+    const user = userEvent.setup();
+    await sizeAgainst(user, DEPLOYED_ACCOUNT);
+
+    const note = screen.getByTestId('cap-basis-note');
+    expect(note.textContent).toContain(fmtMoney(1000));
+    expect(note.textContent).toMatch(/percent of the balance/i);
+  });
+
+  it('shows no cap note under the balance basis', async () => {
+    const user = userEvent.setup();
+    state.buyingPowerBasis.current = { data: { basis: 'balance' } };
+    await sizeAgainst(user, DEPLOYED_ACCOUNT);
+
+    expect(screen.queryByTestId('cap-basis-note')).toBeNull();
+  });
+
+  it('falls back to the balance for an account with no cash figure', async () => {
+    // `cash` is optional on AccountSchema for fixtures predating the split.
+    const user = userEvent.setup();
+    await sizeAgainst(user, { ...DEPLOYED_ACCOUNT, cash: undefined });
+
+    await screen.findByText('Derived Dollar Risk', undefined, { timeout: 2000 });
+    expect(screen.getByText('25')).toBeTruthy();
+    expect(screen.queryByTestId('cap-basis-note')).toBeNull();
+  });
+
+  it('caps against the typed figure alone when the balance is hand-entered', async () => {
+    // No account selected ⇒ no cash figure exists ⇒ the cap is the balance.
+    const user = userEvent.setup();
+    await mount();
+    await fillPercentBasis(user, {
+      entry: '50',
+      stop: '48',
+      balance: '5000',
+      riskPercent: '1',
+    });
+
+    await screen.findByText('Derived Dollar Risk', undefined, { timeout: 2000 });
+    expect(screen.getByText('25')).toBeTruthy();
+    expect(screen.queryByTestId('cap-basis-note')).toBeNull();
   });
 });

--- a/apps/web/src/features/calculator/components/CalculatorForm.tsx
+++ b/apps/web/src/features/calculator/components/CalculatorForm.tsx
@@ -140,10 +140,22 @@ export function CalculatorForm() {
   // cash/position split).
   //
   // Only the cap. The risk budget stays `riskPercent × balance` either way.
-  const buyingPower =
-    riskBasis === 'percent' && capBasis === 'cash'
-      ? (selectedAccount?.cash ?? undefined)
-      : undefined;
+  //
+  // Supplied in BOTH risk bases. A direct dollar risk overshoots exactly as
+  // readily as a percentage one — $1,000 of risk at a $2 stop is $25,000 of
+  // stock however it was expressed — so the cap belongs wherever an account is
+  // selected, not only where a balance happens to exist.
+  //
+  // Under the 'balance' preference this passes the account's balance rather than
+  // undefined. In the percent basis that is the same figure the fallback would
+  // have used, so nothing changes; in the dollar basis there is no fallback to
+  // inherit, and passing it is what makes the preference mean the same thing in
+  // both modes instead of silently doing nothing in one of them.
+  const buyingPower = selectedAccount
+    ? capBasis === 'cash'
+      ? (selectedAccount.cash ?? undefined)
+      : (selectedAccount.balance ?? undefined)
+    : undefined;
 
   let result: CalculatorOutput | null = null;
   let error: string | null = null;
@@ -155,8 +167,10 @@ export function CalculatorForm() {
     }
   }
 
-  // Percent + account-sourced balance ⇒ the account's currency; else USD (D9).
-  const currency = riskBasis === 'percent' && selectedAccount ? selectedAccount.currency : 'USD';
+  // An account-sourced figure ⇒ the account's currency; else USD (D9). No longer
+  // gated on the percent basis: the dollar basis can now source an account too,
+  // and showing a CAD account's cap in dollars would misstate it.
+  const currency = selectedAccount ? selectedAccount.currency : 'USD';
 
   const brokerageHint =
     feeMode === 'brokerage' && !values.feeSchedule
@@ -236,14 +250,24 @@ export function CalculatorForm() {
     setValue('feeSchedule', parsed, { shouldValidate: true });
   };
 
+  // The selected account SURVIVES a basis switch — it is meaningful in both now,
+  // and dropping it would silently remove the cap from a user who only changed
+  // how they express risk. Only the basis-scoped FIELDS are cleared, which the
+  // "exactly one risk basis" refine requires.
   const handleRiskBasisChange = (next: string) => {
     const nextBasis = next as RiskBasis;
     if (nextBasis === 'percent') {
       setValue('dollarRisk', undefined, { shouldValidate: true });
+      // Re-seed the balance the account carries. Without this, switching to
+      // percent with an account already chosen shows a selected account and an
+      // empty Balance — an incomplete form the user has to fix by re-picking
+      // the account they can already see is picked.
+      if (selectedAccount) {
+        setValue('balance', selectedAccount.balance ?? undefined, { shouldValidate: true });
+      }
     } else {
       setValue('balance', undefined, { shouldValidate: true });
       setValue('riskPercent', undefined, { shouldValidate: true });
-      setSelectedAccount(null);
     }
     setRiskBasis(nextBasis);
   };
@@ -251,10 +275,85 @@ export function CalculatorForm() {
   const handleAccountSelect = (accountId: string) => {
     const account = accounts.find((a) => a.id === accountId);
     if (!account) return;
-    // Absent balance ⇒ not-yet-supplied → neutral incomplete state (D8, REQ-3.5).
-    setValue('balance', account.balance ?? undefined, { shouldValidate: true });
+    // The balance is a PERCENT-BASIS field. Setting it in dollar mode would put
+    // a second risk basis on the form, and `CalculatorInputSchema`'s
+    // "exactly one basis" refine would start rejecting the input the moment a
+    // risk percent was also present. In dollar mode the account contributes only
+    // the cap figure and the display currency.
+    if (riskBasis === 'percent') {
+      // Absent balance ⇒ not-yet-supplied → neutral incomplete state (D8, REQ-3.5).
+      setValue('balance', account.balance ?? undefined, { shouldValidate: true });
+    }
     setSelectedAccount(account);
   };
+
+  // Rendered in BOTH risk bases. In the percent basis it also supplies the
+  // balance to size against; in the dollar basis it supplies only the cap figure
+  // and the display currency, because a dollar risk is typed directly and a
+  // `balance` set here would be a second, contradictory risk basis.
+  const accountPicker = (
+    <div className="space-y-2 pt-2">
+      <Label>Account</Label>
+      {accountsQuery.isLoading ? (
+        <Select disabled>
+          <SelectTrigger className="w-full cursor-pointer">
+            <SelectValue placeholder="Loading accounts…" />
+          </SelectTrigger>
+          <SelectContent />
+        </Select>
+      ) : accountsQuery.isError ? (
+        <>
+          <Select disabled>
+            <SelectTrigger className="w-full cursor-pointer">
+              <SelectValue placeholder="Failed to load accounts" />
+            </SelectTrigger>
+            <SelectContent />
+          </Select>
+          <p className="mt-1 text-sm text-destructive">Failed to load accounts</p>
+        </>
+      ) : accounts.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No accounts configured —{' '}
+          <Link to="/accounts" className="underline hover:text-foreground">
+            set one up
+          </Link>
+        </p>
+      ) : (
+        <Select value={selectedAccount?.id ?? ''} onValueChange={handleAccountSelect}>
+          <SelectTrigger className="w-full cursor-pointer">
+            <SelectValue placeholder="Select an account" />
+          </SelectTrigger>
+          <SelectContent>
+            {accounts.map((a) => (
+              <SelectItem key={a.id} value={a.id}>
+                {a.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+      {/*
+        The cap is otherwise invisible: two accounts with the same balance size
+        differently depending on how much is deployed, and without this the
+        smaller number has no visible cause. Shown only when a CASH figure is
+        actually doing the capping — under the 'balance' preference, and for a
+        hand-typed balance, the cap is the figure already on screen.
+
+        The second clause differs by basis because the reassurance differs: in
+        percent mode the worry is that the risk percentage changed too (it did
+        not), and in dollar mode it is that the typed dollar risk changed (it
+        did not).
+      */}
+      {capBasis === 'cash' && selectedAccount?.cash !== undefined && (
+        <p className="text-xs text-muted-foreground" data-testid="cap-basis-note">
+          Sizing capped by {formatMoney(selectedAccount.cash, selectedAccount.currency)} cash —{' '}
+          {riskBasis === 'percent'
+            ? 'risk stays a percent of the balance.'
+            : 'your dollar risk is unchanged.'}
+        </p>
+      )}
+    </div>
+  );
 
   return (
     <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
@@ -443,19 +542,6 @@ export function CalculatorForm() {
                 {errors.balance && (
                   <p className="text-sm text-destructive">{errors.balance.message}</p>
                 )}
-                {/*
-                  The cap basis is otherwise invisible: two accounts with the same
-                  balance size differently depending on how much is deployed, and
-                  without this the user has no way to see why. Shown only when a
-                  cash figure is actually in play — a hand-typed balance caps
-                  against itself and needs no note.
-                */}
-                {buyingPower !== undefined && selectedAccount && (
-                  <p className="text-xs text-muted-foreground" data-testid="cap-basis-note">
-                    Sizing capped by {formatMoney(buyingPower, selectedAccount.currency)} cash —
-                    risk stays a percent of the balance.
-                  </p>
-                )}
               </div>
 
               <div className="space-y-2">
@@ -473,50 +559,10 @@ export function CalculatorForm() {
                   <p className="text-sm text-destructive">{errors.riskPercent.message}</p>
                 )}
               </div>
-
-              <div className="space-y-2">
-                <Label>Account</Label>
-                {accountsQuery.isLoading ? (
-                  <Select disabled>
-                    <SelectTrigger className="w-full cursor-pointer">
-                      <SelectValue placeholder="Loading accounts…" />
-                    </SelectTrigger>
-                    <SelectContent />
-                  </Select>
-                ) : accountsQuery.isError ? (
-                  <>
-                    <Select disabled>
-                      <SelectTrigger className="w-full cursor-pointer">
-                        <SelectValue placeholder="Failed to load accounts" />
-                      </SelectTrigger>
-                      <SelectContent />
-                    </Select>
-                    <p className="mt-1 text-sm text-destructive">Failed to load accounts</p>
-                  </>
-                ) : accounts.length === 0 ? (
-                  <p className="text-sm text-muted-foreground">
-                    No accounts configured —{' '}
-                    <Link to="/accounts" className="underline hover:text-foreground">
-                      set one up
-                    </Link>
-                  </p>
-                ) : (
-                  <Select value={selectedAccount?.id ?? ''} onValueChange={handleAccountSelect}>
-                    <SelectTrigger className="w-full cursor-pointer">
-                      <SelectValue placeholder="Select an account" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {accounts.map((a) => (
-                        <SelectItem key={a.id} value={a.id}>
-                          {a.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-              </div>
             </div>
           )}
+
+          {accountPicker}
         </div>
 
         <div className="space-y-2">

--- a/apps/web/src/features/calculator/components/CalculatorForm.tsx
+++ b/apps/web/src/features/calculator/components/CalculatorForm.tsx
@@ -34,10 +34,12 @@ import {
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useAccounts } from '@/features/accounts/hooks/useAccounts';
 import { useBrokerages } from '@/features/brokerages/hooks/useBrokerages';
+import { useBuyingPowerBasisQuery } from '@/features/calculator/hooks/useBuyingPowerBasis';
 import { OptionsChainViewer } from '@/features/options/components/OptionsChainViewer';
 import type { OptionContract } from '@/features/options/hooks/useOptionsChain';
 import { useStockQuote } from '@/hooks/useStockQuote';
 import { useStockQuoteConfig } from '@/hooks/useStockQuoteConfig';
+import { formatMoney } from '@/lib/format';
 
 import { CalculatorResults } from './CalculatorResults';
 
@@ -108,6 +110,12 @@ export function CalculatorForm() {
   const accountsQuery = useAccounts();
   const accounts = accountsQuery.data ?? [];
 
+  // Which account figure the buying-power cap sizes against. Defaults to 'cash'
+  // while the preference is in flight so a slow settings fetch cannot silently
+  // hand back the looser cap — the conservative value is the safe one to guess.
+  const buyingPowerBasisQuery = useBuyingPowerBasisQuery();
+  const capBasis = buyingPowerBasisQuery.data?.basis ?? 'cash';
+
   const values = watch();
   const direction = values.direction;
   const mode = values.mode;
@@ -120,11 +128,28 @@ export function CalculatorForm() {
       ? values.balance !== undefined && values.riskPercent !== undefined
       : values.dollarRisk !== undefined;
 
+  // The figure the buying-power CAP sizes against, derived rather than written
+  // into the form. Deriving it means a preference that resolves after the user
+  // has already picked an account still applies, and it cannot go stale against
+  // `selectedAccount` — a `setValue` at account-select time would do neither.
+  //
+  // Undefined ⇒ `calculateTrade` caps against `balance`, which is the right
+  // fallback for all three ways there is no cash figure to use: the 'balance'
+  // preference, a hand-typed balance with no account selected, and an account
+  // whose `cash` is absent (the field is optional for fixtures predating the
+  // cash/position split).
+  //
+  // Only the cap. The risk budget stays `riskPercent × balance` either way.
+  const buyingPower =
+    riskBasis === 'percent' && capBasis === 'cash'
+      ? (selectedAccount?.cash ?? undefined)
+      : undefined;
+
   let result: CalculatorOutput | null = null;
   let error: string | null = null;
   if (isValid && basisComplete) {
     try {
-      result = calculateTrade(values);
+      result = calculateTrade({ ...values, buyingPower });
     } catch (e) {
       error = e instanceof Error ? e.message : 'Calculation error';
     }
@@ -417,6 +442,19 @@ export function CalculatorForm() {
                 />
                 {errors.balance && (
                   <p className="text-sm text-destructive">{errors.balance.message}</p>
+                )}
+                {/*
+                  The cap basis is otherwise invisible: two accounts with the same
+                  balance size differently depending on how much is deployed, and
+                  without this the user has no way to see why. Shown only when a
+                  cash figure is actually in play — a hand-typed balance caps
+                  against itself and needs no note.
+                */}
+                {buyingPower !== undefined && selectedAccount && (
+                  <p className="text-xs text-muted-foreground" data-testid="cap-basis-note">
+                    Sizing capped by {formatMoney(buyingPower, selectedAccount.currency)} cash —
+                    risk stays a percent of the balance.
+                  </p>
                 )}
               </div>
 

--- a/apps/web/src/features/calculator/components/CalculatorResults.tsx
+++ b/apps/web/src/features/calculator/components/CalculatorResults.tsx
@@ -51,7 +51,11 @@ function nonSizingMessage(status: CalculatorOutput['sizingStatus']): string {
     case 'exceeds-maximum':
       return "The derived dollar risk exceeds the calculator's maximum.";
     case 'buying-power-zero':
-      return 'The balance cannot fund one share/contract at this entry price.';
+      // Deliberately says "buying power", not "balance": under the default
+      // preference the cap is the account's CASH, so an account with a healthy
+      // balance but everything already deployed lands here. Blaming the balance
+      // would read as a bug.
+      return 'Available buying power cannot fund one share/contract at this entry price.';
     default:
       return 'Dollar risk is insufficient for one share/contract at this stop distance';
   }

--- a/apps/web/src/features/calculator/hooks/useBuyingPowerBasis.ts
+++ b/apps/web/src/features/calculator/hooks/useBuyingPowerBasis.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import type { BuyingPowerBasis } from '@tradr/shared';
+
+import { api } from '@/lib/api';
+
+function getErrorMessage(err: unknown, fallback: string): string {
+  if (typeof err === 'object' && err !== null && 'error' in err) {
+    const e = err as { error?: { message?: string } };
+    if (e.error?.message) return e.error.message;
+  }
+  return fallback;
+}
+
+interface BuyingPowerBasisResponse {
+  basis: BuyingPowerBasis;
+}
+
+export function useBuyingPowerBasisQuery() {
+  return useQuery<BuyingPowerBasisResponse>({
+    queryKey: ['users', 'me', 'buying-power-basis'],
+    queryFn: () => api.get<BuyingPowerBasisResponse>('/users/me/buying-power-basis'),
+  });
+}
+
+export function useBuyingPowerBasisMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (basis: BuyingPowerBasis) =>
+      api.put<BuyingPowerBasisResponse>('/users/me/buying-power-basis', { basis }),
+    onSuccess: () => {
+      // Only the preference itself. Nothing else is cached off it: the
+      // calculator reads the basis at account-select time and recomputes
+      // locally, and no server-side figure depends on it.
+      queryClient.invalidateQueries({ queryKey: ['users', 'me', 'buying-power-basis'] });
+      toast.success('Buying power basis updated');
+    },
+    onError: (err: unknown) => {
+      toast.error(getErrorMessage(err, 'Failed to update buying power basis'));
+    },
+  });
+}

--- a/apps/web/src/features/dashboard/widgets/AccountBalancesWidget.tsx
+++ b/apps/web/src/features/dashboard/widgets/AccountBalancesWidget.tsx
@@ -7,6 +7,7 @@ import { useDashboardTotalQuery } from '@/features/accounting/hooks/useDashboard
 import { useMissingRatePrompt } from '@/features/accounting/hooks/useMissingRatePrompt';
 import { useAccounts } from '@/features/accounts/hooks/useAccounts';
 import { CrossCurrencyTotal } from '@/features/dashboard/components/CrossCurrencyTotal';
+import { formatMoney } from '@/lib/format';
 
 /**
  * Account Balances widget (Req 6.4).
@@ -58,9 +59,7 @@ function AccountBalancesWidget() {
       <span>
         Missing exchange rate
         {missingPairs.length > 1 ? 's' : ''}:{' '}
-        {missingPairs
-          .map((p) => `${p.baseCurrency} → ${p.quoteCurrency}`)
-          .join(', ')}
+        {missingPairs.map((p) => `${p.baseCurrency} → ${p.quoteCurrency}`).join(', ')}
       </span>
       {deeplinkTo && (
         <a
@@ -90,13 +89,29 @@ function AccountBalancesWidget() {
         {accounts.map((account) => (
           <li key={account.id} className="flex items-center justify-between py-2">
             <span className="font-medium">{account.name}</span>
-            <Numeric
-              value={account.balance != null && account.currency ? account.balance : null}
-              kind="money"
-              currency={account.currency ?? undefined}
-              direction="none"
-              className="text-muted-foreground"
-            />
+            <div className="flex flex-col items-end">
+              <Numeric
+                value={account.balance != null && account.currency ? account.balance : null}
+                kind="money"
+                currency={account.currency ?? undefined}
+                direction="none"
+                className="text-muted-foreground"
+              />
+              {/*
+                Cash / positions split (ledger-balances Req 10) — the two halves
+                of the balance above, shown only when the account actually holds
+                open positions. A flat account's split is all cash, so the second
+                line would just repeat the first.
+              */}
+              {account.cash != null &&
+                account.positionValue != null &&
+                Number(account.positionValue) !== 0 && (
+                  <span className="text-xs text-muted-foreground">
+                    {formatMoney(account.cash, account.currency ?? 'USD')} cash ·{' '}
+                    {formatMoney(account.positionValue, account.currency ?? 'USD')} pos
+                  </span>
+                )}
+            </div>
           </li>
         ))}
       </ul>

--- a/apps/web/src/features/drawer/components/OpenPositionsTab.test.tsx
+++ b/apps/web/src/features/drawer/components/OpenPositionsTab.test.tsx
@@ -150,6 +150,9 @@ describe('OpenPositionsTab', () => {
         totalEntryQuantity: 100,
         totalExitQuantity: 0,
         avgEntryPrice: 150,
+        // Cost basis now arrives from the API rather than being recomputed here
+        // (ledger-balances Req 10) — 100 × $150, no fees.
+        openCostBasis: 100 * 150,
         accountCurrency: 'USD',
         openedAt: '2026-05-25T10:00:00.000Z',
       }),
@@ -161,6 +164,10 @@ describe('OpenPositionsTab', () => {
         totalEntryQuantity: 10,
         totalExitQuantity: 0,
         avgEntryPrice: 4.5,
+        // NEGATIVE: a short's unexited size is proceeds received against
+        // contracts still owed, so it is a liability. The old local helper took
+        // an absolute value and reported +$4,500 here.
+        openCostBasis: -(10 * 4.5 * 100),
         accountCurrency: 'USD',
         openedAt: '2026-05-24T10:00:00.000Z',
       }),
@@ -184,6 +191,8 @@ describe('OpenPositionsTab', () => {
     expect(text).toContain('Short');
     expect(text).toContain('· 10');
     expect(text).toContain(formatCurrency(4.5, 'USD'));
+    // The API reports a short's cost basis as negative; this column shows the
+    // magnitude, because the row already reads "Short · 10".
     expect(text).toContain(formatCurrency(10 * 4.5 * 100, 'USD'));
 
     unmount(container, root);

--- a/apps/web/src/features/drawer/components/OpenPositionsTab.tsx
+++ b/apps/web/src/features/drawer/components/OpenPositionsTab.tsx
@@ -13,19 +13,17 @@ function directionLabel(p: PositionListItem): string {
   return p.side === 'long' ? 'Long' : 'Short';
 }
 
-function costBasis(p: PositionListItem): number {
-  return (
-    Math.abs(p.totalEntryQuantity - p.totalExitQuantity) *
-    Number(p.avgEntryPrice ?? 0) *
-    (p.assetType === 'option' ? 100 : 1)
-  );
-}
-
 /**
  * OpenPositionsTab — Side-drawer tab listing all open positions sorted by
  * `openedAt desc` (null-tolerant: null sorts LAST). Per REQ-4.2 / v4-4 the
  * column shows Cost Basis only — unrealized P&L is deferred until a quote
  * feed lands (see ibkr-integration spec).
+ *
+ * Cost basis comes from the API's `openCostBasis` (ledger-balances Req 10) —
+ * the same per-position figure the account's `positionValue` sums, so the
+ * drawer and the account balance card can never disagree. It replaces a local
+ * `openQty × avgEntryPrice × multiplier` helper that omitted entry fees, so the
+ * figures shown here now include the open portion's share of entry commissions.
  *
  * Row click closes the drawer on mobile (REQ-4.6) so the linked detail page
  * is visible without the drawer overlay.
@@ -74,7 +72,7 @@ export function OpenPositionsTab() {
   return (
     <div>
       <p className="text-muted-foreground text-xs px-4 py-2">
-        Cost Basis only — live P&amp;L coming in a future release.
+        Cost Basis only, fees included — live P&amp;L coming in a future release.
       </p>
       {rows.map((p) => (
         <Link
@@ -100,8 +98,20 @@ export function OpenPositionsTab() {
               direction="none"
               className="text-xs text-muted-foreground"
             />
+            {/*
+              MAGNITUDE, deliberately. `openCostBasis` is signed — negative for
+              shorts — but this column is a per-row size and the row already
+              labels the direction ("Short · 10") two lines to the left. The sign
+              is load-bearing in the ACCOUNT aggregate, where cash + positions
+              must equal the balance; here it would only duplicate the label.
+
+              Not left to `direction="none"` to hide: that renders a negative
+              with no sign at all, which would make this row silently
+              indistinguishable from a long's. Taking the absolute value says so
+              out loud.
+            */}
             <Numeric
-              value={costBasis(p)}
+              value={Math.abs(p.openCostBasis)}
               kind="money"
               currency={p.accountCurrency}
               direction="none"

--- a/apps/web/src/features/positions/__fixtures__/position-fixtures.ts
+++ b/apps/web/src/features/positions/__fixtures__/position-fixtures.ts
@@ -37,6 +37,8 @@ export const makePosition = (overrides: Partial<PositionListItem> = {}): Positio
   actualRR: null,
   openUnits: 100,
   closedUnits: 0,
+  // 100 open units at the default $150 avg entry, no fees.
+  openCostBasis: 15000,
   openedAt: '2026-05-01T12:00:00.000Z',
   closedAt: null,
   createdAt: '2026-05-01T12:00:00.000Z',

--- a/apps/web/src/features/positions/components/PositionEditDialog.test.tsx
+++ b/apps/web/src/features/positions/components/PositionEditDialog.test.tsx
@@ -61,6 +61,7 @@ function makePosition(overrides: Partial<PositionDetail> = {}): PositionDetail {
     actualRR: null,
     openUnits: 0,
     closedUnits: 0,
+    openCostBasis: 0,
     ...overrides,
   };
 }

--- a/apps/web/src/routes/_auth.settings.profile.tsx
+++ b/apps/web/src/routes/_auth.settings.profile.tsx
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { DisplayCurrencySelect } from '@/features/accounting/components/DisplayCurrencySelect';
 import { ExchangeRatesPage } from '@/features/accounting/components/ExchangeRatesPage';
+import { BuyingPowerBasisSelect } from '@/features/calculator/components/BuyingPowerBasisSelect';
 
 // FX/display-currency settings live under the Profile tab (design §Component 8).
 const ProfileSearchSchema = z.object({
@@ -15,6 +16,7 @@ function SettingsProfile() {
   return (
     <div className="space-y-8">
       <DisplayCurrencySelect />
+      <BuyingPowerBasisSelect />
       <ExchangeRatesPage initialBase={base} initialQuote={quote} />
     </div>
   );

--- a/e2e/tests/fixtures/performance-fixtures.ts
+++ b/e2e/tests/fixtures/performance-fixtures.ts
@@ -226,6 +226,17 @@ export async function mockAppShell(page: Page): Promise<void> {
   await page.route('**/api/users/me/display-currency', (route) =>
     route.fulfill(json({ currency: 'USD' })),
   );
+  // Mounted by the settings Profile tab and by CalculatorForm (which the
+  // dashboard's position-sizing widget embeds), so it is app-shell surface.
+  //
+  // Leaving it unmocked does NOT merely skip a fetch: the request falls through
+  // to the real API, which does not recognise the mocked session, and the api
+  // client's global 401 handler navigates the whole app to /login. The symptom
+  // is an unrelated assertion failing on a page that silently became the login
+  // (or previous) route.
+  await page.route('**/api/users/me/buying-power-basis', (route) =>
+    route.fulfill(json({ basis: 'cash' })),
+  );
   // Quick Stats tab fetches /performance; the route-under-test mock (registered
   // later by the performance specs) overrides this benign empty default.
   await page.route(/\/api\/performance(\?.*)?$/, (route) =>

--- a/packages/shared/src/calculator.test.ts
+++ b/packages/shared/src/calculator.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { calculateTrade } from './calculator';
 import type { FeeScheduleInput } from './fees';
-import { DOLLAR_RISK_MAX, PRICE_MAX } from './schemas/calculator';
+import { CalculatorInputSchema, DOLLAR_RISK_MAX, PRICE_MAX } from './schemas/calculator';
 import type { CalculatorInput } from './schemas/calculator';
 
 const zeroFeeSchedule: FeeScheduleInput = {
@@ -436,5 +436,126 @@ describe('calculateTrade — percent basis outcomes', () => {
     expect(result.buyingPowerLimited).toBe(true);
     expect(result.actualDollarRisk).toBe('1200.00'); // 2 × 6 × 100
     expect(result.totalPositionValue).toBe('30000.00'); // 50 × 6 × 100
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buyingPower — a separate basis for the CAP only
+// ---------------------------------------------------------------------------
+//
+// `balance` answers two different questions and only one is about equity:
+//   risk budget → balance   "risk 1% of my account" means 1% of equity
+//   cap         → cash      "can I afford this" means liquid funds
+// Using equity for the cap overstates it by whatever is already deployed.
+
+describe('calculateTrade — buyingPower cap basis', () => {
+  it('caps against buyingPower while the risk budget stays on balance', () => {
+    // $5,000 equity with $4,000 deployed ⇒ $1,000 cash. entry 50 / stop 48, risk 1%.
+    //   budget = 1% × 5000 = 50 → floor(50 / 2) = 25 shares
+    //   cap    = floor(1000 / 50) = 20   ← the binding constraint
+    const result = calculateTrade(
+      percentInput({ balance: '5000', riskPercent: '1', buyingPower: '1000' }),
+    );
+    expect(result.positionSize).toBe(20);
+    expect(result.buyingPowerLimited).toBe(true);
+    // The budget is unchanged — it is still a percent of the BALANCE. Sizing
+    // the budget off cash instead would have given floor(10 / 2) = 5 shares.
+    expect(result.derivedDollarRisk).toBe('50.00');
+    expect(result.totalPositionValue).toBe('1000.00');
+  });
+
+  it('reproduces the overshoot it exists to prevent when buyingPower is omitted', () => {
+    // Same account, same trade, no cap basis ⇒ the cap falls back to balance:
+    //   cap = floor(5000 / 50) = 100, so the 25-share budget is unconstrained
+    //   and the position costs $1,250 against $1,000 of actual cash.
+    const result = calculateTrade(percentInput({ balance: '5000', riskPercent: '1' }));
+    expect(result.positionSize).toBe(25);
+    expect(result.buyingPowerLimited).toBeUndefined();
+    expect(result.totalPositionValue).toBe('1250.00');
+  });
+
+  it('stays idle when buyingPower is ample', () => {
+    // cap = floor(50000 / 50) = 1000 ≥ the 25-share budget.
+    const result = calculateTrade(
+      percentInput({ balance: '5000', riskPercent: '1', buyingPower: '50000' }),
+    );
+    expect(result.positionSize).toBe(25);
+    expect(result.buyingPowerLimited).toBeUndefined();
+  });
+
+  it('returns buying-power-zero for a fully-deployed account with a healthy balance', () => {
+    // The case that motivates the whole feature: balance funds 100 shares,
+    // cash funds none. Keyed on cash, this is a zero — not a 2-share position.
+    const result = calculateTrade(
+      percentInput({ balance: '5000', riskPercent: '1', buyingPower: '0' }),
+    );
+    expect(result.positionSize).toBe(0);
+    expect(result.sizingStatus).toBe('buying-power-zero');
+    expect(result.derivedDollarRisk).toBe('50.00');
+  });
+
+  it('returns buying-power-zero for NEGATIVE buying power rather than a negative size', () => {
+    // floor(-500 / 50) = -10. The guard is `cap <= 0`; a `cap === 0` check
+    // would let this through and cap the position at -10 shares.
+    const result = calculateTrade(
+      percentInput({ balance: '5000', riskPercent: '1', buyingPower: '-500' }),
+    );
+    expect(result.positionSize).toBe(0);
+    expect(result.sizingStatus).toBe('buying-power-zero');
+  });
+
+  it('does not let a non-positive buyingPower mask a healthy balance check', () => {
+    // `nothing-to-size-against` is about the BALANCE and is resolved first;
+    // buyingPower never reaches that branch.
+    const result = calculateTrade(
+      percentInput({ balance: '0', riskPercent: '1', buyingPower: '10000' }),
+    );
+    expect(result.sizingStatus).toBe('nothing-to-size-against');
+  });
+
+  it('still prefers insufficient-risk over a zero cap', () => {
+    // budget = 0.50 → floor(0.5 / 2) = 0 shares, decided before the cap runs.
+    const result = calculateTrade(
+      percentInput({ balance: '50', riskPercent: '1', buyingPower: '0' }),
+    );
+    expect(result.positionSize).toBe(0);
+    expect(result.sizingStatus).toBeUndefined();
+  });
+
+  it('applies the options multiplier to the buyingPower cap', () => {
+    // budget = 1% × 100000 = 1000 → floor(1000 / (2 × 100)) = 5 contracts
+    // cap    = floor(20000 / (50 × 100)) = 4  ← without the ×100 it would be 400
+    const result = calculateTrade(
+      percentInput({
+        mode: 'options',
+        balance: '100000',
+        riskPercent: '1',
+        buyingPower: '20000',
+      }),
+    );
+    expect(result.positionSize).toBe(4);
+    expect(result.buyingPowerLimited).toBe(true);
+    expect(result.totalPositionValue).toBe('20000.00'); // 50 × 4 × 100
+  });
+
+  it('is ignored on the dollar basis, which has no cap at all', () => {
+    // dollarRisk 1000 / perUnitRisk 2 = 500 shares = $25,000 of stock, against
+    // a supplied buyingPower of $100. The dollar basis is uncapped by design
+    // and this change does not alter that.
+    const result = calculateTrade(baseInput({ buyingPower: '100' }));
+    expect(result.positionSize).toBe(500);
+    expect(result.buyingPowerLimited).toBeUndefined();
+    expect(result.sizingStatus).toBeUndefined();
+  });
+
+  it('treats an empty-string buyingPower as absent', () => {
+    // The shared optionalEmptyToUndefined preprocessing — a blank form field
+    // must not parse as 0 and zero every position.
+    const parsed = CalculatorInputSchema.parse({
+      ...percentInput({ balance: '5000', riskPercent: '1' }),
+      buyingPower: '',
+    });
+    expect(parsed.buyingPower).toBeUndefined();
+    expect(calculateTrade(parsed).positionSize).toBe(25);
   });
 });

--- a/packages/shared/src/calculator.test.ts
+++ b/packages/shared/src/calculator.test.ts
@@ -538,14 +538,48 @@ describe('calculateTrade — buyingPower cap basis', () => {
     expect(result.totalPositionValue).toBe('20000.00'); // 50 × 4 × 100
   });
 
-  it('is ignored on the dollar basis, which has no cap at all', () => {
-    // dollarRisk 1000 / perUnitRisk 2 = 500 shares = $25,000 of stock, against
-    // a supplied buyingPower of $100. The dollar basis is uncapped by design
-    // and this change does not alter that.
-    const result = calculateTrade(baseInput({ buyingPower: '100' }));
+  it('caps the DOLLAR basis too when buyingPower is supplied', () => {
+    // dollarRisk 1000 / perUnitRisk 2 = 500 shares = $25,000 of stock. A direct
+    // dollar risk overshoots exactly as readily as a percentage one, so the cap
+    // applies here as well: floor(10000 / 50) = 200.
+    const result = calculateTrade(baseInput({ buyingPower: '10000' }));
+    expect(result.positionSize).toBe(200);
+    expect(result.buyingPowerLimited).toBe(true);
+    // Percent-only echo — absent on the dollar basis even when the cap binds.
+    expect(result.derivedDollarRisk).toBeUndefined();
+  });
+
+  it('leaves the dollar basis uncapped when buyingPower is absent', () => {
+    // No account selected ⇒ no cap figure ⇒ the original uncapped behaviour.
+    const result = calculateTrade(baseInput());
     expect(result.positionSize).toBe(500);
     expect(result.buyingPowerLimited).toBeUndefined();
     expect(result.sizingStatus).toBeUndefined();
+  });
+
+  it('reports buying-power-zero on the dollar basis WITHOUT a derivedDollarRisk', () => {
+    // The crash case: the percent path echoes `derivedDollarRisk` on this
+    // outcome, and `to2dp(null!)` constructs `new Decimal(null)`, which THROWS.
+    // A dollar-basis position against an account that cannot fund one unit has
+    // no derived risk to echo, so the echo has to be conditional.
+    const result = calculateTrade(baseInput({ entryPrice: '100', buyingPower: '50' }));
+    expect(result.positionSize).toBe(0);
+    expect(result.sizingStatus).toBe('buying-power-zero');
+    expect(result.derivedDollarRisk).toBeUndefined();
+  });
+
+  it('caps the dollar basis at negative buying power without a negative size', () => {
+    const result = calculateTrade(baseInput({ buyingPower: '-1000' }));
+    expect(result.positionSize).toBe(0);
+    expect(result.sizingStatus).toBe('buying-power-zero');
+  });
+
+  it('still prefers insufficient-risk over a dollar-basis cap', () => {
+    // dollarRisk 1 / perUnitRisk 2 → 0 shares, decided before the cap runs.
+    const result = calculateTrade(baseInput({ dollarRisk: '1', buyingPower: '0' }));
+    expect(result.positionSize).toBe(0);
+    expect(result.sizingStatus).toBeUndefined();
+    expect(result.derivedDollarRisk).toBeUndefined();
   });
 
   it('treats an empty-string buyingPower as absent', () => {

--- a/packages/shared/src/calculator.ts
+++ b/packages/shared/src/calculator.ts
@@ -96,21 +96,30 @@ export function calculateTrade(input: CalculatorInput): CalculatorOutput {
     return derivedDollarRisk ? { ...base, derivedDollarRisk: to2dp(derivedDollarRisk) } : base;
   }
 
+  // The figure the cap is computed against:
+  //
+  //   explicit `buyingPower`  → use it, in EITHER risk basis
+  //   percent basis, no field → `balance`, the original REQ-8 behaviour
+  //   dollar basis, no field  → none; the size is uncapped, as it always was
+  //
+  // The cap used to be percent-only because a balance only existed there. It is
+  // keyed on having a cap basis at all, not on the risk basis: "can I afford
+  // this" is the same question however the risk was expressed, and a direct
+  // dollar risk overshoots exactly as readily as a percentage one — $1,000 of
+  // risk at a $2 stop is $25,000 of stock no matter which box it was typed in.
+  //
+  // The risk budget is untouched by all of this. `balance` answers "risk 1% of
+  // my account" (equity); the cap answers "can I afford this" (liquid funds).
+  let capBasis: Decimal | null = null;
+  if (input.buyingPower !== undefined) {
+    capBasis = new Decimal(input.buyingPower);
+  } else if (isPercent) {
+    capBasis = balanceDec!;
+  }
+
   let finalSize = riskDerivedSize;
   let buyingPowerLimited = false;
-  if (isPercent) {
-    // The cap is computed against `buyingPower` when supplied, `balance`
-    // otherwise. These are deliberately DIFFERENT questions:
-    //
-    //   risk budget → balance   "risk 1% of my account" means 1% of equity
-    //   cap         → cash      "can I afford this" means liquid funds
-    //
-    // Using equity for the cap overstates it by whatever is already deployed,
-    // which is how the calculator could size a position larger than the account
-    // could actually fund. Absent `buyingPower` the two collapse back to one
-    // figure and the behaviour is exactly as before.
-    const capBasis = input.buyingPower !== undefined ? new Decimal(input.buyingPower) : balanceDec!;
-
+  if (capBasis !== null) {
     // entry is a validated positive decimal and multiplier ∈ {1,100} ⇒
     // entry×multiplier > 0 ⇒ no divide-by-zero.
     const cap = capBasis.div(entry.times(multiplier)).floor().toNumber();
@@ -121,10 +130,13 @@ export function calculateTrade(input: CalculatorInput): CalculatorOutput {
     // or negative cash, and `floor(negative / positive)` is negative, which
     // would otherwise sail past the guard and cap the size to a negative number.
     if (cap <= 0) {
-      return {
-        ...zeroOut(perUnitRiskStr, 'buying-power-zero'),
-        derivedDollarRisk: to2dp(derivedDollarRisk!),
-      };
+      const zero = zeroOut(perUnitRiskStr, 'buying-power-zero');
+      // `derivedDollarRisk` is a percent-basis echo and has no dollar-basis
+      // meaning. The conditional is load-bearing, not tidiness: `to2dp(null!)`
+      // constructs `new Decimal(null)`, which throws — so a dollar-basis
+      // position whose account cannot fund one unit would 500 instead of
+      // returning this outcome.
+      return derivedDollarRisk ? { ...zero, derivedDollarRisk: to2dp(derivedDollarRisk) } : zero;
     }
     if (cap < riskDerivedSize) {
       finalSize = cap;

--- a/packages/shared/src/calculator.ts
+++ b/packages/shared/src/calculator.ts
@@ -99,10 +99,28 @@ export function calculateTrade(input: CalculatorInput): CalculatorOutput {
   let finalSize = riskDerivedSize;
   let buyingPowerLimited = false;
   if (isPercent) {
+    // The cap is computed against `buyingPower` when supplied, `balance`
+    // otherwise. These are deliberately DIFFERENT questions:
+    //
+    //   risk budget → balance   "risk 1% of my account" means 1% of equity
+    //   cap         → cash      "can I afford this" means liquid funds
+    //
+    // Using equity for the cap overstates it by whatever is already deployed,
+    // which is how the calculator could size a position larger than the account
+    // could actually fund. Absent `buyingPower` the two collapse back to one
+    // figure and the behaviour is exactly as before.
+    const capBasis = input.buyingPower !== undefined ? new Decimal(input.buyingPower) : balanceDec!;
+
     // entry is a validated positive decimal and multiplier ∈ {1,100} ⇒
     // entry×multiplier > 0 ⇒ no divide-by-zero.
-    const cap = balanceDec!.div(entry.times(multiplier)).floor().toNumber();
-    if (cap === 0) {
+    const cap = capBasis.div(entry.times(multiplier)).floor().toNumber();
+
+    // `<= 0`, not `=== 0`. The old strict check was safe only because the cap
+    // basis was `balance`, already proven positive above. `buyingPower` carries
+    // no such guarantee — a fully-deployed or margined account can present zero
+    // or negative cash, and `floor(negative / positive)` is negative, which
+    // would otherwise sail past the guard and cap the size to a negative number.
+    if (cap <= 0) {
       return {
         ...zeroOut(perUnitRiskStr, 'buying-power-zero'),
         derivedDollarRisk: to2dp(derivedDollarRisk!),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -20,8 +20,18 @@ export type {
   PreviewRateChangeInput,
   PreviewRateChangeResponse,
 } from './schemas/accounting';
-export { CalculatorInputSchema, CalculatorOutputSchema } from './schemas/calculator';
-export type { CalculatorInput, CalculatorOutput } from './schemas/calculator';
+export {
+  BuyingPowerBasisBodySchema,
+  BuyingPowerBasisEnum,
+  CalculatorInputSchema,
+  CalculatorOutputSchema,
+} from './schemas/calculator';
+export type {
+  BuyingPowerBasis,
+  BuyingPowerBasisBody,
+  CalculatorInput,
+  CalculatorOutput,
+} from './schemas/calculator';
 export {
   SymbolSearchItemSchema,
   SymbolSearchResponseSchema,

--- a/packages/shared/src/schemas/account.ts
+++ b/packages/shared/src/schemas/account.ts
@@ -79,6 +79,13 @@ export const AccountSchema = z.object({
   // ships derived account balances. Kept optional so existing callers/tests
   // that construct accounts without a balance continue to parse.
   balance: z.string().optional(),
+  // The two halves of `balance` (ledger-balances Req 10), same optionality
+  // rationale. `cash` is the deployable figure; `positionValue` is the cost
+  // basis of open positions and is NEGATIVE for shorts, where the unexited size
+  // is proceeds received against shares still owed. Cost basis only — neither
+  // moves with the market. `cash + positionValue === balance` always.
+  cash: z.string().optional(),
+  positionValue: z.string().optional(),
 });
 
 export type CreateAccountInput = z.infer<typeof CreateAccountSchema>;

--- a/packages/shared/src/schemas/calculator.ts
+++ b/packages/shared/src/schemas/calculator.ts
@@ -64,6 +64,22 @@ export const CalculatorInputSchema = z
     stopLoss: positiveDecimal(PRICE_MAX),
     dollarRisk: optionalEmptyToUndefined(positiveDecimal(DOLLAR_RISK_MAX)),
     balance: optionalEmptyToUndefined(signedBoundedDecimal(ACCOUNT_BALANCE_MAX)),
+    // The figure the BUYING-POWER CAP is computed against, when it should not be
+    // `balance`. Percent basis only, and optional: absent ⇒ the cap falls back to
+    // `balance`, which is the pre-existing behaviour, so every existing client and
+    // the whole dollar basis are unaffected.
+    //
+    // It exists because `balance` answers two different questions and only one of
+    // them is about equity. "Risk 1% of my account" means 1% of total equity — that
+    // stays on `balance`. "Can I afford this many shares" means cash, and total
+    // equity answers it wrongly whenever capital is already deployed: a $5,000
+    // account with $4,000 in open positions would happily size a $1,250 position
+    // against $1,000 of actual cash. Splitting the two lets the caller pass cash
+    // here and leave the risk budget alone.
+    //
+    // Signed, like `balance` — cash can legitimately be negative on a margin
+    // account, and the cap guard handles that rather than the validator.
+    buyingPower: optionalEmptyToUndefined(signedBoundedDecimal(ACCOUNT_BALANCE_MAX)),
     riskPercent: optionalEmptyToUndefined(positiveDecimal(100)),
     direction: z.enum(['long', 'short']),
     mode: z.enum(['stock', 'options']),
@@ -104,3 +120,25 @@ export const CalculatorOutputSchema = z.object({
 
 export type CalculatorInput = z.infer<typeof CalculatorInputSchema>;
 export type CalculatorOutput = z.infer<typeof CalculatorOutputSchema>;
+
+/**
+ * Which account figure the calculator's buying-power cap is computed against.
+ *
+ * `'cash'` (the default) is the balance less the cost basis of open positions —
+ * what the account can actually deploy. `'balance'` is total equity, the
+ * pre-existing behaviour, kept for users who trade on margin and treat their
+ * whole equity as fundable.
+ *
+ * Cash is the default because the failure mode is asymmetric: sizing against
+ * equity tells a user with capital already deployed to open a position larger
+ * than they can fund, and they find out at the broker. Sizing against cash is
+ * at worst conservative.
+ *
+ * This does NOT change the risk budget, which is always `riskPercent × balance`
+ * — "risk 1% of my account" means 1% of equity under either setting.
+ */
+export const BuyingPowerBasisEnum = z.enum(['cash', 'balance']);
+export type BuyingPowerBasis = z.infer<typeof BuyingPowerBasisEnum>;
+
+export const BuyingPowerBasisBodySchema = z.object({ basis: BuyingPowerBasisEnum });
+export type BuyingPowerBasisBody = z.infer<typeof BuyingPowerBasisBodySchema>;

--- a/packages/shared/src/schemas/calculator.ts
+++ b/packages/shared/src/schemas/calculator.ts
@@ -64,10 +64,10 @@ export const CalculatorInputSchema = z
     stopLoss: positiveDecimal(PRICE_MAX),
     dollarRisk: optionalEmptyToUndefined(positiveDecimal(DOLLAR_RISK_MAX)),
     balance: optionalEmptyToUndefined(signedBoundedDecimal(ACCOUNT_BALANCE_MAX)),
-    // The figure the BUYING-POWER CAP is computed against, when it should not be
-    // `balance`. Percent basis only, and optional: absent ⇒ the cap falls back to
-    // `balance`, which is the pre-existing behaviour, so every existing client and
-    // the whole dollar basis are unaffected.
+    // The figure the BUYING-POWER CAP is computed against. Valid in EITHER risk
+    // basis, and optional: absent ⇒ the percent basis caps against `balance` (the
+    // pre-existing behaviour) and the dollar basis is uncapped (likewise), so
+    // every existing client is unaffected.
     //
     // It exists because `balance` answers two different questions and only one of
     // them is about equity. "Risk 1% of my account" means 1% of total equity — that

--- a/packages/shared/src/schemas/position.ts
+++ b/packages/shared/src/schemas/position.ts
@@ -175,6 +175,11 @@ export const PositionListItemSchema = z.object({
   actualRR: z.number().nullable(),
   openUnits: z.number(),
   closedUnits: z.number(),
+  // Capital tied up in the unexited portion, at cost — the per-position term
+  // the account-level `positionValue` sums. Includes the open portion's share
+  // of entry fees, and is NEGATIVE for shorts (remaining proceeds are a
+  // liability). Cost basis only; it never moves with the market.
+  openCostBasis: z.number(),
 });
 
 export const PositionDetailSchema = z.object({
@@ -210,6 +215,11 @@ export const PositionDetailSchema = z.object({
   actualRR: z.number().nullable(),
   openUnits: z.number(),
   closedUnits: z.number(),
+  // Capital tied up in the unexited portion, at cost — the per-position term
+  // the account-level `positionValue` sums. Includes the open portion's share
+  // of entry fees, and is NEGATIVE for shorts (remaining proceeds are a
+  // liability). Cost basis only; it never moves with the market.
+  openCostBasis: z.number(),
 });
 
 export type CreatePositionInput = z.infer<typeof CreatePositionSchema>;


### PR DESCRIPTION
Splits an account's single balance into **cash** and **position value**, then uses the cash figure to stop the position-size calculator suggesting trades the account cannot fund.

```
$5,000 cash → open a $1,000 position → $4,000 cash + $1,000 position value
            → partially close at a profit → $4,550 cash + $500 position value
```

Position value is **cost basis only**. There is still no quote source and this does not add one.

## Why this is possible now

The derivation `cash = balance − Σ(open cost basis)` did not work before per-fill P&L posting (234d091). Mid-trade the ledger was still holding a position's realized P&L back until it went flat, so the subtraction came up short by exactly that unposted amount — $4,500 against a true $4,550 in the example above. With per-fill posting the gap closes and the split falls out as a pure derivation: no schema change, no double-entry on open.

That premise was verified against the running API before any code was written, and it held — with one correction below.

## The split

```
positionValue = Σ over open positions of
    sideSign · openQty · avgEntryPrice · multiplier   (capital deployed)
  + entryFees · openQty / entryQty                    (unallocated entry fee)

cash          = balance − positionValue
```

`cash` is derived by **subtraction**, never summed independently, so `cash + positionValue = balance` is an identity rather than two code paths that have to be kept agreeing.

**Entry fees are the correction.** The gap closes only for the fee-free case. A commission leaves cash at entry but the ledger posts it slice by slice on exit, so a fee-free cost basis overstates cash by `entryFees × openQty / entryQty` for as long as anything stays open — $5 on a $10 commission, half exited. Folding the open portion's share into position value closes it exactly, and makes the figure the correct tax cost basis, which the old display-only cost basis never was.

**Shorts are signed negative.** Their unexited size is proceeds received against shares still owed. Short 10 @ $100 then cover 5 @ $90 leaves $5,550 of cash; an unsigned magnitude reports $4,550. A shorting account therefore shows cash above its balance, which is what a real margin account does.

**Drafts are excluded** — they never post to the ledger, so counting them would move cash against a balance that never moved. **Reconciliation adjustments need no handling**: already in `balance`, not position value, so the subtraction routes them to cash on its own.

## Calculator: cap by cash, not equity

The buying-power cap was `floor(balance ÷ (entry × multiplier))` because `balance` was the only account figure that existed. It overstates fundable capital by exactly what is already deployed.

`balance` was answering two different questions and only one is about equity:

| | figure | why |
| --- | --- | --- |
| Risk budget | `balance` | "risk 1% of my account" means 1% of **equity** |
| Buying-power cap | `cash` | "can I afford this" means **liquid funds** |

Only the cap moved. Sizing the risk budget off cash would silently shrink the risk taken as capital is deployed, so "risk 1%" would mean a different amount every day.

`calculateTrade` gains an optional `buyingPower` that falls back to `balance`. That fallback is the whole compatibility story — omit it and every existing client and every prior acceptance criterion behave identically.

The cap now applies in the **dollar basis** too, wherever an account is selected. The percent-only restriction was an artefact of a balance only existing there, not a principled boundary: $1,000 of risk at a $2 stop is $25,000 of stock however it was expressed.

**New user setting** `users.buying_power_basis` (`cash` | `balance`), on Settings → Profile, defaulting to `cash` for existing users too via the column default. Defaulting people into a behaviour change needs justifying, and the justification is that the failure is asymmetric: `balance` sizes a position the account cannot fund and the user finds out at the broker, while `cash` is at worst conservative. Margin traders can opt back.

`POST /api/calculator` stays a pure function of its request body and never reads the preference — an API consumer picks its basis explicitly rather than inheriting a setting it cannot see.

## Two bugs caught on the way

- **`cap === 0` → `cap <= 0`.** The strict check was safe only because `balance` was already proven positive before the cap ran. `buyingPower` carries no such guarantee — a fully-deployed or margined account can present zero or negative cash, and `floor(-500 ÷ 50) = -10` would have sailed past the guard and been applied as a negative position size.
- **`derivedDollarRisk` echo.** The `buying-power-zero` return did `to2dp(derivedDollarRisk!)`, sound while that outcome was percent-only. Once the dollar basis could reach it the value is null and `new Decimal(null)` throws — a 500 on an ordinary input, namely a dollar trade against an account that cannot fund one unit. Exactly the case the feature exists to report cleanly.

## API changes

Pre-1.0, so these are additive rather than breaking:

- Accounts LIST/GET gain `cash` and `positionValue`.
- Position LIST/DETAIL gain `openCostBasis` (signed, fee-inclusive).
- `POST /api/calculator` accepts optional `buyingPower`; `sizingStatus` and `buyingPowerLimited` are now reachable on either risk basis, not just percent.
- New `GET`/`PUT /api/users/me/buying-power-basis`.
- One additive migration, `0024`. No table rewrite, no backfill.

`GET /api/accounts` and `/api/accounts/{id}` carry no `@swagger` blocks and are absent from the OpenAPI spec, so there was nothing to resync for the two new account fields — flagging rather than documenting two endpoints as unrelated scope.

## Testing

The rule is necessarily encoded twice — SQL for the account aggregate (a per-account TypeScript pass would be an N+1) and TypeScript for the per-row figure — so a **parity test** over a mixed long/short/option account pins them to the cent. That is the load-bearing test here.

Every expectation in the cash-split suite is a broker-cash figure computed independently of the app, not a value read back from the query.

- 1898 API, 1376 web/shared, 88 e2e, typecheck, lint, bundle gate — all green.
- Existing assertions changed only where behaviour deliberately changed: the drawer's cost basis for shorts is now signed, the advisor token bound rose for two extra fields per account row, and the shared test asserting "the dollar basis has no cap at all" now has a sibling pinning that it stays uncapped when no figure is supplied.

## Known limitation

During a **reopen** window the ledger has reversed its postings while the position's open cost basis is 0, so `balance` is understated. `cash + positionValue = balance` still holds — the split inherits the already-documented reopen divergence rather than adding one, and it resolves when the position next goes flat.
