### PR TITLE
docs: add the version banner, and enforce STYLE.md with Vale

### DIFF
--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -1,0 +1,95 @@
+name: Docs style
+
+# Enforces the mechanical parts of docs/STYLE.md with Vale.
+#
+# SCOPED TO THE FILES A PULL REQUEST CHANGES, deliberately. STYLE.md says:
+#
+#   Do not retrofit. The best existing pages were written before this guide and
+#   are better than a mechanical rewrite would make them. Apply this to new and
+#   substantially-revised content.
+#
+# A whole-tree run reports 117 findings across 40 files, almost all of it prose
+# that predates the guide. Gating on that would demand exactly the retrofit the
+# guide forbids. Linting the diff applies the rule to new and revised content and
+# nothing else — which is what the guide actually asks for.
+#
+# ADVISORY for now (continue-on-error), matching how the security scanners were
+# introduced in this repository. To make it required: clear the backlog on the
+# pages that remain, drop `continue-on-error`, and add "docs-style" to the
+# protect-main ruleset.
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '**/*.mdx'
+      - '.vale.ini'
+      - '.vale/**'
+      - '.github/workflows/docs-style.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-style-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  vale:
+    name: vale (advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Need the base branch to diff against; a shallow clone has neither.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Collect the prose this PR changes
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Deleted files would fail the lint by not existing.
+          git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" \
+            -- '*.md' '*.mdx' > changed.txt || true
+          echo "count=$(wc -l < changed.txt)" >> "$GITHUB_OUTPUT"
+          echo "Files to lint:"
+          cat changed.txt
+
+      - name: Vale
+        if: steps.changed.outputs.count != '0'
+        run: |
+          set -uo pipefail
+          # The pinned image is the one the rules were developed against; Vale's
+          # markdown handling changes between versions.
+          docker run --rm -v "$PWD":/docs -w /docs jdkato/vale:v3.17.0 \
+            $(tr '\n' ' ' < changed.txt) | tee vale.out || true
+
+          # Report, do not fail. A PR that touches ONE line of an old page would
+          # otherwise inherit every finding that page already had — and a check
+          # that goes red for reasons the author did not cause is a check people
+          # learn to ignore. The findings are in the log and the job summary.
+          #
+          # To make this required: clear the backlog, delete the `|| true` above
+          # and the `continue-on-error` on the job, then add "docs-style" to the
+          # protect-main ruleset.
+
+      - name: Summarise
+        if: always()
+        run: |
+          {
+            echo "### Vale — docs/STYLE.md"
+            echo
+            if [ ! -s changed.txt ]; then
+              echo "No markdown changed."
+            else
+              echo '```'
+              cat vale.out 2>/dev/null || echo "(no output)"
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,31 @@
+# Vale — mechanical enforcement of the parts of docs/STYLE.md a linter can check.
+#
+# STYLE.md is an STE-derived house standard. Most of it is judgement a linter
+# cannot make; a few rules are exactly mechanical, and those are the ones here:
+# the banned words, the declared vocabulary in docs/TERMS.md, and the sentence
+# length caps.
+#
+# Scope is the prose we actually maintain. The generated reference pages are
+# excluded — their wording comes from .env.example comments and route
+# descriptions, so a finding there would have to be fixed in a source file that
+# is not prose, and the drift gate would put it straight back.
+#
+# MinAlertLevel is `error` so only the rules the style guide states as absolute
+# fail. Suggestions stay visible in a local run without turning CI red on a
+# judgement call.
+
+StylesPath = .vale
+MinAlertLevel = error
+
+# Vale's MDX support cannot parse Starlight's MDX — it stops with "Unexpected
+# closing slash `/` in tag, expected an open tag first" and lints nothing. Treat
+# .mdx as markdown instead: the prose is what we are checking, and the component
+# tags are handled by TokenIgnores below.
+[formats]
+mdx = md
+
+[*.{md,mdx}]
+BasedOnStyles = Tradr
+
+# Starlight/MDX syntax that is markup, not prose.
+TokenIgnores = (:::[a-z]+(\[.*?\])?), (\{/\*.*?\*/\}), (<[A-Z][A-Za-z]*[^>]*>)

--- a/.vale/Tradr/BannedWords.yml
+++ b/.vale/Tradr/BannedWords.yml
@@ -1,0 +1,15 @@
+extends: existence
+message: "'%s' — see docs/STYLE.md. Delete it, or say what actually happens."
+level: error
+ignorecase: true
+tokens:
+  - simply
+  - just
+  - easily
+  - obviously
+  - should work
+  - ought to
+  - leverage
+  - utilise
+  - utilize
+  - in order to

--- a/.vale/Tradr/SentenceLength.yml
+++ b/.vale/Tradr/SentenceLength.yml
@@ -1,0 +1,9 @@
+# STYLE.md rule 2: procedural sentences under 20 words, descriptive under 25.
+# A linter cannot tell the two apart, so this enforces the looser bound — the
+# one that is unambiguously a violation either way.
+extends: occurrence
+message: "Sentence is over 25 words — split it (docs/STYLE.md rule 2)."
+level: error
+scope: sentence
+max: 25
+token: '\b(\w+)\b'

--- a/.vale/Tradr/Terms.yml
+++ b/.vale/Tradr/Terms.yml
@@ -1,0 +1,19 @@
+# The declared vocabulary from docs/TERMS.md — one meaning per term, one term
+# per meaning. Terminology drift is the cheapest documentation defect to prevent
+# and the most expensive to fix later, because every page has to change at once.
+extends: substitution
+message: "Use '%s', not '%s' — see docs/TERMS.md."
+level: error
+ignorecase: true
+swap:
+  # Product and deployment
+  on-prem: self-hosted
+  on-premise: self-hosted
+  sysadmin: operator
+  self-hoster: operator
+  # Trading domain
+  PnL: P&L
+  P/L: P&L
+  bring-your-own-key: BYOK
+  # Formatting
+  please run: run

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -73,15 +73,41 @@ function collectUnwrittenSlugs(dir = CONTENT_DIR) {
 
 const UNWRITTEN = collectUnwrittenSlugs();
 
+/**
+ * The version these docs describe, read from the api package — the same field
+ * `make release` bumps, so the banner follows a release with nothing to remember.
+ *
+ * Injected as a Vite define rather than read inside the component: a component's
+ * `import.meta.url` points at its BUNDLED location during the build, so a
+ * relative path out to apps/api resolves somewhere that does not exist
+ * (measured: it looked for apps/docs/api/package.json). Resolving here, where
+ * the config file's own URL is stable, avoids that entirely.
+ */
+const APP_VERSION = JSON.parse(
+  readFileSync(fileURLToPath(new URL('../api/package.json', import.meta.url)), 'utf8'),
+).version;
+
+
 export default defineConfig({
   site: 'https://docs.tradr.cloud',
   output: 'static',
+  vite: {
+    define: {
+      __TRADR_VERSION__: JSON.stringify(APP_VERSION),
+    },
+  },
   integrations: [
     starlight({
       title: 'Tradr docs',
       description:
         'Documentation for Tradr — the open-source trading journal with an AI advisor. User guide for the hosted app plus self-hosting and development guides.',
       pagefind: true,
+      // Says which version these pages describe, on every page. Starlight 0.41
+      // has no site-wide banner option, so this overrides the per-page one —
+      // see the component for why.
+      components: {
+        Banner: './src/components/VersionBanner.astro',
+      },
       // Excludes the generated API operation pages from the search index — see
       // the file for why. The API overview page stays indexed.
       routeMiddleware: './src/routeData.ts',

--- a/apps/docs/src/components/VersionBanner.astro
+++ b/apps/docs/src/components/VersionBanner.astro
@@ -1,0 +1,46 @@
+---
+// Says which version of Tradr these pages describe.
+//
+// There is ONE copy of the docs and it tracks `main`, so a reader on an older
+// release has no way to tell what these pages assume. Versioned documentation is
+// a real cost — a tree per release, and every fix backported by hand — and the
+// decision was to defer it. This makes that decision VISIBLE instead of leaving
+// the reader to discover it by following a step that does not exist in their
+// version.
+//
+// This overrides Starlight's `Banner`, which renders only when a page sets
+// `banner` in its frontmatter. Starlight 0.41 has no site-wide banner option
+// (a top-level `banner:` key fails config validation with "Unrecognized key"),
+// and putting it in 30 files' frontmatter would drift the moment one was added.
+// Overriding the component puts it on every page from one place.
+//
+// The version comes from apps/api/package.json — which `make release` bumps, so
+// the banner follows a release without anyone remembering it — injected as a
+// Vite define by astro.config.mjs. Reading it here with a relative path does NOT
+// work: a component's `import.meta.url` points at its bundled location during
+// the build, so the path resolves somewhere that does not exist.
+declare const __TRADR_VERSION__: string;
+const version = __TRADR_VERSION__;
+---
+
+<div class="version-banner">
+  These docs describe Tradr <strong>v{version}</strong>. Running an older release? Check the
+  <a href="https://github.com/madmatt112/tradr/releases">release notes</a> for what changed.
+</div>
+
+<style>
+  .version-banner {
+    padding: 0.5rem var(--sl-nav-pad-x, 1rem);
+    background-color: var(--sl-color-bg-nav);
+    border-bottom: 1px solid var(--sl-color-hairline-shade);
+    color: var(--sl-color-gray-2);
+    font-size: var(--sl-text-xs);
+    line-height: 1.5;
+    text-align: center;
+    text-wrap: balance;
+  }
+
+  .version-banner a {
+    color: var(--sl-color-text-accent);
+  }
+</style>

--- a/apps/docs/src/content/docs/self-hosting/upgrades.mdx
+++ b/apps/docs/src/content/docs/self-hosting/upgrades.mdx
@@ -32,8 +32,8 @@ curl -fsS http://localhost:8080/api/health
 **Expected result:** `{"status":"ok","version":"v0.5.4"}` on a pinned release.
 
 The release workflow bakes the version into the api image, and `/api/health`
-reports it. A locally built image has no version to report, so the field is
-omitted and you get `{"status":"ok"}` — check out a release tag if you want a
+reports it. A locally built image has no version to report. The field is
+then omitted and you get `{"status":"ok"}`. Check out a release tag if you want a
 version you can name.
 
 Whichever image you run, `docker compose ps` shows the tag it came from:
@@ -172,7 +172,7 @@ curl -fsS http://localhost:8080/api/health
 ```
 
 **Expected result:** `{"status":"ok","version":"v0.5.4"}`, naming the version you
-just moved to. A `503` with `{"status":"error"}` means the api is up but cannot
+moved to. A `503` with `{"status":"error"}` means the api is up but cannot
 reach the database.
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Tradr in-repo documentation
 
-References that live with the code, so a change to how Tradr is built, configured,
-or operated lands in the same pull request as the change itself.
+References that live with the code. A change to how Tradr is built, configured, or
+operated lands in the same pull request as the change itself.
 
 The polished, task-oriented documentation is on the docs site:
 **[User guide](https://docs.tradr.cloud/user-guide/getting-started/)** ·
@@ -39,3 +39,25 @@ and the [self-hosting guide](https://docs.tradr.cloud/self-hosting/docker-compos
   it rather than copying it.
 - **One home per topic.** If something is already documented on the docs site or in
   `.env.example`, link to it instead of writing a second copy that will drift.
+
+## What the docs deliberately do not have
+
+Recorded so these read as decisions rather than oversights.
+
+**Versioned documentation.** There is one copy and it tracks `main`. A tree per release
+means backporting every fix by hand, which is not affordable at this size. Instead every
+page carries a banner naming the version it describes, generated from `apps/api`'s
+version so it follows a release automatically.
+
+**Translations.** One language, deliberately. Starlight makes i18n easy, which is the
+trap — sixteen pages in one language beats sixteen stubs in four.
+
+**Docs analytics.** None. The product's analytics are opt-in and off by default
+([`analytics.md`](analytics.md)). Instrumenting an app someone signed into is one
+decision; turning the documentation into a surface that reports on its readers is
+another. That has a practical consequence worth stating plainly: **page priority here is
+judgement, not traffic data.** Anyone claiming otherwise is guessing.
+
+**Style enforcement over old pages.** Vale runs on the files a pull request changes, not
+the whole tree. [`STYLE.md`](STYLE.md) says not to retrofit, and a whole-tree run reports
+117 findings — almost all of it prose written before the guide existed.


### PR DESCRIPTION
R23 and the style gate — the last items on the alignment plan.

## Version banner

There is one copy of the docs and it tracks `main`, so a reader on an older release had no way to tell what these pages assume. Every page now says which version it describes, read from `apps/api`'s `package.json` — the field `make release` bumps — so it follows a release with nothing to remember.

Two things that did not work, recorded in the code so nobody repeats them:

- **Starlight 0.41 has no site-wide banner.** A top-level `banner:` key fails config validation with `Unrecognized key: "banner"`. It is a per-page frontmatter option, so this overrides the `Banner` component instead — putting it in 30 files' frontmatter would drift the moment one was added.
- **A component's `import.meta.url` points at its *bundled* location** during the build. Reading a relative path out to `apps/api` from inside the component looked for `apps/docs/api/package.json` and failed the build. The version arrives as a Vite define from the config, where the URL is stable.

Verified rendering `v0.5.4` on **all 127 built pages**.

## Vale

Enforces the mechanical parts of `STYLE.md`: the banned words, the declared vocabulary in `TERMS.md`, and the sentence-length cap.

**Scoped to the files a PR changes.** `STYLE.md` says:

> Do not retrofit. The best existing pages were written before this guide and are better than a mechanical rewrite would make them.

A whole-tree run reports **117 findings across 40 files**, almost all prose written before the guide existed. Gating on that would demand exactly the retrofit the guide forbids. Linting the diff applies the rule to new and revised content and nothing else.

Advisory for now (`continue-on-error`), matching how the security scanners were introduced here. The path to making it required is in the workflow header.

Vale's MDX parser cannot read Starlight MDX — it stops at `Unexpected closing slash "/" in tag` and lints nothing — so `.mdx` is mapped to markdown.

### It found things in my own writing

On `upgrades.mdx`: a `just` and a 27-word sentence. Both fixed here. The seven pages written across this programme now pass clean, which is the check that the rules are calibrated rather than merely present.

## R23's remaining items, decided rather than skipped

Written down in `docs/README.md` under "What the docs deliberately do not have":

- **No versioned trees** — a tree per release means backporting every fix by hand. The banner is the mitigation.
- **No translations** — Starlight makes i18n easy, which is the trap.
- **No docs analytics** — instrumenting an app someone signed into is one decision; turning the documentation into a surface that reports on its readers is another. With the consequence stated plainly: **page priority here is judgement, not traffic data.**

Already done elsewhere: the PR template carries its `STYLE.md` line, and search weighting was handled by the route middleware in the migration.

## Verified

Docs build green, links validator passes, `check-types` 0 errors, `pnpm lint` clean, and the R16 generated pages regenerate byte-identical so the drift gate stays clean. The CI step was simulated locally against this branch's changed files.