### PR TITLE
docs: write import, the metrics glossary, and the security model

### DIFF
--- a/apps/docs/src/content/docs/self-hosting/explanation/security.mdx
+++ b/apps/docs/src/content/docs/self-hosting/explanation/security.mdx
@@ -1,18 +1,154 @@
 ---
-title: "Security model"
-description: "Session cookies, bcrypt, app-level row scoping, AES-256-GCM BYOK key encryption, rate limiting, CORS/anti-CSRF for split-origin, and FEATURE_GATING."
-pagefind: false
-head:
-  - tag: meta
-    attrs:
-      name: robots
-      content: noindex
+title: Security model
+description: What Tradr protects, how — sessions, password storage, encryption of provider keys, rate limiting, and network exposure — and what it deliberately leaves to you.
 ---
 
-Session cookies, bcrypt, app-level row scoping, AES-256-GCM BYOK key encryption, rate limiting, CORS/anti-CSRF for split-origin, and FEATURE_GATING.
+import SelfHosted from '@/components/SelfHosted.astro';
 
-:::note
-This page is not written yet. It is listed so the shape of the documentation is
-visible. It stays out of search and out of search-engine indexes until it has
-content.
+This page is for someone deciding whether to trust Tradr with their trading
+history. It states what the application does, and — more usefully — what it does
+not do and leaves to you.
+
+## What is at stake
+
+Tradr holds your **trading history**: positions, fills, account balances, and
+whatever you wrote in your notes. On an instance where the advisor is used, it
+also holds **provider API keys**, which can spend money.
+
+It does **not** hold brokerage credentials, and it cannot place orders. There is
+no broker connection — trades arrive by CSV or by hand. A compromised Tradr
+instance exposes a record of your trading; it does not expose your brokerage
+account.
+
+## Accounts and sessions
+
+**Passwords** are hashed with bcrypt. The plaintext is never stored, and a login
+against a non-existent account still performs a hash comparison so that response
+timing does not reveal which emails are registered.
+
+**Sessions** are an `HttpOnly` cookie, so page JavaScript cannot read it. It is
+`SameSite=Lax` and expires after 24 hours. `Secure` is set whenever the api runs
+in production mode.
+
+The cookie is signed with `SESSION_SECRET`. Changing that value invalidates every
+session at once, which is the lever to pull if you think one has leaked.
+
+## Separation between users
+
+Every query is scoped by user id in the application layer. There is no row-level
+security in the database, so that scoping is the boundary — a query written
+without it would cross users.
+
+This is worth knowing rather than glossing: it means the protection lives in the
+code, and it is why an instance should run a released version rather than an
+arbitrary commit.
+
+## Provider API keys
+
+Keys you paste in for the advisor are encrypted at rest with **AES-256-GCM**,
+using `ENCRYPTION_KEY`. GCM authenticates as well as encrypts, so a modified
+ciphertext fails to decrypt rather than producing wrong plaintext.
+
+Set `ENCRYPTION_KEY_FINGERPRINT` as well. Without it, booting with the wrong key
+fails **late and quietly** — the app runs and keys simply refuse to decrypt. With
+it, the api refuses to start and says why.
+
+:::danger
+`ENCRYPTION_KEY` is not recoverable and not derivable from anything else. Lose it
+and every stored provider key is unreadable. Keep it with your backups — see
+[Back up and restore](/self-hosting/backup-restore/).
 :::
