### PR TITLE
feat(telemetry): stamp deployment environment on PostHog events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -326,12 +326,20 @@ FEATURE_GATING_ADVISOR_TURNS_PER_MONTH=200
 # PostHog ingestion host. Optional (default https://us.i.posthog.com); '' is
 # read as the default (does not need a key set to be valid).
 # POSTHOG_HOST=https://us.i.posthog.com
+# Deployment label stamped on every backend event/person as an `environment`
+# property. Optional — absent ⇒ events are unstamped, which is the right default
+# for a single deployment. Set it only if you run more than one (e.g. a staging
+# copy) and want to tell them apart within one PostHog project.
+# POSTHOG_ENVIRONMENT=production
 #
 # --- Frontend (web container; read by the nginx entrypoint into /config.js) ---
 # PostHog browser project key. Absent ⇒ frontend PostHog OFF. Optional.
 # POSTHOG_PUBLIC_KEY=
 # PostHog browser ingestion host. Optional (default https://us.i.posthog.com).
 # POSTHOG_PUBLIC_HOST=https://us.i.posthog.com
+# Deployment label for frontend events — the browser-side mirror of
+# POSTHOG_ENVIRONMENT. Optional; absent ⇒ events are unstamped.
+# POSTHOG_PUBLIC_ENVIRONMENT=production
 
 # ─── Hosted platform (api container) ─────────────────────────────────────────
 # ALL optional — SELF-HOSTERS LEAVE EVERYTHING BELOW UNSET. Each capability is a

