### PR TITLE
feat(accounts): add a default risk percentage per account

### DIFF
--- a/apps/api/src/db/migrations/0025_account_default_risk_percent.sql
+++ b/apps/api/src/db/migrations/0025_account_default_risk_percent.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "accounts" ADD COLUMN "default_risk_percent" numeric(5, 2);

--- a/apps/api/src/db/migrations/meta/0025_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0025_snapshot.json
@@ -1,0 +1,3423 @@
+{
+  "id": "6545c651-965a-49ae-873e-2b2ca4dd1ba5",
+  "prevId": "d987836c-738a-4f6a-ba36-34a6199d491e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.exchange_rates": {
+      "name": "exchange_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_currency": {
+          "name": "base_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_currency": {
+          "name": "quote_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(24, 12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exchange_rates_user_pair_date_unique": {
+          "name": "exchange_rates_user_pair_date_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "base_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exchange_rates_user_id_users_id_fk": {
+          "name": "exchange_rates_user_id_users_id_fk",
+          "tableFrom": "exchange_rates",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "exchange_rates_distinct_currencies_chk": {
+          "name": "exchange_rates_distinct_currencies_chk",
+          "value": "\"exchange_rates\".\"base_currency\" <> \"exchange_rates\".\"quote_currency\""
+        },
+        "exchange_rates_rate_positive_chk": {
+          "name": "exchange_rates_rate_positive_chk",
+          "value": "\"exchange_rates\".\"rate\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ledger_entries": {
+      "name": "ledger_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_id": {
+          "name": "position_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reverses_group_id": {
+          "name": "reverses_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ledger_user_id_idx": {
+          "name": "ledger_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_account_id_idx": {
+          "name": "ledger_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_user_account_occurred_pnl_idx": {
+          "name": "ledger_user_account_occurred_pnl_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"occurred_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ledger_entries\".\"entry_type\" IN ('position_pnl', 'position_pnl_reversal', 'balance_adjustment')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_user_account_direction_amount_pnl_idx": {
+          "name": "ledger_user_account_direction_amount_pnl_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ledger_entries\".\"entry_type\" IN ('position_pnl', 'position_pnl_reversal', 'balance_adjustment')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_reverses_group_id_idx": {
+          "name": "ledger_reverses_group_id_idx",
+          "columns": [
+            {
+              "expression": "reverses_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ledger_entries\".\"reverses_group_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ledger_entries_user_id_users_id_fk": {
+          "name": "ledger_entries_user_id_users_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ledger_entries_account_id_accounts_id_fk": {
+          "name": "ledger_entries_account_id_accounts_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "ledger_entries_position_id_positions_id_fk": {
+          "name": "ledger_entries_position_id_positions_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "positions",
+          "columnsFrom": ["position_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ledger_amount_nonneg_chk": {
+          "name": "ledger_amount_nonneg_chk",
+          "value": "\"ledger_entries\".\"amount\" >= 0"
+        },
+        "ledger_direction_chk": {
+          "name": "ledger_direction_chk",
+          "value": "\"ledger_entries\".\"direction\" IN ('credit', 'debit')"
+        },
+        "ledger_entry_type_chk": {
+          "name": "ledger_entry_type_chk",
+          "value": "\"ledger_entries\".\"entry_type\" IN ('position_pnl', 'position_pnl_reversal', 'balance_adjustment')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "brokerage_id": {
+          "name": "brokerage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_balance": {
+          "name": "starting_balance",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "default_risk_percent": {
+          "name": "default_risk_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_id_name_unique": {
+          "name": "accounts_user_id_name_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_brokerage_id_idx": {
+          "name": "accounts_brokerage_id_idx",
+          "columns": [
+            {
+              "expression": "brokerage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_brokerage_id_brokerages_id_fk": {
+          "name": "accounts_brokerage_id_brokerages_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "brokerages",
+          "columnsFrom": ["brokerage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_email": {
+          "name": "target_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_created_idx": {
+          "name": "admin_audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_actor_user_id_users_id_fk": {
+          "name": "admin_audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_users_id_fk": {
+          "name": "admin_audit_log_target_user_id_users_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["target_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "admin_audit_log_action_chk": {
+          "name": "admin_audit_log_action_chk",
+          "value": "\"admin_audit_log\".\"action\" IN ('admin_toggle')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.advisor_image_counters": {
+      "name": "advisor_image_counters",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_count": {
+          "name": "image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "advisor_image_counters_user_id_users_id_fk": {
+          "name": "advisor_image_counters_user_id_users_id_fk",
+          "tableFrom": "advisor_image_counters",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "advisor_image_counters_user_id_period_key_pk": {
+          "name": "advisor_image_counters_user_id_period_key_pk",
+          "columns": ["user_id", "period_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_turn_counters": {
+      "name": "advisor_turn_counters",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "allowance_turns": {
+          "name": "allowance_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "advisor_turn_counters_user_id_users_id_fk": {
+          "name": "advisor_turn_counters_user_id_users_id_fk",
+          "tableFrom": "advisor_turn_counters",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "advisor_turn_counters_user_id_period_key_pk": {
+          "name": "advisor_turn_counters_user_id_period_key_pk",
+          "columns": ["user_id", "period_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_conversations": {
+      "name": "advisor_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_conversations_user_updated_idx": {
+          "name": "advisor_conversations_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_conversations_user_id_users_id_fk": {
+          "name": "advisor_conversations_user_id_users_id_fk",
+          "tableFrom": "advisor_conversations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "advisor_conversations_persona_id_advisor_personas_id_fk": {
+          "name": "advisor_conversations_persona_id_advisor_personas_id_fk",
+          "tableFrom": "advisor_conversations",
+          "tableTo": "advisor_personas",
+          "columnsFrom": ["persona_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_messages": {
+      "name": "advisor_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_parts": {
+          "name": "content_parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_message_id": {
+          "name": "client_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_messages_conv_created_idx": {
+          "name": "advisor_messages_conv_created_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "advisor_messages_idem": {
+          "name": "advisor_messages_idem",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "role = 'user' AND client_message_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "advisor_messages_assistant_pair_uniq": {
+          "name": "advisor_messages_assistant_pair_uniq",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "role = 'assistant' AND client_message_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_messages_conversation_id_advisor_conversations_id_fk": {
+          "name": "advisor_messages_conversation_id_advisor_conversations_id_fk",
+          "tableFrom": "advisor_messages",
+          "tableTo": "advisor_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "advisor_messages_role_chk": {
+          "name": "advisor_messages_role_chk",
+          "value": "\"advisor_messages\".\"role\" IN ('user', 'assistant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.advisor_personas": {
+      "name": "advisor_personas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_personas_one_default_per_user": {
+          "name": "advisor_personas_one_default_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true AND user_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_personas_user_id_users_id_fk": {
+          "name": "advisor_personas_user_id_users_id_fk",
+          "tableFrom": "advisor_personas",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_provider_keys": {
+      "name": "advisor_provider_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hint_tail": {
+          "name": "key_hint_tail",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_provider_keys_user_provider_uniq": {
+          "name": "advisor_provider_keys_user_provider_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_provider_keys_user_id_users_id_fk": {
+          "name": "advisor_provider_keys_user_id_users_id_fk",
+          "tableFrom": "advisor_provider_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_summaries": {
+      "name": "advisor_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prose": {
+          "name": "prose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trade_data_figures": {
+          "name": "trade_data_figures",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered_through_message_id": {
+          "name": "covered_through_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered_through_created_at": {
+          "name": "covered_through_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_summaries_conversation_uniq": {
+          "name": "advisor_summaries_conversation_uniq",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_summaries_conversation_id_advisor_conversations_id_fk": {
+          "name": "advisor_summaries_conversation_id_advisor_conversations_id_fk",
+          "tableFrom": "advisor_summaries",
+          "tableTo": "advisor_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_api_keys": {
+      "name": "external_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hint_tail": {
+          "name": "key_hint_tail",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_api_keys_user_provider_uniq": {
+          "name": "external_api_keys_user_provider_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_api_keys_user_id_users_id_fk": {
+          "name": "external_api_keys_user_id_users_id_fk",
+          "tableFrom": "external_api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brokerages": {
+      "name": "brokerages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brokerages_user_id_idx": {
+          "name": "brokerages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brokerages_user_id_name_unique": {
+          "name": "brokerages_user_id_name_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"brokerages\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brokerages_system_name_unique": {
+          "name": "brokerages_system_name_unique",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"brokerages\".\"is_system\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brokerages_user_id_users_id_fk": {
+          "name": "brokerages_user_id_users_id_fk",
+          "tableFrom": "brokerages",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_schedules": {
+      "name": "fee_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "brokerage_id": {
+          "name": "brokerage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_per_share_commission": {
+          "name": "stock_per_share_commission",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "stock_min_per_fill": {
+          "name": "stock_min_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "stock_max_per_fill": {
+          "name": "stock_max_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_per_contract_commission": {
+          "name": "options_per_contract_commission",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_per_contract_exchange_fee": {
+          "name": "options_per_contract_exchange_fee",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_min_per_fill": {
+          "name": "options_min_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_max_per_fill": {
+          "name": "options_max_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_schedules_brokerage_id_brokerages_id_fk": {
+          "name": "fee_schedules_brokerage_id_brokerages_id_fk",
+          "tableFrom": "fee_schedules",
+          "tableTo": "brokerages",
+          "columnsFrom": ["brokerage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_schedules_brokerage_id_unique": {
+          "name": "fee_schedules_brokerage_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["brokerage_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.csv_import_counters": {
+      "name": "csv_import_counters",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "committed_count": {
+          "name": "committed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "csv_import_counters_user_id_users_id_fk": {
+          "name": "csv_import_counters_user_id_users_id_fk",
+          "tableFrom": "csv_import_counters",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.csv_import_staging": {
+      "name": "csv_import_staging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'staged'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committed_result": {
+          "name": "committed_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "csv_import_staging_one_active_per_user_idx": {
+          "name": "csv_import_staging_one_active_per_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"csv_import_staging\".\"status\" IN ('staged', 'committing')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "csv_import_staging_user_id_idx": {
+          "name": "csv_import_staging_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "csv_import_staging_expires_at_idx": {
+          "name": "csv_import_staging_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "csv_import_staging_user_id_users_id_fk": {
+          "name": "csv_import_staging_user_id_users_id_fk",
+          "tableFrom": "csv_import_staging",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "csv_import_staging_account_id_accounts_id_fk": {
+          "name": "csv_import_staging_account_id_accounts_id_fk",
+          "tableFrom": "csv_import_staging",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_layouts": {
+      "name": "dashboard_layouts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgets": {
+          "name": "widgets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_layouts_user_id_users_id_fk": {
+          "name": "dashboard_layouts_user_id_users_id_fk",
+          "tableFrom": "dashboard_layouts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_tokens": {
+      "name": "email_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_tokens_user_purpose_idx": {
+          "name": "email_tokens_user_purpose_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_tokens_one_live_per_user_purpose": {
+          "name": "email_tokens_one_live_per_user_purpose",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "consumed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_tokens_user_id_users_id_fk": {
+          "name": "email_tokens_user_id_users_id_fk",
+          "tableFrom": "email_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_tokens_token_hash_unique": {
+          "name": "email_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_tokens_purpose_chk": {
+          "name": "email_tokens_purpose_chk",
+          "value": "\"email_tokens\".\"purpose\" IN ('password_reset','email_verification')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.expenses": {
+      "name": "expenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "expenses_user_id_idx": {
+          "name": "expenses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "expenses_user_occurred_idx": {
+          "name": "expenses_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"occurred_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "expenses_user_id_users_id_fk": {
+          "name": "expenses_user_id_users_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "expenses_amount_positive_chk": {
+          "name": "expenses_amount_positive_chk",
+          "value": "\"expenses\".\"amount\" > 0"
+        },
+        "expenses_category_chk": {
+          "name": "expenses_category_chk",
+          "value": "category IN ('data_subscription', 'platform_fee', 'software', 'education', 'hardware', 'other')"
+        },
+        "expenses_currency_chk": {
+          "name": "expenses_currency_chk",
+          "value": "currency IN ('USD', 'EUR', 'GBP', 'CAD', 'AUD', 'JPY', 'CHF', 'HKD', 'SGD', 'NZD', 'SEK', 'NOK', 'DKK', 'MXN', 'BRL', 'INR', 'KRW', 'TWD', 'ZAR')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public._post_migrations_journal": {
+      "name": "_post_migrations_journal",
+      "schema": "",
+      "columns": {
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fills": {
+      "name": "fills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "position_id": {
+          "name": "position_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fees": {
+          "name": "fees",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filled_at": {
+          "name": "filled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fills_position_id_idx": {
+          "name": "fills_position_id_idx",
+          "columns": [
+            {
+              "expression": "position_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fills_position_id_positions_id_fk": {
+          "name": "fills_position_id_positions_id_fk",
+          "tableFrom": "fills",
+          "tableTo": "positions",
+          "columnsFrom": ["position_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.positions": {
+      "name": "positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_price": {
+          "name": "target_price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_loss": {
+          "name": "stop_loss",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_flat_at": {
+          "name": "last_flat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_flat_net_pnl": {
+          "name": "last_flat_net_pnl",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "positions_user_id_idx": {
+          "name": "positions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "positions_account_id_idx": {
+          "name": "positions_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "positions_user_id_status_updated_at_idx": {
+          "name": "positions_user_id_status_updated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "positions_user_status_closed_at_idx": {
+          "name": "positions_user_status_closed_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "positions_user_id_users_id_fk": {
+          "name": "positions_user_id_users_id_fk",
+          "tableFrom": "positions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "positions_account_id_accounts_id_fk": {
+          "name": "positions_account_id_accounts_id_fk",
+          "tableFrom": "positions",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "positions_closed_at_when_closed_chk": {
+          "name": "positions_closed_at_when_closed_chk",
+          "value": "\"positions\".\"status\" <> 'closed' OR \"positions\".\"closed_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.symbol_sync_state": {
+      "name": "symbol_sync_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "smallint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncing": {
+          "name": "syncing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "syncing_started_at": {
+          "name": "syncing_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "symbol_count": {
+          "name": "symbol_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "symbol_sync_state_singleton": {
+          "name": "symbol_sync_state_singleton",
+          "value": "\"symbol_sync_state\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.symbols": {
+      "name": "symbols",
+      "schema": "",
+      "columns": {
+        "ticker": {
+          "name": "ticker",
+          "type": "varchar(16)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exchange": {
+          "name": "exchange",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cik": {
+          "name": "cik",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "symbols_ticker_prefix_idx": {
+          "name": "symbols_ticker_prefix_idx",
+          "columns": [
+            {
+              "expression": "ticker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "varchar_pattern_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed": {
+          "name": "last_accessed",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_currency": {
+          "name": "display_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_jurisdiction": {
+          "name": "tax_jurisdiction",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "buying_power_basis": {
+          "name": "buying_power_basis",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cash'"
+        },
+        "advisor_default_persona_id": {
+          "name": "advisor_default_persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advisor_trade_data_consent": {
+          "name": "advisor_trade_data_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "writable_account_id": {
+          "name": "writable_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changelog_viewed_at": {
+          "name": "changelog_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_tax_jurisdiction_chk": {
+          "name": "users_tax_jurisdiction_chk",
+          "value": "\"users\".\"tax_jurisdiction\" IS NULL OR \"users\".\"tax_jurisdiction\" IN ('US', 'CA', 'other')"
+        },
+        "users_theme_chk": {
+          "name": "users_theme_chk",
+          "value": "\"users\".\"theme\" IN ('light','dark','system')"
+        },
+        "users_buying_power_basis_chk": {
+          "name": "users_buying_power_basis_chk",
+          "value": "\"users\".\"buying_power_basis\" IN ('cash','balance')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_customers": {
+      "name": "billing_customers",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_customers_user_id_users_id_fk": {
+          "name": "billing_customers_user_id_users_id_fk",
+          "tableFrom": "billing_customers",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_customers_stripe_customer_id_unique": {
+          "name": "billing_customers_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_customer_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_unit_amount": {
+          "name": "price_unit_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_currency": {
+          "name": "price_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_created_at": {
+          "name": "stripe_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entered_past_due_at": {
+          "name": "entered_past_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_created": {
+          "name": "last_event_created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_subscription_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_cost": {
+          "name": "credit_cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_cost": {
+          "name": "raw_cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_records_user_created_idx": {
+          "name": "usage_records_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_records_created_idx": {
+          "name": "usage_records_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_user_id_users_id_fk": {
+          "name": "usage_records_user_id_users_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_records_conversation_id_advisor_conversations_id_fk": {
+          "name": "usage_records_conversation_id_advisor_conversations_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "advisor_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "usage_records_message_id_advisor_messages_id_fk": {
+          "name": "usage_records_message_id_advisor_messages_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "advisor_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_transactions": {
+      "name": "wallet_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_record_id": {
+          "name": "usage_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_transactions_user_created_idx": {
+          "name": "wallet_transactions_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transactions_payment_intent_idx": {
+          "name": "wallet_transactions_payment_intent_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_transactions_user_id_users_id_fk": {
+          "name": "wallet_transactions_user_id_users_id_fk",
+          "tableFrom": "wallet_transactions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_transactions_usage_record_id_usage_records_id_fk": {
+          "name": "wallet_transactions_usage_record_id_usage_records_id_fk",
+          "tableFrom": "wallet_transactions",
+          "tableTo": "usage_records",
+          "columnsFrom": ["usage_record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "wallet_transactions_kind_chk": {
+          "name": "wallet_transactions_kind_chk",
+          "value": "\"wallet_transactions\".\"kind\" IN ('credit', 'debit', 'reversal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "reserved": {
+          "name": "reserved",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallets_user_id_users_id_fk": {
+          "name": "wallets_user_id_users_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "wallets_reserved_nonneg_chk": {
+          "name": "wallets_reserved_nonneg_chk",
+          "value": "\"wallets\".\"reserved\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_events_stripe_event_id_unique": {
+          "name": "webhook_events_stripe_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_event_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webhook_events_status_chk": {
+          "name": "webhook_events_status_chk",
+          "value": "\"webhook_events\".\"status\" IN ('received', 'processed', 'ignored', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1785871256384,
       "tag": "0024_user_buying_power_basis",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1785962349981,
+      "tag": "0025_account_default_risk_percent",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema/accounts.schema.ts
+++ b/apps/api/src/db/schema/accounts.schema.ts
@@ -34,6 +34,15 @@ export const accounts = pgTable(
     startingBalance: numeric('starting_balance', { precision: 18, scale: 4 })
       .notNull()
       .default('0'),
+    // Share of the account balance the user is willing to risk per trade, used
+    // to seed the position-size calculator's riskPercent input (user-onboarding
+    // R1). NULL means "no rule set" and preserves today's calculator behaviour
+    // exactly — an empty field the user fills in per calculation (R1.4). It is
+    // NOT a default of 0, which would mean "risk nothing on every trade".
+    //
+    // Unlike starting_balance above, this stays editable after creation: it
+    // seeds a form field and rewrites no history.
+    defaultRiskPercent: numeric('default_risk_percent', { precision: 5, scale: 2 }),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },

--- a/apps/api/src/features/accounts/accounts.query.ts
+++ b/apps/api/src/features/accounts/accounts.query.ts
@@ -110,6 +110,9 @@ export function findAccountsByUser(db: Database | Transaction, userId: string) {
       timezone: accounts.timezone,
       brokerageId: accounts.brokerageId,
       brokerageName: brokerages.name,
+      // NULL means no rule set — the calculator then behaves exactly as it did
+      // before this column existed (user-onboarding R1.4).
+      defaultRiskPercent: accounts.defaultRiskPercent,
       createdAt: accounts.createdAt,
       updatedAt: accounts.updatedAt,
       balance: balanceProjection,
@@ -133,6 +136,8 @@ export function findAccountById(db: Database | Transaction, id: string, userId: 
       timezone: accounts.timezone,
       brokerageId: accounts.brokerageId,
       brokerageName: brokerages.name,
+      // NULL means no rule set (user-onboarding R1.4) — see findAccountsByUser.
+      defaultRiskPercent: accounts.defaultRiskPercent,
       createdAt: accounts.createdAt,
       updatedAt: accounts.updatedAt,
       balance: balanceProjection,
@@ -156,16 +161,31 @@ export function insertAccount(
     brokerageId?: string | null;
     startingBalance?: string;
     timezone?: string;
+    defaultRiskPercent?: string | null;
   },
 ) {
   return tx.insert(accounts).values(data).returning();
 }
 
+// `defaultRiskPercent` distinguishes absent from null and BOTH cases are
+// reachable from UpdateAccountSchema: an omitted key never reaches `.set()`
+// (Zod `.optional()` drops it, and Drizzle skips undefined values anyway), so
+// the stored value is untouched; an explicit `null` is a real value and clears
+// the rule back to unset. `brokerageId` above relies on the identical
+// mechanism. Widening this Partial is load-bearing — the field is spread into
+// `.set()` untyped, so leaving it out silently drops every update with no type
+// error.
 export function updateAccount(
   tx: Transaction,
   id: string,
   userId: string,
-  data: Partial<{ name: string; currency: string; brokerageId: string | null; timezone: string }>,
+  data: Partial<{
+    name: string;
+    currency: string;
+    brokerageId: string | null;
+    timezone: string;
+    defaultRiskPercent: string | null;
+  }>,
 ) {
   return tx
     .update(accounts)

--- a/apps/api/src/features/accounts/accounts.route.ts
+++ b/apps/api/src/features/accounts/accounts.route.ts
@@ -83,6 +83,16 @@ accounts.get('/:id', validate('param', ParamSchema), async (c) => {
  *                   `Etc/UTC`). Defines the account's trading day. Omitted
  *                   defaults to `America/New_York`; an unknown zone is a 400.
  *                 example: America/New_York
+ *               defaultRiskPercent:
+ *                 type: string
+ *                 description: >
+ *                   Share of the account balance risked per trade, as a decimal
+ *                   string above 0 and up to 100 with at most 2 decimal places.
+ *                   Seeds the position-size calculator. Omitted means no rule is
+ *                   set, which leaves the calculator's field empty as before.
+ *                   Unlike `PUT /api/accounts/{id}`, an explicit `null` is a 400
+ *                   here — there is no rule to clear on create.
+ *                 example: '1.00'
  *     responses:
  *       201: { description: The created account. }
  *       400: { description: Validation error. }
@@ -143,7 +153,8 @@ accounts.put('/writable', validate('json', SetWritableAccountSchema), async (c) 
  *     description: >
  *       Authed. All fields optional. `startingBalance` is deliberately absent —
  *       it is creation-only. `timezone` IS editable: it changes only subsequent
- *       trading-day evaluations and rewrites no history.
+ *       trading-day evaluations and rewrites no history, and `defaultRiskPercent`
+ *       is editable for the same reason.
  *     tags: [Accounts]
  *     parameters:
  *       - in: path
@@ -164,6 +175,15 @@ accounts.put('/writable', validate('json', SetWritableAccountSchema), async (c) 
  *                 type: string
  *                 description: IANA zone name (canonical spelling). Unknown zone is a 400.
  *                 example: America/New_York
+ *               defaultRiskPercent:
+ *                 type: string
+ *                 nullable: true
+ *                 description: >
+ *                   Share of the account balance risked per trade (decimal string
+ *                   above 0, up to 100, at most 2 decimal places). Omitting the
+ *                   key leaves the stored value untouched; sending an explicit
+ *                   `null` clears the rule back to unset.
+ *                 example: '1.00'
  *     responses:
  *       200: { description: The updated account. }
  *       400: { description: Validation error (includes an unknown IANA timezone). }

--- a/apps/api/src/features/accounts/accounts.service.ts
+++ b/apps/api/src/features/accounts/accounts.service.ts
@@ -48,6 +48,9 @@ export async function createAccount(
     brokerageId?: string | null;
     startingBalance?: string;
     timezone?: string;
+    // Omitted means no rule set (user-onboarding R1.1/R1.4). Bounds are
+    // CreateAccountSchema's job — never re-checked here.
+    defaultRiskPercent?: string;
   },
   // Routes pass `isAdmin` from AuthEnv — services never read Hono context
   // (plan-tiers D9).
@@ -110,7 +113,16 @@ export async function editAccount(
   db: Database,
   id: string,
   userId: string,
-  data: Partial<{ name: string; currency: string; brokerageId: string | null; timezone: string }>,
+  // `defaultRiskPercent` omitted leaves the stored value untouched; an
+  // explicit null clears the rule back to unset (user-onboarding R1.1). The
+  // distinction is carried all the way to `.set()` — see updateAccount.
+  data: Partial<{
+    name: string;
+    currency: string;
+    brokerageId: string | null;
+    timezone: string;
+    defaultRiskPercent: string | null;
+  }>,
 ) {
   return withTransaction(db, async (tx) => {
     const existing = await findAccountById(tx, id, userId);

--- a/apps/api/src/features/accounts/accounts.test.ts
+++ b/apps/api/src/features/accounts/accounts.test.ts
@@ -451,6 +451,134 @@ describe('accounts', () => {
     expect([200, 400]).toContain(res.status);
   });
 
+  // 15b. Default risk percentage (user-onboarding R1.1/R1.5). Editable after
+  // creation, unlike startingBalance — it rewrites no history.
+  it('creates an account with a defaultRiskPercent and returns it on read', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const res = await authedRequest('POST', '/api/accounts', cookie, {
+      name: 'Risk Rule Account',
+      currency: 'USD',
+      defaultRiskPercent: '1.5',
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    // numeric(5,2) normalises the stored decimal string to two places.
+    expect(body.defaultRiskPercent).toBe('1.50');
+
+    const getRes = await authedRequest('GET', `/api/accounts/${body.id}`, cookie);
+    expect(getRes.status).toBe(200);
+    expect((await getRes.json()).defaultRiskPercent).toBe('1.50');
+
+    const listRes = await authedRequest('GET', '/api/accounts', cookie);
+    const list = await listRes.json();
+    expect(list[0].defaultRiskPercent).toBe('1.50');
+  });
+
+  it.each([
+    ['zero', '0'],
+    ['negative', '-1'],
+    ['above 100', '101'],
+    ['too many decimals', '3.141'],
+    ['untrimmed', ' 1.5 '],
+  ])('returns 400 for %s default risk percent', async (_label, defaultRiskPercent) => {
+    const { cookie } = await registerAndGetCookie();
+    const res = await authedRequest('POST', '/api/accounts', cookie, {
+      name: 'Bad Risk Rule',
+      currency: 'USD',
+      defaultRiskPercent,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  // The update path bounds the field through a DIFFERENT schema object
+  // (UpdateAccountSchema, which is additionally nullable), so route-level
+  // rejection has to be pinned separately from create's — and a rejected
+  // update must leave the stored rule exactly as it was.
+  it.each([
+    ['zero', '0'],
+    ['negative', '-1'],
+    ['above 100', '101'],
+    ['too many decimals', '3.141'],
+    ['untrimmed', ' 1.5 '],
+  ])('returns 400 for %s default risk percent on update', async (_label, defaultRiskPercent) => {
+    const { cookie } = await registerAndGetCookie();
+    const createRes = await authedRequest('POST', '/api/accounts', cookie, {
+      name: 'Bad Risk Rule Update',
+      currency: 'USD',
+      defaultRiskPercent: '1',
+    });
+    const account = await createRes.json();
+
+    const res = await authedRequest('PUT', `/api/accounts/${account.id}`, cookie, {
+      defaultRiskPercent,
+    });
+    expect(res.status).toBe(400);
+
+    const getRes = await authedRequest('GET', `/api/accounts/${account.id}`, cookie);
+    expect((await getRes.json()).defaultRiskPercent).toBe('1.00');
+  });
+
+  it('leaves defaultRiskPercent null when omitted on create', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const account = await createTestAccount(cookie, 'No Risk Rule');
+    expect(account.defaultRiskPercent).toBeNull();
+  });
+
+  it('updates defaultRiskPercent', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const account = await createTestAccount(cookie, 'Risk Rule Edit');
+
+    const res = await authedRequest('PUT', `/api/accounts/${account.id}`, cookie, {
+      defaultRiskPercent: '2.25',
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).defaultRiskPercent).toBe('2.25');
+  });
+
+  // Omitted key === "leave it alone" (standard PATCH semantics). This is the
+  // case a too-narrow `updateAccount` type would silently break in the other
+  // direction, so it is pinned alongside the explicit-null clear below.
+  it('leaves a stored defaultRiskPercent untouched when the update omits it', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const createRes = await authedRequest('POST', '/api/accounts', cookie, {
+      name: 'Untouched Risk Rule',
+      currency: 'USD',
+      defaultRiskPercent: '3',
+    });
+    const account = await createRes.json();
+    expect(account.defaultRiskPercent).toBe('3.00');
+
+    const res = await authedRequest('PUT', `/api/accounts/${account.id}`, cookie, {
+      name: 'Untouched Risk Rule Renamed',
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.name).toBe('Untouched Risk Rule Renamed');
+    expect(body.defaultRiskPercent).toBe('3.00');
+  });
+
+  // Explicit null is a real value, not an omission — without it a user who set
+  // a percentage could never remove it.
+  it('clears defaultRiskPercent when the update sends an explicit null', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const createRes = await authedRequest('POST', '/api/accounts', cookie, {
+      name: 'Cleared Risk Rule',
+      currency: 'USD',
+      defaultRiskPercent: '5',
+    });
+    const account = await createRes.json();
+    expect(account.defaultRiskPercent).toBe('5.00');
+
+    const res = await authedRequest('PUT', `/api/accounts/${account.id}`, cookie, {
+      defaultRiskPercent: null,
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).defaultRiskPercent).toBeNull();
+
+    const getRes = await authedRequest('GET', `/api/accounts/${account.id}`, cookie);
+    expect((await getRes.json()).defaultRiskPercent).toBeNull();
+  });
+
   // 16. Position-count endpoint
   it('returns position count for an account', async () => {
     const { cookie } = await registerAndGetCookie();

--- a/apps/docs/src/content/docs/self-hosting/reference/db-schema.mdx
+++ b/apps/docs/src/content/docs/self-hosting/reference/db-schema.mdx
@@ -6,9 +6,9 @@ description: Every table Tradr creates, its columns, and how they reference each
 {/* GENERATED FILE — do not edit.
     Source: apps/api/src/db/migrations/meta/ (latest snapshot) · Generator: apps/docs/scripts/gen-db-schema.mjs */}
 
-Tradr's schema is **32 tables**, created by **25 migrations** that run
+Tradr's schema is **32 tables**, created by **26 migrations** that run
 automatically when the api boots. This page is generated from the Drizzle snapshot
-for the latest migration (`0024_user_buying_power_basis`), so it describes the schema the migrations
+for the latest migration (`0025_account_default_risk_percent`), so it describes the schema the migrations
 actually produce.
 
 You do not need any of this to run Tradr. It is here for writing queries against
@@ -84,6 +84,7 @@ a query you write against these tables may need updating on any release.
 | `timezone` | `varchar(64)` | not null, default `'America/New_York'` |
 | `brokerage_id` | `uuid` | — |
 | `starting_balance` | `numeric(18, 4)` | not null, default `'0'` |
+| `default_risk_percent` | `numeric(5, 2)` | — |
 | `created_at` | `timestamp with time zone` | not null, default `now()` |
 | `updated_at` | `timestamp with time zone` | not null, default `now()` |
 

--- a/apps/docs/src/openapi/tradr-api.json
+++ b/apps/docs/src/openapi/tradr-api.json
@@ -134,6 +134,11 @@
                     "minLength": 3,
                     "type": "string"
                   },
+                  "defaultRiskPercent": {
+                    "description": "Share of the account balance risked per trade, as a decimal string above 0 and up to 100 with at most 2 decimal places. Seeds the position-size calculator. Omitted means no rule is set, which leaves the calculator's field empty as before. Unlike `PUT /api/accounts/{id}`, an explicit `null` is a 400 here — there is no rule to clear on create.\n",
+                    "example": "1.00",
+                    "type": "string"
+                  },
                   "name": {
                     "minLength": 1,
                     "type": "string"
@@ -218,7 +223,7 @@
     },
     "/api/accounts/{id}": {
       "put": {
-        "description": "Authed. All fields optional. `startingBalance` is deliberately absent — it is creation-only. `timezone` IS editable: it changes only subsequent trading-day evaluations and rewrites no history.\n",
+        "description": "Authed. All fields optional. `startingBalance` is deliberately absent — it is creation-only. `timezone` IS editable: it changes only subsequent trading-day evaluations and rewrites no history, and `defaultRiskPercent` is editable for the same reason.\n",
         "parameters": [
           {
             "in": "path",
@@ -243,6 +248,12 @@
                   "currency": {
                     "maxLength": 3,
                     "minLength": 3,
+                    "type": "string"
+                  },
+                  "defaultRiskPercent": {
+                    "description": "Share of the account balance risked per trade (decimal string above 0, up to 100, at most 2 decimal places). Omitting the key leaves the stored value untouched; sending an explicit `null` clears the rule back to unset.\n",
+                    "example": "1.00",
+                    "nullable": true,
                     "type": "string"
                   },
                   "name": {

--- a/apps/web/src/features/accounts/components/AccountDialog.test.tsx
+++ b/apps/web/src/features/accounts/components/AccountDialog.test.tsx
@@ -9,9 +9,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-const { createMutateAsync, tierData } = vi.hoisted(() => ({
+const { createMutateAsync, updateMutateAsync, tierData, brokerageData } = vi.hoisted(() => ({
   createMutateAsync: vi.fn(),
+  updateMutateAsync: vi.fn(),
   tierData: { current: undefined as unknown },
+  // Only id/name/isSystem are read by the dialog.
+  brokerageData: { current: [] as { id: string; name: string; isSystem: boolean }[] },
 }));
 
 // Keep the real getAccountErrorCode — the dialog's mapping goes through it.
@@ -20,7 +23,7 @@ vi.mock('../hooks/useAccounts', async (importOriginal) => {
   return {
     ...actual,
     useCreateAccount: () => ({ mutateAsync: createMutateAsync, isPending: false }),
-    useUpdateAccount: () => ({ mutateAsync: vi.fn(), isPending: false }),
+    useUpdateAccount: () => ({ mutateAsync: updateMutateAsync, isPending: false }),
   };
 });
 
@@ -29,7 +32,7 @@ vi.mock('@/features/billing/useTierState', () => ({
 }));
 
 vi.mock('@/features/brokerages/hooks/useBrokerages', () => ({
-  useBrokerages: () => ({ data: [] }),
+  useBrokerages: () => ({ data: brokerageData.current }),
 }));
 
 // Stub the Radix primitives (portals/focus-trap fight jsdom).
@@ -53,29 +56,46 @@ vi.mock('@/components/ui/alert-dialog', () => ({
   AlertDialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
 }));
 
-vi.mock('@/components/ui/select', () => ({
-  Select: ({
-    value,
-    onValueChange,
-    children,
-  }: {
-    value?: string;
-    onValueChange: (v: string) => void;
-    children: React.ReactNode;
-  }) => (
-    <select value={value} onChange={(e) => onValueChange(e.currentTarget.value)}>
-      {children}
-    </select>
-  ),
-  SelectTrigger: () => null,
-  SelectValue: () => null,
-  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  SelectGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  SelectLabel: () => null,
-  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
-    <option value={value}>{children}</option>
-  ),
-}));
+vi.mock('@/components/ui/select', async () => {
+  const { Children, isValidElement } = await import('react');
+  // SelectTrigger carries the id each <Label htmlFor> points at, and the stub
+  // drops the trigger — so lift that id onto the <select> to keep the field
+  // reachable by its label rather than by DOM order.
+  const triggerId = (children: React.ReactNode): string | undefined => {
+    let id: string | undefined;
+    Children.forEach(children, (child) => {
+      if (isValidElement<{ id?: string }>(child) && child.props.id) id = child.props.id;
+    });
+    return id;
+  };
+  return {
+    Select: ({
+      value,
+      onValueChange,
+      children,
+    }: {
+      value?: string;
+      onValueChange: (v: string) => void;
+      children: React.ReactNode;
+    }) => (
+      <select
+        id={triggerId(children)}
+        value={value}
+        onChange={(e) => onValueChange(e.currentTarget.value)}
+      >
+        {children}
+      </select>
+    ),
+    SelectTrigger: () => null,
+    SelectValue: () => null,
+    SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SelectGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SelectLabel: () => null,
+    SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+      <option value={value}>{children}</option>
+    ),
+  };
+});
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({
@@ -105,18 +125,58 @@ vi.mock('@/lib/telemetry/posthog', () => ({
   captureClientEvent: vi.fn(),
 }));
 
+import type { Account } from '@tradr/shared';
+
 import { AccountDialog } from './AccountDialog';
 
-function renderDialog(onOpenChange = vi.fn()) {
+function renderDialog(onOpenChange = vi.fn(), account?: Account) {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
   render(
     <QueryClientProvider client={qc}>
-      <AccountDialog open onOpenChange={onOpenChange} />
+      <AccountDialog open onOpenChange={onOpenChange} account={account} />
     </QueryClientProvider>,
   );
   return onOpenChange;
+}
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+  return {
+    id: '11111111-1111-4111-8111-111111111111',
+    userId: '22222222-2222-4222-8222-222222222222',
+    name: 'IBKR Main',
+    currency: 'USD',
+    timezone: 'America/New_York',
+    brokerageId: null,
+    brokerageName: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const BROKERAGE_A = '33333333-3333-4333-8333-333333333333';
+const BROKERAGE_B = '44444444-4444-4444-8444-444444444444';
+
+// AccountList mounts ONE dialog with no `key` and swaps the `account` prop, so
+// the same component instance is reused across create/edit and edit/edit
+// switches. This drives that instance the way the list does.
+function renderPersistentDialog(open: boolean, account: Account | null) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const tree = (props: { open: boolean; account: Account | null }) => (
+    <QueryClientProvider client={qc}>
+      <AccountDialog open={props.open} onOpenChange={vi.fn()} account={props.account} />
+    </QueryClientProvider>
+  );
+  const { rerender } = render(tree({ open, account }));
+  return (next: { open: boolean; account: Account | null }) => rerender(tree(next));
+}
+
+function fieldValue(label: string): string {
+  return (screen.getByLabelText(label) as HTMLInputElement | HTMLSelectElement).value;
 }
 
 function submitCreate(): void {
@@ -126,6 +186,8 @@ function submitCreate(): void {
 
 beforeEach(() => {
   createMutateAsync.mockReset();
+  updateMutateAsync.mockReset();
+  brokerageData.current = [];
   tierData.current = {
     gatingEnabled: true,
     exempt: false,
@@ -210,5 +272,187 @@ describe('AccountDialog — TIER_LIMIT_ACCOUNTS mapping', () => {
 
     await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
     expect(screen.queryByTestId('account-tier-refusal')).toBeNull();
+  });
+});
+
+// Default risk percentage (user-onboarding R1.1/R1.6).
+describe('AccountDialog — default risk %', () => {
+  it('offers the field with its explanation and a conservative hint on create', () => {
+    renderDialog();
+
+    const input = screen.getByLabelText('Default risk %') as HTMLInputElement;
+    expect(input.placeholder).toBe('3');
+    expect(
+      screen.getByText(/share of this account's balance you risk on a single trade/i),
+    ).toBeTruthy();
+    expect(screen.getByText(/3% is a conservative starting point/i)).toBeTruthy();
+  });
+
+  it('submits an empty field as undefined, never an empty string', async () => {
+    createMutateAsync.mockResolvedValue({ id: 'new' });
+    renderDialog();
+
+    submitCreate();
+
+    await waitFor(() => expect(createMutateAsync).toHaveBeenCalledTimes(1));
+    const sent = createMutateAsync.mock.calls[0][0] as Record<string, unknown>;
+    expect(sent.defaultRiskPercent).toBeUndefined();
+    expect(sent).not.toHaveProperty('defaultRiskPercent', '');
+  });
+
+  it('submits the entered percentage on create', async () => {
+    createMutateAsync.mockResolvedValue({ id: 'new' });
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText('Default risk %'), { target: { value: '1.5' } });
+    submitCreate();
+
+    await waitFor(() => expect(createMutateAsync).toHaveBeenCalledTimes(1));
+    expect(createMutateAsync.mock.calls[0][0]).toMatchObject({ defaultRiskPercent: '1.5' });
+  });
+
+  it('blocks submit and renders the schema message for an out-of-range value', async () => {
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText('Default risk %'), { target: { value: '101' } });
+    submitCreate();
+
+    await waitFor(() => expect(screen.getByText(/percentage above 0 and up to 100/i)).toBeTruthy());
+    expect(createMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('prefills the field from the account on edit, in the stored normalised form', () => {
+    renderDialog(vi.fn(), makeAccount({ defaultRiskPercent: '1.50' }));
+
+    expect((screen.getByLabelText('Default risk %') as HTMLInputElement).value).toBe('1.50');
+  });
+
+  it('sends an explicit null when the field is emptied on edit, so the rule clears', async () => {
+    updateMutateAsync.mockResolvedValue({ id: 'a' });
+    renderDialog(vi.fn(), makeAccount({ defaultRiskPercent: '1.50' }));
+
+    fireEvent.change(screen.getByLabelText('Default risk %'), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(updateMutateAsync).toHaveBeenCalledTimes(1));
+    const { data } = updateMutateAsync.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(data.defaultRiskPercent).toBeNull();
+  });
+
+  // The dialog stays mounted while AccountList swaps `account` between create
+  // and edit, so the fields are re-seeded on open. Without that, edit opens
+  // blank and saving would clear the stored rule.
+  it('seeds the field when a mounted create dialog is reopened for edit', async () => {
+    updateMutateAsync.mockResolvedValue({ id: 'a' });
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const { rerender } = render(
+      <QueryClientProvider client={qc}>
+        <AccountDialog open={false} onOpenChange={vi.fn()} account={null} />
+      </QueryClientProvider>,
+    );
+    rerender(
+      <QueryClientProvider client={qc}>
+        <AccountDialog
+          open
+          onOpenChange={vi.fn()}
+          account={makeAccount({ defaultRiskPercent: '1.50' })}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('IBKR Main');
+    expect((screen.getByLabelText('Default risk %') as HTMLInputElement).value).toBe('1.50');
+
+    // Saving an untouched edit must not clear the rule it just displayed.
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(updateMutateAsync).toHaveBeenCalledTimes(1));
+    const { data } = updateMutateAsync.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(data.defaultRiskPercent).toBe('1.50');
+  });
+
+  it('sends the edited percentage on edit', async () => {
+    updateMutateAsync.mockResolvedValue({ id: 'a' });
+    renderDialog(vi.fn(), makeAccount({ defaultRiskPercent: '1.50' }));
+
+    fireEvent.change(screen.getByLabelText('Default risk %'), { target: { value: '2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(updateMutateAsync).toHaveBeenCalledTimes(1));
+    const { data } = updateMutateAsync.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(data.defaultRiskPercent).toBe('2');
+  });
+});
+
+// The re-seed on open covers every field, not just the risk rule. Currency and
+// timezone carry hardcoded fallbacks ('USD' / 'America/New_York'), so a dialog
+// that failed to re-seed would display those over the account's stored values
+// and overwrite them on save — silent data corruption, not a cosmetic glitch.
+describe('AccountDialog — re-seeding on open', () => {
+  beforeEach(() => {
+    brokerageData.current = [
+      { id: BROKERAGE_A, name: 'Alpha Broker', isSystem: false },
+      { id: BROKERAGE_B, name: 'Beta Broker', isSystem: false },
+    ];
+  });
+
+  it('shows the account currency, timezone and brokerage when a create dialog is reopened for edit', async () => {
+    updateMutateAsync.mockResolvedValue({ id: 'a' });
+    const rerender = renderPersistentDialog(false, null);
+
+    rerender({
+      open: true,
+      account: makeAccount({
+        currency: 'GBP',
+        timezone: 'Europe/London',
+        brokerageId: BROKERAGE_A,
+      }),
+    });
+
+    expect(fieldValue('Currency')).toBe('GBP');
+    expect(fieldValue('Timezone')).toBe('Europe/London');
+    expect(fieldValue('Brokerage')).toBe(BROKERAGE_A);
+
+    // The corruption itself: an untouched save must not write the create
+    // defaults over what the account actually stores.
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(updateMutateAsync).toHaveBeenCalledTimes(1));
+    const { data } = updateMutateAsync.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(data).toMatchObject({
+      currency: 'GBP',
+      timezone: 'Europe/London',
+      brokerageId: BROKERAGE_A,
+    });
+  });
+
+  it('replaces the previous account values when edit is reopened on a different account', () => {
+    const first = makeAccount({
+      name: 'IBKR Main',
+      currency: 'GBP',
+      timezone: 'Europe/London',
+      brokerageId: BROKERAGE_A,
+      defaultRiskPercent: '1.50',
+    });
+    const second = makeAccount({
+      id: '55555555-5555-4555-8555-555555555555',
+      name: 'Prop Firm',
+      currency: 'JPY',
+      timezone: 'Asia/Tokyo',
+      brokerageId: BROKERAGE_B,
+      defaultRiskPercent: '2.00',
+    });
+    const rerender = renderPersistentDialog(true, first);
+
+    expect(fieldValue('Currency')).toBe('GBP');
+
+    rerender({ open: false, account: first });
+    rerender({ open: true, account: second });
+
+    expect(fieldValue('Currency')).toBe('JPY');
+    expect(fieldValue('Timezone')).toBe('Asia/Tokyo');
+    expect(fieldValue('Brokerage')).toBe(BROKERAGE_B);
+    expect(fieldValue('Name')).toBe('Prop Firm');
+    expect(fieldValue('Default risk %')).toBe('2.00');
   });
 });

--- a/apps/web/src/features/accounts/components/AccountDialog.tsx
+++ b/apps/web/src/features/accounts/components/AccountDialog.tsx
@@ -66,16 +66,40 @@ export function AccountDialog({ open, onOpenChange, account }: AccountDialogProp
   const systemBrokerages = brokerages?.filter((b) => b.isSystem) ?? [];
   const userBrokerages = brokerages?.filter((b) => !b.isSystem) ?? [];
 
+  const formValues = (): CreateAccountInput => ({
+    name: account?.name ?? '',
+    currency: account?.currency ?? 'USD',
+    brokerageId: account?.brokerageId ?? null,
+    startingBalance: undefined,
+    timezone: account?.timezone ?? DEFAULT_ACCOUNT_TIMEZONE,
+    // The column is numeric(5,2), so the API hands back a normalised decimal
+    // string ('1.5' stored comes back as '1.50'). Null means no rule is set,
+    // which the form expresses as an empty field.
+    defaultRiskPercent: account?.defaultRiskPercent ?? undefined,
+  });
+
   const form = useForm<CreateAccountInput>({
     resolver: zodResolver(CreateAccountSchema),
-    defaultValues: {
-      name: account?.name ?? '',
-      currency: account?.currency ?? 'USD',
-      brokerageId: account?.brokerageId ?? null,
-      startingBalance: undefined,
-      timezone: account?.timezone ?? DEFAULT_ACCOUNT_TIMEZONE,
-    },
+    defaultValues: formValues(),
   });
+
+  // `useForm` reads defaultValues once, but AccountList keeps a single dialog
+  // mounted and swaps `account` to switch between create and edit — so the
+  // fields must be re-seeded each time it opens, or edit shows the previous
+  // occupant's values. Load-bearing for the risk rule specifically: an
+  // unseeded (blank) field submits as null and would silently clear a stored
+  // rule whenever the user edited anything else.
+  //
+  // The dependency list is deliberately narrow: it keys on the account *id*,
+  // never the `account` object or `form`. A background accounts refetch hands
+  // back a new object identity for the same account, so depending on either
+  // would re-run the reset mid-edit and discard whatever the user had typed.
+  // Widening these deps reintroduces that hazard — nothing lints it, since no
+  // react-hooks plugin is registered in eslint.config.js.
+  const accountId = account?.id;
+  useEffect(() => {
+    if (open) form.reset(formValues());
+  }, [open, accountId]);
 
   const selectedBrokerageId = form.watch('brokerageId');
   const selectedCurrency = form.watch('currency');
@@ -97,7 +121,14 @@ export function AccountDialog({ open, onOpenChange, account }: AccountDialogProp
     };
 
     if (isEdit) {
-      await updateAccount.mutateAsync({ id: account!.id, data: submitData });
+      await updateAccount.mutateAsync({
+        id: account!.id,
+        // An emptied risk field must actually clear a rule that was set, and
+        // on update only an explicit null does that — an omitted key leaves
+        // the stored value untouched. The form's `undefined` therefore becomes
+        // `null` here. Harmless when no rule existed: null overwrites null.
+        data: { ...submitData, defaultRiskPercent: submitData.defaultRiskPercent ?? null },
+      });
       // Invalidate positions if brokerage changed
       if ((submitData.brokerageId ?? null) !== (account?.brokerageId ?? null)) {
         queryClient.invalidateQueries({ queryKey: ['positions'] });
@@ -244,6 +275,33 @@ export function AccountDialog({ open, onOpenChange, account }: AccountDialogProp
                 )}
               </div>
             )}
+            {/* Default risk percentage (user-onboarding R1.1/R1.6). Shown on
+                create AND edit — unlike starting balance it rewrites no
+                history, it only seeds the position-size calculator. */}
+            <div className="space-y-2">
+              <Label htmlFor="defaultRiskPercent">Default risk %</Label>
+              <Input
+                id="defaultRiskPercent"
+                inputMode="decimal"
+                placeholder="3"
+                {...form.register('defaultRiskPercent', {
+                  // Empty field means "no rule set" — the schema only accepts a
+                  // decimal string or undefined, never ''.
+                  setValueAs: (v: unknown) =>
+                    typeof v === 'string' && v.trim() !== '' ? v.trim() : undefined,
+                })}
+              />
+              <p className="text-sm text-muted-foreground">
+                The share of this account&apos;s balance you risk on a single trade — it prefills
+                the position-size calculator, and you can override it on any one calculation. If you
+                don&apos;t have a rule of your own yet, 3% is a conservative starting point.
+              </p>
+              {form.formState.errors.defaultRiskPercent && (
+                <p className="text-sm text-destructive">
+                  {form.formState.errors.defaultRiskPercent.message}
+                </p>
+              )}
+            </div>
             <div className="space-y-2">
               <Label htmlFor="brokerage">Brokerage</Label>
               <Select

--- a/apps/web/src/features/calculator/components/CalculatorForm.test.tsx
+++ b/apps/web/src/features/calculator/components/CalculatorForm.test.tsx
@@ -154,6 +154,17 @@ const CAD_ACCOUNT = { id: 'acc-cad', name: 'Maple Margin', currency: 'CAD', bala
 // A selected account whose balance is not yet derived (REQ-3.5) — no `balance`.
 const NO_BALANCE_ACCOUNT = { id: 'acc-nobal', name: 'Fresh', currency: 'USD' };
 
+// An account carrying its own risk rule (user-onboarding R1.2). The value is the
+// numeric(5,2)-NORMALISED string the API returns — a stored 1.5 comes back
+// '1.50' — so the prefill assertions expect that form, not what a user typed.
+const RULED_ACCOUNT = {
+  id: 'acc-ruled',
+  name: 'By The Book',
+  currency: 'USD',
+  balance: '50000',
+  defaultRiskPercent: '1.50',
+};
+
 // ---- Harness ----------------------------------------------------------------
 
 /** Same Intl call the Numeric primitive uses, so assertions match regardless of locale. */
@@ -266,6 +277,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.unstubAllGlobals();
 });
 
 // -----------------------------------------------------------------------------
@@ -858,5 +870,117 @@ describe('CalculatorForm — dollar basis account sourcing', () => {
     // Not the percent-basis reassurance — there is no risk percentage here.
     expect(note.textContent).toMatch(/dollar risk is unchanged/i);
     expect(note.textContent).not.toMatch(/percent of the balance/i);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Account default risk percentage (user-onboarding R1.2/R1.3/R1.4)
+//
+// RULED_ACCOUNT: $50,000 balance, a 1.50% rule. Entry $50 / stop $48 is $2 of
+// per-share risk, so the rule alone gives a $750 budget → 375 shares, and an
+// override to 2% gives $1,000 → 500 shares. Both fund comfortably inside the
+// $50,000 cap, so the cap never confounds the prefill assertions.
+// -----------------------------------------------------------------------------
+
+describe('CalculatorForm — account default risk prefill', () => {
+  it('prefills the risk percent from the account rule and sizes against it (R1.2)', async () => {
+    const user = userEvent.setup();
+    setAccounts({ data: [RULED_ACCOUNT] });
+    await mount();
+    await switchBasis(user, 'Percent');
+
+    fill('Entry price', '50');
+    fill('Stop loss', '48');
+    // Neither the balance NOR the percent is typed — both come from the account.
+    fireEvent.change(selectByOptionValue(RULED_ACCOUNT.id), {
+      target: { value: RULED_ACCOUNT.id },
+    });
+
+    expect(input('Balance').value).toBe('50000');
+    // The numeric(5,2)-normalised form, not the '1.5' someone typed into the dialog.
+    expect(input('Risk percent').value).toBe('1.50');
+
+    await screen.findByText('Derived Dollar Risk', undefined, { timeout: 2000 });
+    expect(screen.getAllByText(fmtMoney(750)).length).toBeGreaterThan(0);
+    expect(screen.getByText('375')).toBeTruthy();
+  });
+
+  it('leaves the risk percent cleared for an account with no rule (R1.4)', async () => {
+    const user = userEvent.setup();
+    setAccounts({ data: [CAD_ACCOUNT] });
+    await mount();
+    await switchBasis(user, 'Percent');
+
+    fireEvent.change(selectByOptionValue(CAD_ACCOUNT.id), { target: { value: CAD_ACCOUNT.id } });
+
+    expect(input('Balance').value).toBe('50000');
+    expect(input('Risk percent').value).toBe('');
+  });
+
+  it('does not disturb a typed risk percent when the account has no rule (R1.4)', async () => {
+    // Every account predating the column has no rule, so this is the path every
+    // existing user is on: selecting an account must behave exactly as it did.
+    const user = userEvent.setup();
+    setAccounts({ data: [CAD_ACCOUNT] });
+    await mount();
+    await switchBasis(user, 'Percent');
+
+    fill('Risk percent', '2');
+    fireEvent.change(selectByOptionValue(CAD_ACCOUNT.id), { target: { value: CAD_ACCOUNT.id } });
+
+    expect(input('Risk percent').value).toBe('2');
+  });
+
+  it('re-seeds the risk percent alongside the balance on a switch back to percent', async () => {
+    const user = userEvent.setup();
+    setAccounts({ data: [RULED_ACCOUNT] });
+    await mount();
+    await switchBasis(user, 'Dollar');
+
+    // Selected on the dollar basis, where the account contributes only the cap —
+    // no balance and no percent go on the form there.
+    fireEvent.change(selectByOptionValue(RULED_ACCOUNT.id), {
+      target: { value: RULED_ACCOUNT.id },
+    });
+    await switchBasis(user, 'Percent');
+
+    expect(input('Balance').value).toBe('50000');
+    expect(input('Risk percent').value).toBe('1.50');
+  });
+
+  it('overriding the prefilled percent changes only this calculation and issues NO request (R1.3)', async () => {
+    // The load-bearing assertion of R1.3: the prefill is a READ path. Every API
+    // call in the app goes through lib/api's single `fetch`, so a stubbed global
+    // fetch catches a write-back however it were wired.
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const user = userEvent.setup();
+    setAccounts({ data: [RULED_ACCOUNT] });
+    await mount();
+    await switchBasis(user, 'Percent');
+
+    fill('Entry price', '50');
+    fill('Stop loss', '48');
+    fireEvent.change(selectByOptionValue(RULED_ACCOUNT.id), {
+      target: { value: RULED_ACCOUNT.id },
+    });
+    expect(input('Risk percent').value).toBe('1.50');
+
+    // Override the rule for this one calculation.
+    fireEvent.change(input('Risk percent'), { target: { value: '2' } });
+    fireEvent.blur(input('Risk percent'));
+
+    // Applied to THIS calculation: $1,000 of budget → 500 shares, not the 375 the
+    // account's own 1.50% rule would have sized.
+    await screen.findByText('Derived Dollar Risk', undefined, { timeout: 2000 });
+    expect(screen.getAllByText(fmtMoney(1000)).length).toBeGreaterThan(0);
+    expect(screen.getByText('500')).toBeTruthy();
+    expect(screen.queryByText('375')).toBeNull();
+
+    // …and NOT written back. No request of any kind left the form, and the
+    // account's stored rule is untouched.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(RULED_ACCOUNT.defaultRiskPercent).toBe('1.50');
   });
 });

--- a/apps/web/src/features/calculator/components/CalculatorForm.tsx
+++ b/apps/web/src/features/calculator/components/CalculatorForm.tsx
@@ -250,6 +250,26 @@ export function CalculatorForm() {
     setValue('feeSchedule', parsed, { shouldValidate: true });
   };
 
+  // Seed the risk percent from the account's own rule (user-onboarding R1.2), at
+  // the two points that already re-seed `balance`. READ PATH ONLY — the account
+  // is never written back to from here (R1.3): a risk percent typed on one
+  // calculation is that calculation's, and the stored rule is unchanged.
+  //
+  // Only when a rule EXISTS. An account without one deliberately leaves the field
+  // exactly as it found it (R1.4) rather than clearing it the way an absent
+  // `balance` clears the balance — every account predating the column has no
+  // rule, so clearing would wipe a percent the user typed before picking their
+  // account and change today's behaviour for every existing user.
+  //
+  // The value arrives numeric(5,2)-normalised ('1.50', not '1.5'). It is a
+  // percent-basis field, so this is guarded by the basis at both call sites for
+  // the same reason `balance` is: the schema's "exactly one risk basis" refine.
+  const seedRiskPercent = (account: Account) => {
+    if (account.defaultRiskPercent) {
+      setValue('riskPercent', account.defaultRiskPercent, { shouldValidate: true });
+    }
+  };
+
   // The selected account SURVIVES a basis switch — it is meaningful in both now,
   // and dropping it would silently remove the cap from a user who only changed
   // how they express risk. Only the basis-scoped FIELDS are cleared, which the
@@ -264,6 +284,7 @@ export function CalculatorForm() {
       // the account they can already see is picked.
       if (selectedAccount) {
         setValue('balance', selectedAccount.balance ?? undefined, { shouldValidate: true });
+        seedRiskPercent(selectedAccount);
       }
     } else {
       setValue('balance', undefined, { shouldValidate: true });
@@ -283,6 +304,7 @@ export function CalculatorForm() {
     if (riskBasis === 'percent') {
       // Absent balance ⇒ not-yet-supplied → neutral incomplete state (D8, REQ-3.5).
       setValue('balance', account.balance ?? undefined, { shouldValidate: true });
+      seedRiskPercent(account);
     }
     setSelectedAccount(account);
   };

--- a/packages/shared/src/schemas/account.test.ts
+++ b/packages/shared/src/schemas/account.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+
+import { AccountSchema, CreateAccountSchema, UpdateAccountSchema } from './account';
+
+const baseCreate = { name: 'Main', currency: 'USD' };
+
+describe('CreateAccountSchema.defaultRiskPercent', () => {
+  it('is optional — omitting it means no rule is set', () => {
+    const result = CreateAccountSchema.safeParse(baseCreate);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.defaultRiskPercent).toBeUndefined();
+  });
+
+  it.each(['1', '3', '2.5', '0.01', '100', '99.99'])('accepts %s', (v) => {
+    expect(CreateAccountSchema.safeParse({ ...baseCreate, defaultRiskPercent: v }).success).toBe(
+      true,
+    );
+  });
+
+  // Zero is the absence of a rule, not a rule to risk nothing — absence is
+  // already expressed by omitting the field.
+  it.each(['0', '0.00', '-1', '-0.5'])('rejects %s (not above zero)', (v) => {
+    expect(CreateAccountSchema.safeParse({ ...baseCreate, defaultRiskPercent: v }).success).toBe(
+      false,
+    );
+  });
+
+  it.each(['100.01', '101', '999.99'])('rejects %s (above 100)', (v) => {
+    expect(CreateAccountSchema.safeParse({ ...baseCreate, defaultRiskPercent: v }).success).toBe(
+      false,
+    );
+  });
+
+  // The numeric(5,2) column would silently round a third decimal, so the
+  // schema rejects it rather than storing something the user did not type.
+  it.each(['3.141', '2.005', '1.00000'])('rejects %s (more than 2 decimal places)', (v) => {
+    expect(CreateAccountSchema.safeParse({ ...baseCreate, defaultRiskPercent: v }).success).toBe(
+      false,
+    );
+  });
+
+  // Number('  3  ') passes a bounds check but new Decimal('  3  ') throws
+  // server-side, so whitespace must fail at the schema, not in the service.
+  it.each([' 3', '3 ', ' 3 ', '', '  '])('rejects %j (whitespace or empty)', (v) => {
+    expect(CreateAccountSchema.safeParse({ ...baseCreate, defaultRiskPercent: v }).success).toBe(
+      false,
+    );
+  });
+
+  it.each(['abc', 'NaN', 'Infinity', '3%'])('rejects %s (not a number)', (v) => {
+    expect(CreateAccountSchema.safeParse({ ...baseCreate, defaultRiskPercent: v }).success).toBe(
+      false,
+    );
+  });
+
+  it('rejects a numeric literal — the field is a decimal string', () => {
+    expect(CreateAccountSchema.safeParse({ ...baseCreate, defaultRiskPercent: 3 }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe('UpdateAccountSchema.defaultRiskPercent', () => {
+  // Editable after creation, unlike startingBalance, because it rewrites no
+  // history — it only seeds a form field.
+  it('accepts a new value', () => {
+    expect(UpdateAccountSchema.safeParse({ defaultRiskPercent: '2.5' }).success).toBe(true);
+  });
+
+  it('accepts null to clear the rule back to unset', () => {
+    const result = UpdateAccountSchema.safeParse({ defaultRiskPercent: null });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.defaultRiskPercent).toBeNull();
+  });
+
+  it('omitting it leaves the stored value untouched (undefined, not null)', () => {
+    const result = UpdateAccountSchema.safeParse({ name: 'Renamed' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.defaultRiskPercent).toBeUndefined();
+  });
+
+  it('applies the same bounds as create', () => {
+    expect(UpdateAccountSchema.safeParse({ defaultRiskPercent: '0' }).success).toBe(false);
+    expect(UpdateAccountSchema.safeParse({ defaultRiskPercent: '101' }).success).toBe(false);
+    expect(UpdateAccountSchema.safeParse({ defaultRiskPercent: '3.141' }).success).toBe(false);
+  });
+
+  // startingBalance stays creation-only: the derived balance is
+  // startingBalance + SUM(ledger), so editing it would move every historical
+  // figure. Guard the distinction so it cannot be blurred later.
+  it('still strips startingBalance (creation-only)', () => {
+    const result = UpdateAccountSchema.safeParse({ startingBalance: '1000' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).not.toHaveProperty('startingBalance');
+    }
+  });
+});
+
+describe('AccountSchema.defaultRiskPercent', () => {
+  const baseAccount = {
+    id: '11111111-1111-4111-8111-111111111111',
+    userId: '22222222-2222-4222-8222-222222222222',
+    name: 'Main',
+    currency: 'USD',
+    timezone: 'America/New_York',
+    brokerageId: null,
+    brokerageName: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+
+  it('parses when the field is absent (existing fixtures keep working)', () => {
+    expect(AccountSchema.safeParse(baseAccount).success).toBe(true);
+  });
+
+  it('parses null for an account with no rule set', () => {
+    expect(AccountSchema.safeParse({ ...baseAccount, defaultRiskPercent: null }).success).toBe(
+      true,
+    );
+  });
+
+  it('parses a stored value', () => {
+    const result = AccountSchema.safeParse({ ...baseAccount, defaultRiskPercent: '3.00' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.defaultRiskPercent).toBe('3.00');
+  });
+});

--- a/packages/shared/src/schemas/account.ts
+++ b/packages/shared/src/schemas/account.ts
@@ -46,6 +46,33 @@ const timezone = z
     { message: 'Must be a valid IANA timezone name' },
   );
 
+// Default risk percentage (user-onboarding R1): the share of the account
+// balance risked per trade, seeding the calculator's `riskPercent` input.
+// Bounded to the accounts.default_risk_percent numeric(5,2) column (≤3 integer
+// digits, ≤2 fractional) AND to the 0–100 range the calculator's own
+// `riskPercent` already uses (`positiveDecimal(100)`, schemas/calculator.ts).
+// That module's helper is deliberately not reused: it bounds magnitude only
+// and would accept `3.14159`, which the numeric(5,2) column would silently
+// round. The whitespace rejection mirrors `startingBalance` above — Number("
+// 3 ") passes a bounds check but new Decimal("  3  ") throws server-side.
+//
+// Unlike startingBalance this IS editable after creation (it appears in
+// UpdateAccountSchema): it seeds a form field and rewrites no history.
+//
+// Strictly positive. Zero would mean "risk nothing on every trade", which is
+// not a rule but the absence of one — and absence is already expressed by
+// omitting the field entirely.
+const defaultRiskPercent = z.string().refine(
+  (v) => {
+    if (v.length === 0) return false;
+    if (v !== v.trim()) return false;
+    if (!/^\d{1,3}(\.\d{1,2})?$/.test(v)) return false;
+    const n = Number(v);
+    return n > 0 && n <= 100;
+  },
+  { message: 'Must be a percentage above 0 and up to 100, with at most 2 decimal places' },
+);
+
 export const CreateAccountSchema = z.object({
   name: z.string().min(1).max(100).trim(),
   currency: z.enum(CURRENCY_CODES as [string, ...string[]]),
@@ -56,6 +83,9 @@ export const CreateAccountSchema = z.object({
   startingBalance: startingBalance.optional(),
   // Optional — omitted falls back to the column default 'America/New_York'.
   timezone: timezone.optional(),
+  // Optional — omitted means no rule is set, which preserves the calculator's
+  // pre-existing behaviour exactly (empty field, user-supplied per calculation).
+  defaultRiskPercent: defaultRiskPercent.optional(),
 });
 
 export const UpdateAccountSchema = z.object({
@@ -63,6 +93,11 @@ export const UpdateAccountSchema = z.object({
   currency: z.enum(CURRENCY_CODES as [string, ...string[]]).optional(),
   brokerageId: z.string().uuid().nullable().optional(),
   timezone: timezone.optional(),
+  // Nullable AND optional, and the two mean different things: omitted leaves
+  // the stored value untouched (standard PATCH semantics), while an explicit
+  // null clears the rule back to unset. Without the null case a user who set a
+  // percentage could never remove it.
+  defaultRiskPercent: defaultRiskPercent.nullable().optional(),
 });
 
 export const AccountSchema = z.object({
@@ -79,6 +114,10 @@ export const AccountSchema = z.object({
   // ships derived account balances. Kept optional so existing callers/tests
   // that construct accounts without a balance continue to parse.
   balance: z.string().optional(),
+  // Null when no rule is set. `.optional()` as well as `.nullable()` for the
+  // same reason as `balance` above — existing callers and test fixtures build
+  // accounts without this field and must keep parsing.
+  defaultRiskPercent: z.string().nullable().optional(),
   // The two halves of `balance` (ledger-balances Req 10), same optionality
   // rationale. `cash` is the deployable figure; `positionValue` is the cost
   // basis of open positions and is NEGATIVE for shorts, where the unexited size


### PR DESCRIPTION
Adds an optional default risk percentage to each brokerage account, which seeds the position-size calculator so a trader starts from their own rule instead of retyping it on every calculation.

## What changed

- `accounts.default_risk_percent` — a new nullable `numeric(5,2)` column. NULL means no rule is set and preserves today's calculator behaviour exactly, so existing accounts see no change.
- Settable on create *and* edit, unlike the starting balance, because it rewrites no history. An explicit `null` on update clears the rule; an omitted key leaves it untouched.
- The account dialog gains the field as a hint rather than a prefilled value, so "no rule set" stays distinguishable from a deliberate choice.
- The calculator seeds `riskPercent` from the selected account. Overriding it affects only that calculation and never writes back to the account — there is a test that fails if any mutation is issued.

## Also fixes a pre-existing bug

`AccountList` keeps a single `AccountDialog` mounted and swaps the `account` prop, but `useForm` reads `defaultValues` only once. Opening edit therefore showed hardcoded defaults rather than the account's stored values — and submitting that form overwrote the user's real currency and timezone with `USD` / `America/New_York`.

This was latent before. Adding a risk field would have made it worse, because a blank-because-unseeded field submits as `null` and would clear a stored rule. Fixed with a `form.reset()` keyed on the account id, so a background refetch cannot discard in-progress edits. The regression tests were verified by disabling the fix and confirming they fail.

## Checks

Typecheck across all packages; the api, web and shared test suites; eslint; the migration check; and the generated reference artifacts regenerate to a clean tree.
