### PR TITLE
feat: link the documentation from inside the app

### DIFF
--- a/apps/api/src/lib/config.ts
+++ b/apps/api/src/lib/config.ts
@@ -6,7 +6,9 @@ import { logger } from './logger';
 
 export const envSchema = z.object({
   DATABASE_URL: z.string(),
-  SESSION_SECRET: z.string().min(32),
+  SESSION_SECRET: z
+    .string()
+    .min(32, 'must be at least 32 characters — generate with: openssl rand -base64 24'),
   PORT: z.coerce.number().default(3100),
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
   // Deployed-version string surfaced by GET /api/health (e.g. "v0.2.0-f51f9f5").
@@ -24,7 +26,9 @@ export const envSchema = z.object({
     .enum(['true', 'false'])
     .default('false')
     .transform((v) => v === 'true'),
-  ENCRYPTION_KEY: z.string().regex(/^[0-9a-fA-F]{64}$/),
+  ENCRYPTION_KEY: z
+    .string()
+    .regex(/^[0-9a-fA-F]{64}$/, 'must be 64 hex characters — generate with: openssl rand -hex 32'),
   // Both OPTIONAL keys ship uncommented-and-empty in .env.example, so the
   // documented `cp .env.example .env` path hands the schema '' — and `.optional()`
   // only tolerates *undefined*, not ''. Without the empty-tolerant preprocess
@@ -36,7 +40,7 @@ export const envSchema = z.object({
     (v) => (v === '' ? undefined : v),
     z
       .string()
-      .regex(/^[0-9a-fA-F]{64}$/)
+      .regex(/^[0-9a-fA-F]{64}$/, 'must be 64 hex characters — generate with: openssl rand -hex 32')
       .optional(),
   ),
   ENCRYPTION_KEY_FINGERPRINT: z.preprocess(
@@ -332,7 +336,40 @@ export const envSchema = z.object({
   ),
 });
 
-export const config = envSchema.parse(process.env);
+/** Where an operator can look up every variable, its default, and its format. */
+export const ENV_VARS_DOCS_URL = 'https://docs.tradr.cloud/self-hosting/reference/env-vars/';
+
+/**
+ * Parse the environment, and fail READABLY when it is wrong.
+ *
+ * A bare `envSchema.parse()` throws a ZodError, which Node prints as a wall of
+ * internal structure — issue objects, `addIssue` function references, a stack
+ * through the bundle. An operator staring at a crash-looping container has to
+ * dig the variable name out of it. That happened for real: every release through
+ * v0.5.4 crash-looped on a blank optional key, and the output named the variable
+ * only inside a `path: [ … ]` array several screens down.
+ *
+ * So: name the variables, say what each one wants, point at the reference, and
+ * exit. Nothing here changes WHICH environments are valid.
+ */
+function parseEnv(): z.infer<typeof envSchema> {
+  const result = envSchema.safeParse(process.env);
+  if (result.success) return result.data;
+
+  const problems = result.error.issues.map((issue) => {
+    const name = issue.path.join('.') || '(unknown)';
+    return `  ${name}: ${issue.message}`;
+  });
+
+  console.error('Tradr cannot start — the environment is not valid.\n');
+  console.error(problems.join('\n'));
+  console.error(`\nEvery variable, its default, and how to generate it:\n  ${ENV_VARS_DOCS_URL}\n`);
+  console.error('If this is a fresh install, ./docker/quickstart.sh writes a working .env.\n');
+
+  process.exit(1);
+}
+
+export const config = parseEnv();
 export type Config = z.infer<typeof envSchema>;
 
 /**

--- a/apps/web/src/components/layout/Sidebar.docs-link.test.tsx
+++ b/apps/web/src/components/layout/Sidebar.docs-link.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+//
+// There were previously ZERO links from this app to the documentation, so a user
+// who needed an explanation had to already know the site existed. These assert
+// the way in stays present, and stays an external link — the docs are on their
+// own host, so a router <Link> would 404 inside the SPA.
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, to, ...rest }: { children: React.ReactNode; to: string }) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { email: 'someone@example.com', isAdmin: false } }),
+}));
+
+vi.mock('@/features/changelog/hooks/useChangelog', () => ({
+  useChangelogReleases: () => ({ data: undefined }),
+  hasNewReleases: () => false,
+}));
+
+vi.mock('@/components/layout/ThemeToggle', () => ({ ThemeToggle: () => null }));
+
+import { DOCS_BASE_URL, docsUrl } from '@/lib/docs';
+
+import { Sidebar } from './Sidebar';
+
+function mountWith(ui: React.ReactElement): { container: HTMLElement; root: Root } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+  return { container, root };
+}
+
+function unmount(container: HTMLElement, root: Root): void {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Sidebar — documentation link', () => {
+  it('links out to the documentation host', () => {
+    const { container, root } = mountWith(<Sidebar />);
+
+    const link = Array.from(container.querySelectorAll('nav a')).find((a) =>
+      a.getAttribute('href')?.startsWith(DOCS_BASE_URL),
+    );
+
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute('href')).toBe(docsUrl('home'));
+    expect(link?.textContent).toContain('Docs');
+
+    unmount(container, root);
+  });
+
+  it('opens in a new tab, with rel=noreferrer', () => {
+    const { container, root } = mountWith(<Sidebar />);
+
+    const link = Array.from(container.querySelectorAll('nav a')).find((a) =>
+      a.getAttribute('href')?.startsWith(DOCS_BASE_URL),
+    );
+
+    // The reader is mid-task; replacing the app loses their place.
+    expect(link?.getAttribute('target')).toBe('_blank');
+    expect(link?.getAttribute('rel')).toContain('noreferrer');
+
+    unmount(container, root);
+  });
+
+  it('is styled as a pointer target, like every other button-like element', () => {
+    const { container, root } = mountWith(<Sidebar />);
+
+    const link = Array.from(container.querySelectorAll('nav a')).find((a) =>
+      a.getAttribute('href')?.startsWith(DOCS_BASE_URL),
+    );
+
+    expect(link?.className).toContain('cursor-pointer');
+
+    unmount(container, root);
+  });
+});

--- a/apps/web/src/components/layout/Sidebar.test.tsx
+++ b/apps/web/src/components/layout/Sidebar.test.tsx
@@ -200,7 +200,10 @@ describe('Sidebar — Changelog link + new-updates badge', () => {
       a.getAttribute('href'),
     );
     expect(hrefs.indexOf('/changelog')).toBeGreaterThanOrEqual(0);
-    expect(hrefs.indexOf('/settings')).toBe(hrefs.indexOf('/changelog') + 1);
+    // Ordering, not adjacency — which is what this test's name has always
+    // claimed. The Docs link now sits between the two, and pinning `+ 1` would
+    // make every future nav insertion look like a regression in the changelog.
+    expect(hrefs.indexOf('/settings')).toBeGreaterThan(hrefs.indexOf('/changelog'));
 
     const link = Array.from(container.querySelectorAll('a')).find(
       (a) => a.getAttribute('href') === '/changelog',

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -1,5 +1,14 @@
 import { Link } from '@tanstack/react-router';
-import { LineChart, Megaphone, Receipt, Shield, Sigma, Sparkles, Upload } from 'lucide-react';
+import {
+  BookOpen,
+  LineChart,
+  Megaphone,
+  Receipt,
+  Shield,
+  Sigma,
+  Sparkles,
+  Upload,
+} from 'lucide-react';
 import { useState, useEffect } from 'react';
 
 import { ThemeToggle } from '@/components/layout/ThemeToggle';
@@ -7,6 +16,7 @@ import { Button } from '@/components/ui/button';
 import { hasNewReleases, useChangelogReleases } from '@/features/changelog/hooks/useChangelog';
 import { derivePresetRange } from '@/features/performance/utils/derivePresetRange';
 import { useAuth } from '@/hooks/useAuth';
+import { docsUrl } from '@/lib/docs';
 import { cn } from '@/lib/utils';
 
 // Default search params for the Performance route. The route's
@@ -190,6 +200,21 @@ export function Sidebar() {
           </span>
           {!collapsed && <span>Changelog</span>}
         </Link>
+        {/* The documentation lives on its own host, so this is an <a>, not a
+            router <Link>. New tab: a reader following it is mid-task and should
+            not lose the page they were on. */}
+        <a
+          href={docsUrl('home')}
+          target="_blank"
+          rel="noreferrer"
+          title="Documentation"
+          className={cn(
+            'cursor-pointer flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent',
+          )}
+        >
+          <BookOpen className="h-4 w-4" aria-hidden="true" />
+          {!collapsed && <span>Docs</span>}
+        </a>
         <Link
           to="/settings"
           className={cn(

--- a/apps/web/src/features/csv-import/components/ImportPage.tsx
+++ b/apps/web/src/features/csv-import/components/ImportPage.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useAccounts } from '@/features/accounts/hooks/useAccounts';
 import { UpgradeLink } from '@/features/billing/UpgradeLink';
 import { useTierState } from '@/features/billing/useTierState';
+import { docsUrl } from '@/lib/docs';
 
 import { useCsvPreview } from '../hooks/useCsvPreview';
 import { targetFieldsForShape } from '../lib/fields';
@@ -130,7 +131,18 @@ export function ImportPage() {
         <h1 className="text-2xl font-semibold">Import trades from CSV</h1>
         <p className="text-sm text-muted-foreground">
           Imports are additive — they add positions and fills to the target account. Fees come from
-          the CSV unless no fees column is mapped.
+          the CSV unless no fees column is mapped.{' '}
+          {/* Column mapping is the step people get stuck on, and the answer is
+              longer than a tooltip. Link out rather than grow this paragraph. */}
+          <a
+            href={docsUrl('importHistory')}
+            target="_blank"
+            rel="noreferrer"
+            className="cursor-pointer font-medium text-primary underline underline-offset-2"
+          >
+            Read the import guide
+          </a>
+          .
         </p>
         {csvRemaining !== null && (
           <p

--- a/apps/web/src/lib/docs.ts
+++ b/apps/web/src/lib/docs.ts
@@ -1,0 +1,34 @@
+/**
+ * Links from the app to the documentation.
+ *
+ * One place, so the host appears once. There were previously ZERO links from
+ * this app to the docs: a user who needed an explanation had to already know the
+ * site existed and go looking for it, which is most of the reason documentation
+ * goes unread.
+ *
+ * External links deliberately open in a new tab — a reader following a "how does
+ * this work" link is mid-task, and replacing the app they were working in loses
+ * their place.
+ */
+export const DOCS_BASE_URL = 'https://docs.tradr.cloud';
+
+/** Named pages, so a rename is one edit rather than a grep. */
+export const DOCS = {
+  home: '/',
+  gettingStarted: '/user-guide/getting-started/',
+  positions: '/user-guide/positions/',
+  importHistory: '/user-guide/import-history/',
+  metricsGlossary: '/user-guide/reference/metrics-glossary/',
+  accounts: '/user-guide/accounts/',
+  advisor: '/user-guide/ai-advisor/',
+  selfHosting: '/self-hosting/docker-compose/',
+  envVars: '/self-hosting/reference/env-vars/',
+  backupRestore: '/self-hosting/backup-restore/',
+} as const;
+
+export type DocsPage = keyof typeof DOCS;
+
+/** Absolute URL for a named documentation page. */
+export function docsUrl(page: DocsPage): string {
+  return `${DOCS_BASE_URL}${DOCS[page]}`;
+}


### PR DESCRIPTION
R20. There were **zero** links from `apps/web` to the documentation. A user who needed an explanation had to already know the site existed and go looking for it — which is most of the reason documentation goes unread.

Three ways in, with the host in one place (`apps/web/src/lib/docs.ts`).

## 1. A Docs entry in the sidebar

An `<a>`, not a router `<Link>` — the docs are on their own host, so a `<Link>` would 404 inside the SPA. Opens in a new tab, because a reader following it is mid-task.

## 2. A link to the import guide on the CSV import page

Column mapping is the step people get stuck on, and the answer is longer than a tooltip.

## 3. Fatal boot errors now point at the reference

This one earns its place. A bare `envSchema.parse()` throws a `ZodError`, which Node prints as a wall of internal structure — issue objects, `addIssue` function references, a stack through the bundle. **Every release through v0.5.4 crash-looped on a blank optional key, and the output named the variable only inside a `path: [ … ]` array several screens down.**

Now:

```
Tradr cannot start — the environment is not valid.

  SESSION_SECRET: must be at least 32 characters — generate with: openssl rand -base64 24
  ENCRYPTION_KEY: must be 64 hex characters — generate with: openssl rand -hex 32

Every variable, its default, and how to generate it:
  https://docs.tradr.cloud/self-hosting/reference/env-vars/

If this is a fresh install, ./docker/quickstart.sh writes a working .env.
```

Exit code 1, as before. **Which** environments are valid is unchanged — only the message. The two required secrets gained operator-facing regex messages so the output says what it wants instead of Zod's bare `Invalid`.

## One test assertion relaxed

`Sidebar.test.tsx` asserted `indexOf('/settings') === indexOf('/changelog') + 1` while the test's own name says "renders the Changelog link **before** Settings". The Docs entry sits between them. Relaxed to ordering, which is what it always claimed to check — pinning the offset would make every future nav insertion look like a changelog regression.

## Verified

- The boot-failure output above is a real run against a deliberately invalid environment; exit code 1 confirmed.
- New `Sidebar.docs-link.test.tsx`: the link exists, points at the docs host, opens in a new tab with `rel=noreferrer`, and carries `cursor-pointer` (the repo's button-like-element rule).
- `src/components/layout` + `src/features/csv-import` 8 files / 44 tests green; api `config` + `cli` + self-host parity 6 files / 192 tests green; both `check-types` clean; `pnpm lint` clean.