--- a/apps/api/src/lib/config.ts
+++ b/apps/api/src/lib/config.ts
@@ -170,6 +170,13 @@ export const envSchema = z.object({
     (v) => (v === '' ? undefined : v),
     z.string().url().default('https://us.i.posthog.com'),
   ),
+  // Deployment label stamped onto every captured event/person as an
+  // `environment` property (e.g. 'production', 'staging'). Plain optional string
+  // (POSTHOG_API_KEY idiom) — unset/'' means the property is simply ABSENT, which
+  // is the correct self-host default: a self-hoster running one deployment has no
+  // environments to tell apart. Deliberately NOT derived from NODE_ENV, which is
+  // 'production' on every deployed tier and so cannot distinguish them.
+  POSTHOG_ENVIRONMENT: z.string().optional(),
   // ─── Hosted platform (REQ-12.1) ───────────────────────────────────────────
   // ALL optional — every capability is a no-op when unconfigured (REQ-1 self-host
   // parity). With none of these set the system behaves EXACTLY as today: advisor

--- a/apps/api/src/lib/posthog.test.ts
+++ b/apps/api/src/lib/posthog.test.ts
@@ -11,7 +11,12 @@ const h = vi.hoisted(() => {
   const PostHogCtor = vi.fn(() => ({ capture, identify, captureException, shutdown }));
   const isPostHogConfigured = vi.fn();
   const logTelemetryFailureOnce = vi.fn();
-  const config = { POSTHOG_API_KEY: 'phc_test123', POSTHOG_HOST: 'https://us.i.posthog.com' };
+  const config = {
+    POSTHOG_API_KEY: 'phc_test123',
+    POSTHOG_HOST: 'https://us.i.posthog.com',
+    // Unset by default — the self-host shape every other test asserts against.
+    POSTHOG_ENVIRONMENT: undefined as string | undefined,
+  };
   return {
     capture,
     identify,
@@ -38,6 +43,7 @@ async function load() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  h.config.POSTHOG_ENVIRONMENT = undefined;
 });
 
 describe('initPostHog', () => {
@@ -222,6 +228,87 @@ describe('captureServerException', () => {
 
     expect(() => captureServerException(new Error('x'), 'user-3')).not.toThrow();
     expect(h.logTelemetryFailureOnce).toHaveBeenCalledWith('posthog', expect.any(Error));
+  });
+});
+
+describe('POSTHOG_ENVIRONMENT stamp', () => {
+  it('unset: adds no environment property to a captured event (self-host default)', async () => {
+    h.isPostHogConfigured.mockReturnValue(true);
+    const { initPostHog, captureServerEvent } = await load();
+
+    initPostHog();
+    captureServerEvent('position_created', { distinctId: 'user-1' });
+
+    const props = h.capture.mock.calls[0][0].properties as Record<string, unknown>;
+    expect(props).not.toHaveProperty('environment');
+  });
+
+  it('set: stamps environment onto a captured event alongside scrubbed properties', async () => {
+    h.config.POSTHOG_ENVIRONMENT = 'staging';
+    h.isPostHogConfigured.mockReturnValue(true);
+    const { initPostHog, captureServerEvent } = await load();
+
+    initPostHog();
+    captureServerEvent('position_created', {
+      distinctId: 'user-1',
+      properties: { assetType: 'stock' },
+    });
+
+    expect(h.capture).toHaveBeenCalledWith({
+      distinctId: 'user-1',
+      event: 'position_created',
+      properties: { assetType: 'stock', environment: 'staging' },
+    });
+  });
+
+  it("set: the deploy's label wins over a caller-supplied environment property", async () => {
+    h.config.POSTHOG_ENVIRONMENT = 'production';
+    h.isPostHogConfigured.mockReturnValue(true);
+    const { initPostHog, captureServerEvent } = await load();
+
+    initPostHog();
+    captureServerEvent('position_created', {
+      distinctId: 'user-1',
+      properties: { environment: 'not-the-deploy-label' },
+    });
+
+    const props = h.capture.mock.calls[0][0].properties as Record<string, unknown>;
+    expect(props.environment).toBe('production');
+  });
+
+  it('set: stamps environment onto person properties via $set', async () => {
+    h.config.POSTHOG_ENVIRONMENT = 'staging';
+    h.isPostHogConfigured.mockReturnValue(true);
+    const { initPostHog, identifyServerUser } = await load();
+
+    initPostHog();
+    identifyServerUser('user-1', { email_verified: true });
+
+    expect(h.identify).toHaveBeenCalledWith({
+      distinctId: 'user-1',
+      properties: { $set: { email_verified: true, environment: 'staging' } },
+    });
+  });
+
+  it('set: passes environment as captureException additional properties', async () => {
+    h.config.POSTHOG_ENVIRONMENT = 'staging';
+    h.isPostHogConfigured.mockReturnValue(true);
+    const { initPostHog, captureServerException } = await load();
+
+    initPostHog();
+    captureServerException(new Error('boom'), 'user-1');
+
+    expect(h.captureException.mock.calls[0][2]).toEqual({ environment: 'staging' });
+  });
+
+  it('unset: passes undefined additional properties to captureException', async () => {
+    h.isPostHogConfigured.mockReturnValue(true);
+    const { initPostHog, captureServerException } = await load();
+
+    initPostHog();
+    captureServerException(new Error('boom'), 'user-1');
+
+    expect(h.captureException.mock.calls[0][2]).toBeUndefined();
   });
 });
 

--- a/apps/api/src/lib/posthog.ts
+++ b/apps/api/src/lib/posthog.ts
@@ -39,12 +39,35 @@ export function initPostHog(): void {
 }
 
 /**
+ * The deployment label as a property bag, or undefined when POSTHOG_ENVIRONMENT
+ * is unset/'' — the self-host default, where there is one deployment and nothing
+ * to tell apart. Stamped at every capture exit (events, person properties,
+ * exceptions) so one project can be read per-environment, and so a mis-pointed
+ * key is VISIBLE rather than silently blending two deployments' data.
+ */
+function environmentProperties(): { environment: string } | undefined {
+  const environment = config.POSTHOG_ENVIRONMENT;
+  return environment ? { environment } : undefined;
+}
+
+/**
+ * Merge the deployment label into an outbound property bag. Spread LAST on
+ * purpose: a caller's own `environment` property is overwritten, so the label is
+ * always the deploy's, never a caller's. Returns the input untouched when
+ * unconfigured — no empty-object churn on the self-host path.
+ */
+function withEnvironment(properties: Record<string, unknown>): Record<string, unknown> {
+  const stamp = environmentProperties();
+  return stamp ? { ...properties, ...stamp } : properties;
+}
+
+/**
  * Capture a named backend business event, fire-and-forget. No-op when the
  * singleton is unset (unconfigured, or initPostHog() not run — e.g. unit tests).
  * `distinctId` is the opaque DB userId surrogate (never email). Properties pass
  * through scrubDeep — the REQ-8.5 value step at the backend capture boundary —
- * and a capture throw is swallowed via the warn-storm guard so it never
- * propagates (REQ-1.4).
+ * then pick up the deployment label — and a capture throw is swallowed via the
+ * warn-storm guard so it never propagates (REQ-1.4).
  */
 export function captureServerEvent(
   event: string,
@@ -55,7 +78,7 @@ export function captureServerEvent(
     client.capture({
       distinctId: opts.distinctId,
       event,
-      properties: scrubDeep(opts.properties ?? {}) as Record<string, unknown>,
+      properties: withEnvironment(scrubDeep(opts.properties ?? {}) as Record<string, unknown>),
     });
   } catch (err) {
     logTelemetryFailureOnce('posthog', err);
@@ -73,7 +96,7 @@ export function identifyServerUser(
 ): void {
   if (!client) return;
   try {
-    client.identify({ distinctId, properties: { $set: properties } });
+    client.identify({ distinctId, properties: { $set: withEnvironment(properties) } });
   } catch (err) {
     logTelemetryFailureOnce('posthog', err);
   }
@@ -107,7 +130,7 @@ function redactError(err: unknown): unknown {
 export function captureServerException(err: unknown, distinctId?: string): void {
   if (!client) return;
   try {
-    client.captureException(redactError(err), distinctId);
+    client.captureException(redactError(err), distinctId, environmentProperties());
   } catch (captureErr) {
     logTelemetryFailureOnce('posthog', captureErr);
   }

--- a/apps/docs/src/content/docs/self-hosting/reference/env-vars.mdx
+++ b/apps/docs/src/content/docs/self-hosting/reference/env-vars.mdx
@@ -7,7 +7,7 @@ description: Every environment variable Tradr reads, its default, and what it do
     Source: .env.example · Generator: apps/docs/scripts/gen-env-vars.mjs
     Run `pnpm --filter @tradr/docs env-vars:generate` after changing .env.example. */}
 
-Tradr reads **78 environment variables**, of which **3 are required** —
+Tradr reads **80 environment variables**, of which **3 are required** —
 everything else has a working default or turns a feature off when unset.
 
 This page is generated from [`.env.example`](https://github.com/madmatt112/tradr/blob/main/.env.example),
@@ -33,7 +33,7 @@ original `ENCRYPTION_KEY` nothing can decrypt them. See
 
 ## Reading the tables
 
-Of the 78 variables, **50 ship unset** — either commented out in the
+Of the 80 variables, **52 ship unset** — either commented out in the
 template or present with an empty value. An unset optional variable means the feature
 is **absent, not broken**: nothing logs an error and no outbound call is made.
 
@@ -176,8 +176,10 @@ is **absent, not broken**: nothing logs an error and no outbound call is made.
 | --- | --- | --- |
 | `POSTHOG_API_KEY` | Optional | ALL four vars are OPTIONAL. Each PostHog surface is ABSENT when its key is unset — a fresh clone + `docker compose up` runs identically with none set (no SDK loaded, no outbound calls, no errors). Configure only what you want. PRIVACY POSTURE (what is / isn't sent): `• PostHog (frontend) uses MEMORY-ONLY persistence (cookieless); autocapture, && session replay, and surveys are DISABLED in the SDK, and client IP is && neutralised in-SDK ($ip=null, $geoip_* dropped). Pageviews ARE captured, && but MASKED: only the matched route PATTERN (e.g. /_auth/positions/ && $positionId) is sent — never the resolved id, query string, or referrer. && OPERATOR ACTION: also enable PostHog project-side "Discard client IP data" && for defence in depth. && • PostHog (backend) sends deliberate, non-financial product events keyed by an && OPAQUE user surrogate — no PII, no trade data, in any payload. Event values && pass a redaction guard that masks secrets/emails/upload-filenames.` Structured logs go to stdout (captured by your container orchestrator); Tradr ships no logs to a third-party sink of its own. SHUTDOWN FLUSH: on SIGTERM the PostHog flush is bounded at 3s, comfortably under Docker's default ~10s SIGTERM→SIGKILL grace. If you need longer to drain, raise `stop_grace_period` for the api service in a compose override. --- Backend (api container) --- PostHog project API key. Absent ⇒ backend PostHog surface OFF. Optional. |
 | `POSTHOG_HOST` | Optional | PostHog ingestion host. Optional (default https://us.i.posthog.com); '' is read as the default (does not need a key set to be valid). |
+| `POSTHOG_ENVIRONMENT` | Optional | Deployment label stamped on every backend event/person as an `environment` property. Optional — absent ⇒ events are unstamped, which is the right default for a single deployment. Set it only if you run more than one (e.g. a staging copy) and want to tell them apart within one PostHog project. |
 | `POSTHOG_PUBLIC_KEY` | Optional | --- Frontend (web container; read by the nginx entrypoint into /config.js) --- PostHog browser project key. Absent ⇒ frontend PostHog OFF. Optional. |
 | `POSTHOG_PUBLIC_HOST` | Optional | PostHog browser ingestion host. Optional (default https://us.i.posthog.com). |
+| `POSTHOG_PUBLIC_ENVIRONMENT` | Optional | Deployment label for frontend events — the browser-side mirror of POSTHOG_ENVIRONMENT. Optional; absent ⇒ events are unstamped. |
 
 ## Hosted platform (api container)
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -5,6 +5,7 @@ declare global {
       advisorImageMaxBytes?: number; // per-image encoded-byte cap for the client pre-upload check (hosted-platform REQ-4.6); always emitted by the runtime-config seam
       posthogPublicKey?: string; // publishable phc_… project key
       posthogPublicHost?: string; // PostHog ingestion host
+      posthogPublicEnvironment?: string; // deployment label stamped on every event ('production', 'staging'); absent ⇒ unstamped
       appVersion?: string; // deploy-stamped version badge (prod "v1.2.3", staging "v1.2.3-abc1234"); absent ⇒ local dev
     };
   }

--- a/apps/web/src/lib/telemetry/config.test.ts
+++ b/apps/web/src/lib/telemetry/config.test.ts
@@ -28,11 +28,13 @@ describe('getTelemetryConfig', () => {
         apiBaseUrl: 'https://api.example.com',
         posthogPublicKey: 'phc_abc123',
         posthogPublicHost: 'https://us.i.posthog.com',
+        posthogPublicEnvironment: 'production',
       },
     });
     expect(getTelemetryConfig()).toEqual({
       posthogPublicKey: 'phc_abc123',
       posthogPublicHost: 'https://us.i.posthog.com',
+      posthogPublicEnvironment: 'production',
     });
   });
 

--- a/apps/web/src/lib/telemetry/config.ts
+++ b/apps/web/src/lib/telemetry/config.ts
@@ -8,6 +8,7 @@
 export interface TelemetryConfig {
   posthogPublicKey?: string;
   posthogPublicHost?: string;
+  posthogPublicEnvironment?: string;
 }
 
 /**
@@ -22,6 +23,7 @@ export function getTelemetryConfig(): TelemetryConfig {
   return {
     posthogPublicKey: cfg.posthogPublicKey,
     posthogPublicHost: cfg.posthogPublicHost,
+    posthogPublicEnvironment: cfg.posthogPublicEnvironment,
   };
 }
 

--- a/apps/web/src/lib/telemetry/posthog.test.ts
+++ b/apps/web/src/lib/telemetry/posthog.test.ts
@@ -8,14 +8,14 @@ import posthogSource from './posthog.ts?raw';
 
 // Stub the dynamically-imported posthog-js to a minimal init/capture surface.
 // vi.mock is hoisted, so the spies are created with vi.hoisted.
-const { initSpy, captureSpy, startExceptionAutocaptureSpy, captureExceptionSpy } = vi.hoisted(
-  () => ({
+const { initSpy, captureSpy, startExceptionAutocaptureSpy, captureExceptionSpy, registerSpy } =
+  vi.hoisted(() => ({
     initSpy: vi.fn(),
     captureSpy: vi.fn(),
     startExceptionAutocaptureSpy: vi.fn(),
     captureExceptionSpy: vi.fn(),
-  }),
-);
+    registerSpy: vi.fn(),
+  }));
 
 vi.mock('posthog-js', () => ({
   default: {
@@ -23,6 +23,7 @@ vi.mock('posthog-js', () => ({
     capture: captureSpy,
     startExceptionAutocapture: startExceptionAutocaptureSpy,
     captureException: captureExceptionSpy,
+    register: registerSpy,
   },
 }));
 
@@ -60,6 +61,7 @@ beforeEach(() => {
   captureSpy.mockClear();
   startExceptionAutocaptureSpy.mockClear();
   captureExceptionSpy.mockClear();
+  registerSpy.mockClear();
 });
 
 afterEach(() => {
@@ -111,6 +113,44 @@ describe('initPostHogClient', () => {
     await initPostHogClient(makeStubRouter([{ routeId: PATTERN }]));
 
     expect(initSpy.mock.calls[0][1].api_host).toBe('https://us.i.posthog.com');
+  });
+
+  it('registers environment as a super property when posthogPublicEnvironment is set', async () => {
+    window.__TRADR_CONFIG__ = {
+      posthogPublicKey: 'phc_test',
+      posthogPublicEnvironment: 'staging',
+    };
+    const { initPostHogClient } = await import('./posthog');
+
+    await initPostHogClient(makeStubRouter([{ routeId: PATTERN }]));
+
+    expect(registerSpy).toHaveBeenCalledTimes(1);
+    expect(registerSpy).toHaveBeenCalledWith({ environment: 'staging' });
+  });
+
+  it('registers nothing when posthogPublicEnvironment is absent (self-host default)', async () => {
+    window.__TRADR_CONFIG__ = { posthogPublicKey: 'phc_test' };
+    const { initPostHogClient } = await import('./posthog');
+
+    await initPostHogClient(makeStubRouter([{ routeId: PATTERN }]));
+
+    expect(registerSpy).not.toHaveBeenCalled();
+  });
+
+  it('registers before the entry pageview, so the pageview carries the label', async () => {
+    window.__TRADR_CONFIG__ = {
+      posthogPublicKey: 'phc_test',
+      posthogPublicEnvironment: 'production',
+    };
+    const { initPostHogClient } = await import('./posthog');
+
+    await initPostHogClient(makeStubRouter([{ routeId: PATTERN }]));
+
+    expect(registerSpy).toHaveBeenCalled();
+    expect(captureSpy).toHaveBeenCalledWith('$pageview');
+    expect(registerSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      captureSpy.mock.invocationCallOrder[0],
+    );
   });
 });
 

--- a/apps/web/src/lib/telemetry/posthog.ts
+++ b/apps/web/src/lib/telemetry/posthog.ts
@@ -143,6 +143,18 @@ export async function initPostHogClient(router: AnyRouter): Promise<void> {
   });
   posthog = ph;
 
+  // Stamp the deployment label ('production', 'staging') onto EVERY event as a
+  // super property — including the ones we never call capture() for ourselves:
+  // autocaptured $exception and the masked $pageview below. register() runs
+  // before before_send, so scrubEvent sees the property and passes it through
+  // untouched (it only rewrites the URL/geoip/exception keys). Skipped when the
+  // deploy did not set posthogPublicEnvironment — the self-host default, where
+  // there is one deployment and nothing to tell apart. Super properties live in
+  // the memory-only persistence store (REQ-3.7), so this stays cookieless.
+  if (cfg.posthogPublicEnvironment) {
+    ph.register({ environment: cfg.posthogPublicEnvironment });
+  }
+
   // Enable client-side exception autocapture: window errors + unhandled promise
   // rejections. Console errors stay OFF — a console.error is not an exception and
   // would be noise. Every $exception event routes through before_send: scrubEvent,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,7 @@ services:
       # z.preprocess('' → undefined, …url().default()) maps '' to the default.
       POSTHOG_API_KEY: ${POSTHOG_API_KEY:-}
       POSTHOG_HOST: ${POSTHOG_HOST:-}
+      POSTHOG_ENVIRONMENT: ${POSTHOG_ENVIRONMENT:-}
       # Hosted platform (api container). ALL optional — self-host leaves them unset
       # and behaves exactly as today (REQ-1 parity). Bare ${VAR:-} is SAFE for the
       # URL/preprocess vars (REDIS_URL / DIRECT_DATABASE_URL / OBJECT_STORAGE_ENDPOINT:
@@ -169,6 +170,7 @@ services:
       # NGINX_ENVSUBST_FILTER change is needed (it governs *.template, not config.js).
       POSTHOG_PUBLIC_KEY: ${POSTHOG_PUBLIC_KEY:-}
       POSTHOG_PUBLIC_HOST: ${POSTHOG_PUBLIC_HOST:-}
+      POSTHOG_PUBLIC_ENVIRONMENT: ${POSTHOG_PUBLIC_ENVIRONMENT:-}
     networks:
       - tradr
     restart: unless-stopped

--- a/docker/docker-entrypoint.d/10-runtime-config.sh
+++ b/docker/docker-entrypoint.d/10-runtime-config.sh
@@ -9,6 +9,8 @@
 #   API_BASE_URL         -> apiBaseUrl
 #   POSTHOG_PUBLIC_KEY   -> posthogPublicKey
 #   POSTHOG_PUBLIC_HOST  -> posthogPublicHost
+#   POSTHOG_PUBLIC_ENVIRONMENT -> posthogPublicEnvironment  (deployment label
+#     stamped on every frontend event; absent => events are unstamped)
 #   APP_VERSION          -> appVersion   (corner version badge; absent => the SPA shows "localdev")
 #
 # ONE deliberate exception to the absent-when-unset rule: advisorImageMaxBytes is
@@ -59,6 +61,7 @@ emit_num() {
 emit apiBaseUrl         "${API_BASE_URL:-}"
 emit posthogPublicKey   "${POSTHOG_PUBLIC_KEY:-}"
 emit posthogPublicHost  "${POSTHOG_PUBLIC_HOST:-}"
+emit posthogPublicEnvironment "${POSTHOG_PUBLIC_ENVIRONMENT:-}"
 emit appVersion         "${APP_VERSION:-}"
 
 # Always-on image byte cap: emit the operator override or the shared default.


### PR DESCRIPTION
Nothing in the codebase distinguished one deployment from another in PostHog. `NODE_ENV` is `production` on every deployed tier, so once events were ingested there was no way to tell which deployment produced them.

Adds an optional deployment label, stamped as an `environment` property on every captured event, person profile, and exception:

| Variable | Surface |
| --- | --- |
| `POSTHOG_ENVIRONMENT` | backend (api container) |
| `POSTHOG_PUBLIC_ENVIRONMENT` | frontend (web container → `config.js`) |

**Backend** stamps at the three capture exits (`captureServerEvent`, `identifyServerUser`, `captureServerException`) through a shared helper. The label is spread *last*, so a caller's own `environment` property can never shadow the deploy's.

**Frontend** registers a posthog-js super property at init. That covers the events we never call `capture()` for ourselves — autocaptured `$exception` and the masked `$pageview` — and needs no `before_send` change, since `scrubEvent` only rewrites the URL/geoip/exception keys. Super properties live in the memory-only persistence store, so this stays cookieless.

## Self-host parity

Unset yields an **absent** property, not an empty one. A self-hoster running a single deployment has nothing to tell apart and sees no behaviour change. The label is deliberately *not* derived from `NODE_ENV` — that value cannot distinguish deployed tiers.

## Verified

- `apps/api/src/lib/posthog.test.ts` — 22 pass, incl. absent-when-unset, `$set` stamping, `captureException` additional-properties, and the caller-override case
- `apps/web/src/lib/telemetry/` — 26 pass, incl. register-before-entry-pageview ordering
- Wider scoped suites: api `src/lib` 267 pass, web `src/lib` 81 pass, api config + self-host-parity + index 160 pass
- `check-types` clean, eslint clean
- Bundle gate green — **`entry chunk: no posthog-js markers`**, so the dynamic-import boundary is intact
- `10-runtime-config.sh` exercised directly: all-unset omits the field, set emits it, and the generated `config.js` parses as valid JS