+
+## What reaches a third party
+
+With nothing configured, **nothing leaves your instance**. No telemetry, no
+outbound calls, no error reporting.
+
+Each of these is off until you turn it on:
+
+| Configured | What is sent |
+| --- | --- |
+| An LLM key | Advisor conversations, and the position data the advisor was asked about, to that provider |
+| Analytics | Product events — no trade data, users identified by an opaque id |
+| Email | Address and message content to your SMTP server |
+| Market data | The symbols you look up |
+
+The advisor is the one to think hardest about: using it means sending trading
+data to a model provider, under that provider's terms. That is inherent to the
+feature, not something Tradr adds.
+
+## Network exposure
+
+The shipped Compose stack publishes **one port**. `postgres` and `api` are
+reachable only inside the Compose network, so the database is not on your host's
+interface.
+
+**TLS is yours to provide.** The stack does not terminate HTTPS. Put a reverse
+proxy in front of it — see
+[Put TLS in front of the stack](/self-hosting/tls-reverse-proxy/). Without one,
+session cookies cross the network in the clear.
+
+If you do put a proxy in front, set `TRUSTED_PROXIES` to its address. Rate
+limiting is per-IP, and behind an untrusted proxy every request appears to come
+from the proxy — so the limit applies to everyone at once instead of per client.
+
+## Rate limiting
+
+Authentication endpoints are rate limited per IP, which blunts credential
+stuffing and brute force. On a single instance the counters are in memory, so
+they reset when the api restarts.
+
+<SelfHosted>
+  There is no lockout after N failed attempts, and no CAPTCHA. For an instance
+  with a handful of known users that is a reasonable trade; if yours is exposed to
+  the internet with open registration, put an authenticating proxy in front.
+</SelfHosted>
+
+## What is off by default
+
+Feature gating (`FEATURE_GATING`) ships **off**, and with it every plan limit. A
+self-hosted instance has no tiers. The billing, object storage, and Redis paths
+are inert until configured, and the test suite enforces that an unconfigured
+instance behaves as a plain journal.
+
+That is the design rule: a capability you have not configured is **absent, not
+disabled**. It makes no outbound calls and logs no errors.
+
+## What Tradr does not do
+
+Stated plainly, because a security page that only lists strengths is not useful:
+
+- **No two-factor authentication.** A password is the only factor.
+- **No audit log of user actions.** Admin actions are recorded; ordinary ones are not.
+- **No account lockout** after repeated failures — only rate limiting.
+- **No encryption of trade data at rest** beyond whatever your disk provides.
+  Provider keys are encrypted; positions and notes are not.
+- **No row-level security** in the database, as above.
+- **No security guarantee before 1.0.** The project is pre-1.0 and has not been
+  independently audited.
+
+If any of those is disqualifying for your situation, better to know now.
+
+## Keeping an instance safe
+
+1. Run a released version, and upgrade when one ships. See
+   [Upgrade an instance](/self-hosting/upgrades/).
+2. Put TLS in front of it.
+3. Generate the three secrets rather than inventing them — `docker/quickstart.sh`
+   does this.
+4. Set `ENCRYPTION_KEY_FINGERPRINT`.
+5. Keep `.env` with your backups, and keep both somewhere the server cannot reach.
+6. Do not expose Postgres. The shipped Compose file already does not.
+
+## Reporting a vulnerability
+
+Report privately, not as a public issue. The process, the scope, and what to
+expect are in
+[`SECURITY.md`](https://github.com/madmatt112/tradr/blob/main/SECURITY.md).
+
+## Next steps
+
+- [Put TLS in front of the stack](/self-hosting/tls-reverse-proxy/).
+- [Back up and restore](/self-hosting/backup-restore/) — including the key that
+  makes a backup readable.
+- [Environment variables](/self-hosting/reference/env-vars/) — every setting named here.

--- a/apps/docs/src/content/docs/user-guide/import-history.mdx
+++ b/apps/docs/src/content/docs/user-guide/import-history.mdx
@@ -18,14 +18,136 @@ presets so a familiar export maps in one click, but the transport is always a
 file you supply. A direct read-only IBKR connection is planned; until it ships,
 CSV is the only import path, and this page will say so.
 
-## Import a CSV
+## Before you start
 
-:::note
-This section is not written yet. The importer is in the app under
-**Positions → Import**; it walks you through upload, column mapping, a preview,
-and a commit step. This page will document the broker presets, the column
-mapping rules, and the file and row limits.
+Create an account first. An import needs somewhere to put the trades, and the
+importer will not proceed without one. See
+[Accounts](/user-guide/accounts/).
+
+Imports are **additive**. They add positions and fills to the target account and
+never replace what is there, so importing the same file twice gives you the
+trades twice. There is no de-duplication.
+
+## Step 1 — Choose the target account
+
+Open **Import** and pick the account under **1. Target account**.
+
+## Step 2 — Upload the file
+
+Select **Choose file** and pick your export. The server parses and validates it
+on upload; nothing is written to your account yet.
+
+The limits are 10 MB per file and 10,000 data rows. Split a larger export and
+import it in parts.
+
+## Step 3 — Map the columns
+
+Tradr does not guess what your columns mean. Tell it, either by choosing a preset
+or by mapping each field by hand.
+
+**Presets** pre-fill the mapping for a known export format — Interactive Brokers
+Flex Query trades, a generic one-row-per-fill layout, and formats used by common
+journalling tools. Choosing one fills the fields in; you can then adjust any of
+them. A preset is a starting point, not a lock.
+
+Set these alongside the mapping:
+
+| Setting | What it controls |
+| --- | --- |
+| **Row shape** | Whether each row is one fill (**Execution**) or a whole round trip with entry and exit on one line (**Round-trip**). Set independently of the preset. |
+| **Timezone** | The zone your export's timestamps are written in. |
+| **Date format** | How to read the date column — ISO, US, and so on. |
+| **Number format** | Whether `1,234.56` or `1.234,56`. |
+
+For execution rows, these fields are **required**:
+
+- Symbol
+- Asset type
+- Price
+- Quantity
+- Filled at (date/time)
+- Exactly **one** of Type (entry/exit) or Action (buy/sell)
+
+**Preview import** stays disabled until all of them are mapped, and the page
+lists what is still missing.
+
+:::caution[Asset type has to be a column]
+Every field maps to a **column in your file**. There is no "treat every row as a
+stock" option, so an export with no asset-type column cannot be mapped as it
+stands — including some formats Tradr ships a preset for.
+
+Add the column before you upload. One value for every row is fine:
+
+```
+Symbol,AssetType,Action,Quantity,Price,FilledAt,Fees
+AAPL,STK,BUY,100,181.50,2026-03-02T09:35:00,1.00
+```
 :::
+
+## Step 4 — Read the preview
+
+Select **Preview import**. Nothing has been written yet — this is the check.
+
+The summary counts what Tradr found:
+
+| | Meaning |
+| --- | --- |
+| **Rows parsed** | Data rows read from the file |
+| **Rows valid** | Rows that mapped cleanly |
+| **Rows with errors** | Rows Tradr could not read. They are listed with their line numbers. |
+| **Positions** | Positions these rows will become |
+| **Fills** | Fills across those positions |
+
+Below the summary, each proposed position is shown with its fills and, when the
+rows close it, its proposed P&L.
+
+### How rows become positions
+
+Fills are grouped **by symbol and direction**. A position runs from its first
+entry until the quantity returns to flat; the next fill after that starts a new
+position.
+
+So four rows — buy 100 AAPL, sell 100 AAPL, buy 50 MSFT, sell 50 MSFT — become
+two closed positions, not one and not four.
+
+Row numbers in the preview count the file's lines, so the header is row 1 and the
+first trade is row 2. That matches what your spreadsheet shows.
+
+## Step 5 — Confirm
+
+Select **Confirm import**.
+
+**Expected result:** `Added 2 positions and 4 fills to the target account.`, with
+a link through to them.
+
+The realized P&L posts to the account balance at the same time. In the worked
+example above, a $25,000.00 account becomes $25,303.50 — plus $473.00 from AAPL,
+minus $169.50 from MSFT, both after fees.
+
+A preview you do not confirm expires after 30 minutes.
+
+## If something is wrong afterwards
+
+There is no "undo import". Positions imported are ordinary positions: open one
+and fix a fill, or delete it. Deleting reverses its P&L out of the balance. See
+[Log and manage positions](/user-guide/positions/).
+
+For a bad import of any size, deleting position by position is the only path
+today. Preview carefully — that is what the step is for.
+
+## Troubleshooting
+
+- **`Preview import` stays greyed out** — a required field is unmapped. The line
+  above the button names which.
+- **Rows with errors is not zero** — open the list. It gives the line number and
+  what failed, usually a date that does not match the chosen date format.
+- **Every row failed on the date** — the **Date format** or **Timezone** setting
+  does not match the file.
+- **Quantities look wrong by a factor of a thousand** — the **Number format** is
+  reading `1,234` as `1.234` or the reverse.
+- **The P&L in the preview is not what you expect** — check whether your export
+  already nets fees out of the price. Tradr subtracts mapped fees itself, so fees
+  counted twice show up here, before anything is written.
 
 ## Related
 

--- a/apps/docs/src/content/docs/user-guide/reference/metrics-glossary.mdx
+++ b/apps/docs/src/content/docs/user-guide/reference/metrics-glossary.mdx
@@ -1,18 +1,164 @@
 ---
-title: "Metrics glossary"
-description: "Exact definitions of every computed figure: realised and unrealised P&L, win rate, R:R, expectancy, average win/loss, equity-curve basis, and fee handling."
-pagefind: false
-head:
-  - tag: meta
-    attrs:
-      name: robots
-      content: noindex
+title: Metrics glossary
+description: Exact definitions of every figure Tradr computes — gross and net P&L, return percentage, both risk/reward ratios, win rate, profit factor, and how fees are allocated.
 ---
 
-Exact definitions of every computed figure: realised and unrealised P&L, win rate, R:R, expectancy, average win/loss, equity-curve basis, and fee handling.
+Every number in Tradr is derived from your fills. Nothing is stored as a running
+total, so correcting a fill corrects every figure that depends on it.
 
-:::note
-This page is not written yet. It is listed so the shape of the documentation is
-visible. It stays out of search and out of search-engine indexes until it has
-content.
-:::
+This page gives the exact definition of each one, including the parts that are
+easy to assume wrongly.
+
+## Per position
+
+### Average entry / average exit
+
+The quantity-weighted average price across the fills of that type.
+
+Two entries — 100 at 190.00 and 50 at 195.00 — average to **191.6667**, not
+192.50. The larger fill counts for more.
+
+### Gross P&L
+
+```
+(average exit − average entry) × quantity exited × direction × contract size
+```
+
+Direction is +1 for a long and −1 for a short. Contract size is 100 for an
+option and 1 for a stock. Fees are not included.
+
+### Net P&L
+
+Gross P&L, minus the fees attributable to the quantity exited. **This is the
+figure that reaches your account balance.**
+
+### Fees
+
+Not simply "the fees on the exit". Each exit carries:
+
+- its own fee, plus
+- a **proportional share of the entry fees**, for the quantity being closed.
+
+Close 60 of 150 units and 60/150 of the entry fees come with it. Close the
+remaining 90 and the rest follows. This keeps a partial exit from either escaping
+its share of the entry cost or paying all of it up front.
+
+The displayed fee figure is derived as gross minus net, so
+`gross − fees = net` holds exactly rather than to within a rounding error.
+
+### Return %
+
+```
+net P&L ÷ (average entry × quantity exited × contract size + allocated entry fees) × 100
+```
+
+The denominator is what the closed portion cost you. For a short position it is
+the proceeds of the sale, not the margin you posted — margin varies by broker and
+Tradr does not know yours.
+
+### Target R/R
+
+```
+|target price − average entry| ÷ |average entry − stop loss|
+```
+
+Planned reward per unit of risk, from the trade plan you recorded.
+
+**It moves when you scale in.** Both distances are measured from the *average*
+entry, so a second fill at a worse price re-bases the ratio even though your
+target and stop have not moved.
+
+Null when there is no target, no stop, or when the stop equals the average entry
+— the risk per unit would be zero.
+
+### Actual R/R
+
+```
+(average exit − average entry) × direction ÷ |average entry − stop loss|
+```
+
+What you actually got, in the same units as the plan. **Signed** — negative when
+the trade went against you, so a −1.0 means you lost exactly the risk you planned.
+
+## Across positions
+
+These appear on the performance page. They count **closed positions only**, in a
+single currency at a time.
+
+### Win, loss, breakeven
+
+A position is classified by its net P&L **rounded to the currency's smallest
+unit**. Exactly zero after rounding is a **breakeven**, not a win and not a loss.
+A position that made half a cent is a breakeven in USD.
+
+### Win rate
+
+```
+wins ÷ (wins + losses) × 100
+```
+
+**Breakevens are excluded from the denominator**, not counted as losses. A
+record of 6 wins, 3 losses and 1 breakeven gives a 66.7% win rate, not 60%.
+
+That choice makes the figure comparable between a strategy that scratches trades
+and one that does not. Breakevens are reported separately as the breakeven rate,
+which *does* divide by the total.
+
+Null when nothing has been decided — no wins and no losses in range.
+
+### Breakeven rate
+
+```
+breakevens ÷ total positions × 100
+```
+
+Unlike win rate, this one uses every closed position as its denominator.
+
+### Average win / average loss
+
+The mean net P&L of winning and of losing positions respectively. Average loss is
+negative. Breakevens are in neither.
+
+### Profit factor
+
+```
+sum of winning net P&L ÷ |sum of losing net P&L|
+```
+
+Above 1.0 means the wins outweigh the losses. Null when there are **no wins or no
+losses** — not infinity, and not zero. With no losses there is no meaningful
+ratio, and reporting one would flatter a two-trade record.
+
+### Largest win / largest loss
+
+The single best and single worst net P&L in range.
+
+### Equity curve
+
+The running total of net P&L, bucket by bucket, over the range you selected. It
+starts at zero rather than at your account balance: it shows what your trading
+did, not what your account is worth.
+
+## Things worth knowing
+
+**Realized P&L does not wait for a close.** A partial exit realizes its share
+immediately, so an open position can carry a realized P&L and contribute to your
+balance. The performance statistics above are a different question — they count
+positions that have gone flat, which is why a half-closed position appears in your
+balance but not yet in your win rate.
+
+**Currencies are never mixed.** Statistics are computed per currency. Positions in
+a currency Tradr has no rate for are excluded and reported as excluded rather than
+silently dropped.
+
+**A reopened position keeps its last flat figures** until it goes flat again.
+Recomputing from the current fills would give a different number, because the
+fills have changed since — so the last completed result is held rather than
+recalculated.
+
+## Next steps
+
+- [Review performance & P&L](/user-guide/performance/) — where these appear.
+- [Log and manage positions](/user-guide/positions/) — where the fills come from.
+- [Accounts & the multi-currency ledger](/user-guide/accounts/) — how P&L reaches
+  a balance.


### PR DESCRIPTION
The rest of R14. Three pages; unwritten count **15 → 12**.

## Import your history

Written by running a real import end to end rather than reading the components. Four execution rows became two closed positions — AAPL **+$473.00**, MSFT **−$169.50** — and a $25,000.00 account became **$25,303.50**, which is the arithmetic checking out through the ledger.

Documents the parts a reader would otherwise have to discover:

- **Grouping**: fills group by symbol and direction; a position runs from its first entry until flat, and the next fill starts a new one. Four rows → two positions, not one and not four.
- **Additive, with no de-duplication.** Import the same file twice and you get the trades twice.
- **No undo.** Deleting position by position is the only path back, which is what makes the preview step load-bearing.
- Limits: 10 MB, 10,000 rows, and a preview that expires after 30 minutes.

### A gap found by using it

Every field maps to a **CSV column** — there is no "treat every row as a stock" constant. So an export with no asset-type column **cannot be mapped at all**, and `Preview import` stays disabled forever.

That includes formats Tradr ships a preset for. One preset's own source comment says it leaves `assetType` unmapped "for the user to complete (REQ-3.4)" — but the UI gives no way to complete it. The page documents the workaround (add the column before uploading) rather than pretending the path is clean. Not fixed here; it needs a product decision about whether mapping should accept a constant.

## Metrics glossary

Exact definitions, leading with the ones that are easy to assume wrongly:

- **Win rate divides by wins + losses, excluding breakevens.** A 6/3/1 record is **66.7%**, not 60%.
- **Profit factor is null** when there are no wins *or* no losses — not infinity, not zero.
- A position is a **breakeven** when net P&L rounds to zero in the account's currency. Half a cent is a breakeven in USD.
- Fees on a partial exit carry a **proportional share of the entry fees**.
- Both risk/reward ratios measure from the **average** entry, so scaling in moves them.
- The equity curve starts at **zero**, not at your balance — it shows what trading did, not what the account is worth.

## Security model

What is protected and how — bcrypt, `HttpOnly` session cookies, AES-256-GCM for provider keys, per-IP rate limiting, one published port.

It also has a **"What Tradr does not do"** section that names the absences plainly: no 2FA, no account lockout, no audit log of ordinary user actions, no row-level security in the database, trade data not encrypted at rest, no independent audit before 1.0. This page's reader is deciding whether to trust the product with their trading history; one that lists only strengths is not useful to them.

## Verified

- The import walkthrough is a real run: preview reported 4 parsed / 4 valid / 0 errors / 2 positions / 4 fills, confirm reported "Added 2 positions and 4 fills", and the API confirms both positions closed with the stated P&L.
- Docs build green, links validator passes, `check-types` 0 errors.
- The R16 generated pages regenerate byte-identical, so the drift gate stays clean.