### PR TITLE
feat(settings): store the reporting timezone per user

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -14,7 +14,7 @@ import { advisorRouter } from '@/features/advisor/advisor.route';
 import { ListModelsCache } from '@/features/advisor/providers/list-models-cache';
 import { initProviderRegistry } from '@/features/advisor/providers/registry';
 import { applyBuiltinPersonaOverrides, runDecryptCanary } from '@/features/advisor/startup';
-import auth from '@/features/auth/auth.route';
+import auth, { userPreferencesRouter } from '@/features/auth/auth.route';
 import passwordResetRouter from '@/features/auth/password-reset.route';
 import verificationRouter from '@/features/auth/verification.route';
 import { billingRouter, billingWebhookRouter } from '@/features/billing/billing.route';
@@ -104,6 +104,9 @@ app.route('/api/symbols', symbolsRouter);
 app.route('/api', calculatorPreferencesRouter);
 app.route('/api', accountingRouter);
 app.route('/api', expensesRouter);
+// Same bare-/api reason as the three above: it owns the absolute
+// /api/users/me/timezone path, which cannot be declared on the /api/auth router.
+app.route('/api', userPreferencesRouter);
 
 // Error handler
 app.onError(errorHandler);

--- a/apps/api/src/db/migrations/0026_user_reporting_timezone.sql
+++ b/apps/api/src/db/migrations/0026_user_reporting_timezone.sql
@@ -1,0 +1,14 @@
+-- The user's REPORTING timezone — the zone P&L is bucketed into by day, week and
+-- month (user-onboarding R2). It is not a display format: nothing renders a
+-- timestamp in it. See users.schema.ts.
+--
+-- This is NOT accounts.timezone. That one is the account's trading-day boundary
+-- and defaults to America/New_York because that is where NYSE, NASDAQ and NYSE
+-- Arca run; this one follows the person and is seeded from the browser at
+-- registration. Neither is derived from the other.
+--
+-- Nullable with no backfill and no default: NULL marks a pre-migration row and
+-- is resolved at read time (R2.5), so no existing row is altered. No CHECK
+-- enumerating zones — validity is decided by resolveTimezone, and a hardcoded
+-- list would reject legitimate Etc/* zones.
+ALTER TABLE "users" ADD COLUMN "timezone" varchar(64);

--- a/apps/api/src/db/migrations/meta/0026_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0026_snapshot.json
@@ -1,0 +1,3429 @@
+{
+  "id": "77aeedbc-6e86-481a-946e-1efac99a285f",
+  "prevId": "6545c651-965a-49ae-873e-2b2ca4dd1ba5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.exchange_rates": {
+      "name": "exchange_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_currency": {
+          "name": "base_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_currency": {
+          "name": "quote_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(24, 12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exchange_rates_user_pair_date_unique": {
+          "name": "exchange_rates_user_pair_date_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "base_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exchange_rates_user_id_users_id_fk": {
+          "name": "exchange_rates_user_id_users_id_fk",
+          "tableFrom": "exchange_rates",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "exchange_rates_distinct_currencies_chk": {
+          "name": "exchange_rates_distinct_currencies_chk",
+          "value": "\"exchange_rates\".\"base_currency\" <> \"exchange_rates\".\"quote_currency\""
+        },
+        "exchange_rates_rate_positive_chk": {
+          "name": "exchange_rates_rate_positive_chk",
+          "value": "\"exchange_rates\".\"rate\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ledger_entries": {
+      "name": "ledger_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_id": {
+          "name": "position_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reverses_group_id": {
+          "name": "reverses_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ledger_user_id_idx": {
+          "name": "ledger_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_account_id_idx": {
+          "name": "ledger_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_user_account_occurred_pnl_idx": {
+          "name": "ledger_user_account_occurred_pnl_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"occurred_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ledger_entries\".\"entry_type\" IN ('position_pnl', 'position_pnl_reversal', 'balance_adjustment')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_user_account_direction_amount_pnl_idx": {
+          "name": "ledger_user_account_direction_amount_pnl_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ledger_entries\".\"entry_type\" IN ('position_pnl', 'position_pnl_reversal', 'balance_adjustment')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_reverses_group_id_idx": {
+          "name": "ledger_reverses_group_id_idx",
+          "columns": [
+            {
+              "expression": "reverses_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ledger_entries\".\"reverses_group_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ledger_entries_user_id_users_id_fk": {
+          "name": "ledger_entries_user_id_users_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ledger_entries_account_id_accounts_id_fk": {
+          "name": "ledger_entries_account_id_accounts_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "ledger_entries_position_id_positions_id_fk": {
+          "name": "ledger_entries_position_id_positions_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "positions",
+          "columnsFrom": ["position_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ledger_amount_nonneg_chk": {
+          "name": "ledger_amount_nonneg_chk",
+          "value": "\"ledger_entries\".\"amount\" >= 0"
+        },
+        "ledger_direction_chk": {
+          "name": "ledger_direction_chk",
+          "value": "\"ledger_entries\".\"direction\" IN ('credit', 'debit')"
+        },
+        "ledger_entry_type_chk": {
+          "name": "ledger_entry_type_chk",
+          "value": "\"ledger_entries\".\"entry_type\" IN ('position_pnl', 'position_pnl_reversal', 'balance_adjustment')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "brokerage_id": {
+          "name": "brokerage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_balance": {
+          "name": "starting_balance",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "default_risk_percent": {
+          "name": "default_risk_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_id_name_unique": {
+          "name": "accounts_user_id_name_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_brokerage_id_idx": {
+          "name": "accounts_brokerage_id_idx",
+          "columns": [
+            {
+              "expression": "brokerage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_brokerage_id_brokerages_id_fk": {
+          "name": "accounts_brokerage_id_brokerages_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "brokerages",
+          "columnsFrom": ["brokerage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_email": {
+          "name": "target_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_created_idx": {
+          "name": "admin_audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_actor_user_id_users_id_fk": {
+          "name": "admin_audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_users_id_fk": {
+          "name": "admin_audit_log_target_user_id_users_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["target_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "admin_audit_log_action_chk": {
+          "name": "admin_audit_log_action_chk",
+          "value": "\"admin_audit_log\".\"action\" IN ('admin_toggle')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.advisor_image_counters": {
+      "name": "advisor_image_counters",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_count": {
+          "name": "image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "advisor_image_counters_user_id_users_id_fk": {
+          "name": "advisor_image_counters_user_id_users_id_fk",
+          "tableFrom": "advisor_image_counters",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "advisor_image_counters_user_id_period_key_pk": {
+          "name": "advisor_image_counters_user_id_period_key_pk",
+          "columns": ["user_id", "period_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_turn_counters": {
+      "name": "advisor_turn_counters",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "allowance_turns": {
+          "name": "allowance_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "advisor_turn_counters_user_id_users_id_fk": {
+          "name": "advisor_turn_counters_user_id_users_id_fk",
+          "tableFrom": "advisor_turn_counters",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "advisor_turn_counters_user_id_period_key_pk": {
+          "name": "advisor_turn_counters_user_id_period_key_pk",
+          "columns": ["user_id", "period_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_conversations": {
+      "name": "advisor_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_conversations_user_updated_idx": {
+          "name": "advisor_conversations_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_conversations_user_id_users_id_fk": {
+          "name": "advisor_conversations_user_id_users_id_fk",
+          "tableFrom": "advisor_conversations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "advisor_conversations_persona_id_advisor_personas_id_fk": {
+          "name": "advisor_conversations_persona_id_advisor_personas_id_fk",
+          "tableFrom": "advisor_conversations",
+          "tableTo": "advisor_personas",
+          "columnsFrom": ["persona_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_messages": {
+      "name": "advisor_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_parts": {
+          "name": "content_parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_message_id": {
+          "name": "client_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_messages_conv_created_idx": {
+          "name": "advisor_messages_conv_created_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "advisor_messages_idem": {
+          "name": "advisor_messages_idem",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "role = 'user' AND client_message_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "advisor_messages_assistant_pair_uniq": {
+          "name": "advisor_messages_assistant_pair_uniq",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "role = 'assistant' AND client_message_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_messages_conversation_id_advisor_conversations_id_fk": {
+          "name": "advisor_messages_conversation_id_advisor_conversations_id_fk",
+          "tableFrom": "advisor_messages",
+          "tableTo": "advisor_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "advisor_messages_role_chk": {
+          "name": "advisor_messages_role_chk",
+          "value": "\"advisor_messages\".\"role\" IN ('user', 'assistant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.advisor_personas": {
+      "name": "advisor_personas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_personas_one_default_per_user": {
+          "name": "advisor_personas_one_default_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true AND user_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_personas_user_id_users_id_fk": {
+          "name": "advisor_personas_user_id_users_id_fk",
+          "tableFrom": "advisor_personas",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_provider_keys": {
+      "name": "advisor_provider_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hint_tail": {
+          "name": "key_hint_tail",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_provider_keys_user_provider_uniq": {
+          "name": "advisor_provider_keys_user_provider_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_provider_keys_user_id_users_id_fk": {
+          "name": "advisor_provider_keys_user_id_users_id_fk",
+          "tableFrom": "advisor_provider_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_summaries": {
+      "name": "advisor_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prose": {
+          "name": "prose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trade_data_figures": {
+          "name": "trade_data_figures",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered_through_message_id": {
+          "name": "covered_through_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered_through_created_at": {
+          "name": "covered_through_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_summaries_conversation_uniq": {
+          "name": "advisor_summaries_conversation_uniq",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_summaries_conversation_id_advisor_conversations_id_fk": {
+          "name": "advisor_summaries_conversation_id_advisor_conversations_id_fk",
+          "tableFrom": "advisor_summaries",
+          "tableTo": "advisor_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_api_keys": {
+      "name": "external_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hint_tail": {
+          "name": "key_hint_tail",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_api_keys_user_provider_uniq": {
+          "name": "external_api_keys_user_provider_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_api_keys_user_id_users_id_fk": {
+          "name": "external_api_keys_user_id_users_id_fk",
+          "tableFrom": "external_api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brokerages": {
+      "name": "brokerages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brokerages_user_id_idx": {
+          "name": "brokerages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brokerages_user_id_name_unique": {
+          "name": "brokerages_user_id_name_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"brokerages\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brokerages_system_name_unique": {
+          "name": "brokerages_system_name_unique",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"brokerages\".\"is_system\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brokerages_user_id_users_id_fk": {
+          "name": "brokerages_user_id_users_id_fk",
+          "tableFrom": "brokerages",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_schedules": {
+      "name": "fee_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "brokerage_id": {
+          "name": "brokerage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_per_share_commission": {
+          "name": "stock_per_share_commission",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "stock_min_per_fill": {
+          "name": "stock_min_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "stock_max_per_fill": {
+          "name": "stock_max_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_per_contract_commission": {
+          "name": "options_per_contract_commission",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_per_contract_exchange_fee": {
+          "name": "options_per_contract_exchange_fee",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_min_per_fill": {
+          "name": "options_min_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_max_per_fill": {
+          "name": "options_max_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_schedules_brokerage_id_brokerages_id_fk": {
+          "name": "fee_schedules_brokerage_id_brokerages_id_fk",
+          "tableFrom": "fee_schedules",
+          "tableTo": "brokerages",
+          "columnsFrom": ["brokerage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_schedules_brokerage_id_unique": {
+          "name": "fee_schedules_brokerage_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["brokerage_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.csv_import_counters": {
+      "name": "csv_import_counters",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "committed_count": {
+          "name": "committed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "csv_import_counters_user_id_users_id_fk": {
+          "name": "csv_import_counters_user_id_users_id_fk",
+          "tableFrom": "csv_import_counters",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.csv_import_staging": {
+      "name": "csv_import_staging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'staged'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committed_result": {
+          "name": "committed_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "csv_import_staging_one_active_per_user_idx": {
+          "name": "csv_import_staging_one_active_per_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"csv_import_staging\".\"status\" IN ('staged', 'committing')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "csv_import_staging_user_id_idx": {
+          "name": "csv_import_staging_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "csv_import_staging_expires_at_idx": {
+          "name": "csv_import_staging_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "csv_import_staging_user_id_users_id_fk": {
+          "name": "csv_import_staging_user_id_users_id_fk",
+          "tableFrom": "csv_import_staging",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "csv_import_staging_account_id_accounts_id_fk": {
+          "name": "csv_import_staging_account_id_accounts_id_fk",
+          "tableFrom": "csv_import_staging",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_layouts": {
+      "name": "dashboard_layouts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgets": {
+          "name": "widgets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_layouts_user_id_users_id_fk": {
+          "name": "dashboard_layouts_user_id_users_id_fk",
+          "tableFrom": "dashboard_layouts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_tokens": {
+      "name": "email_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_tokens_user_purpose_idx": {
+          "name": "email_tokens_user_purpose_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_tokens_one_live_per_user_purpose": {
+          "name": "email_tokens_one_live_per_user_purpose",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "consumed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_tokens_user_id_users_id_fk": {
+          "name": "email_tokens_user_id_users_id_fk",
+          "tableFrom": "email_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_tokens_token_hash_unique": {
+          "name": "email_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_tokens_purpose_chk": {
+          "name": "email_tokens_purpose_chk",
+          "value": "\"email_tokens\".\"purpose\" IN ('password_reset','email_verification')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.expenses": {
+      "name": "expenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "expenses_user_id_idx": {
+          "name": "expenses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "expenses_user_occurred_idx": {
+          "name": "expenses_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"occurred_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "expenses_user_id_users_id_fk": {
+          "name": "expenses_user_id_users_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "expenses_amount_positive_chk": {
+          "name": "expenses_amount_positive_chk",
+          "value": "\"expenses\".\"amount\" > 0"
+        },
+        "expenses_category_chk": {
+          "name": "expenses_category_chk",
+          "value": "category IN ('data_subscription', 'platform_fee', 'software', 'education', 'hardware', 'other')"
+        },
+        "expenses_currency_chk": {
+          "name": "expenses_currency_chk",
+          "value": "currency IN ('USD', 'EUR', 'GBP', 'CAD', 'AUD', 'JPY', 'CHF', 'HKD', 'SGD', 'NZD', 'SEK', 'NOK', 'DKK', 'MXN', 'BRL', 'INR', 'KRW', 'TWD', 'ZAR')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public._post_migrations_journal": {
+      "name": "_post_migrations_journal",
+      "schema": "",
+      "columns": {
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fills": {
+      "name": "fills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "position_id": {
+          "name": "position_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fees": {
+          "name": "fees",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filled_at": {
+          "name": "filled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fills_position_id_idx": {
+          "name": "fills_position_id_idx",
+          "columns": [
+            {
+              "expression": "position_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fills_position_id_positions_id_fk": {
+          "name": "fills_position_id_positions_id_fk",
+          "tableFrom": "fills",
+          "tableTo": "positions",
+          "columnsFrom": ["position_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.positions": {
+      "name": "positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_price": {
+          "name": "target_price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_loss": {
+          "name": "stop_loss",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_flat_at": {
+          "name": "last_flat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_flat_net_pnl": {
+          "name": "last_flat_net_pnl",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "positions_user_id_idx": {
+          "name": "positions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "positions_account_id_idx": {
+          "name": "positions_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "positions_user_id_status_updated_at_idx": {
+          "name": "positions_user_id_status_updated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "positions_user_status_closed_at_idx": {
+          "name": "positions_user_status_closed_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "positions_user_id_users_id_fk": {
+          "name": "positions_user_id_users_id_fk",
+          "tableFrom": "positions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "positions_account_id_accounts_id_fk": {
+          "name": "positions_account_id_accounts_id_fk",
+          "tableFrom": "positions",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "positions_closed_at_when_closed_chk": {
+          "name": "positions_closed_at_when_closed_chk",
+          "value": "\"positions\".\"status\" <> 'closed' OR \"positions\".\"closed_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.symbol_sync_state": {
+      "name": "symbol_sync_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "smallint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncing": {
+          "name": "syncing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "syncing_started_at": {
+          "name": "syncing_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "symbol_count": {
+          "name": "symbol_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "symbol_sync_state_singleton": {
+          "name": "symbol_sync_state_singleton",
+          "value": "\"symbol_sync_state\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.symbols": {
+      "name": "symbols",
+      "schema": "",
+      "columns": {
+        "ticker": {
+          "name": "ticker",
+          "type": "varchar(16)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exchange": {
+          "name": "exchange",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cik": {
+          "name": "cik",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "symbols_ticker_prefix_idx": {
+          "name": "symbols_ticker_prefix_idx",
+          "columns": [
+            {
+              "expression": "ticker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "varchar_pattern_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed": {
+          "name": "last_accessed",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_currency": {
+          "name": "display_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_jurisdiction": {
+          "name": "tax_jurisdiction",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "buying_power_basis": {
+          "name": "buying_power_basis",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cash'"
+        },
+        "advisor_default_persona_id": {
+          "name": "advisor_default_persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advisor_trade_data_consent": {
+          "name": "advisor_trade_data_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "writable_account_id": {
+          "name": "writable_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changelog_viewed_at": {
+          "name": "changelog_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_tax_jurisdiction_chk": {
+          "name": "users_tax_jurisdiction_chk",
+          "value": "\"users\".\"tax_jurisdiction\" IS NULL OR \"users\".\"tax_jurisdiction\" IN ('US', 'CA', 'other')"
+        },
+        "users_theme_chk": {
+          "name": "users_theme_chk",
+          "value": "\"users\".\"theme\" IN ('light','dark','system')"
+        },
+        "users_buying_power_basis_chk": {
+          "name": "users_buying_power_basis_chk",
+          "value": "\"users\".\"buying_power_basis\" IN ('cash','balance')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_customers": {
+      "name": "billing_customers",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_customers_user_id_users_id_fk": {
+          "name": "billing_customers_user_id_users_id_fk",
+          "tableFrom": "billing_customers",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_customers_stripe_customer_id_unique": {
+          "name": "billing_customers_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_customer_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_unit_amount": {
+          "name": "price_unit_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_currency": {
+          "name": "price_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_created_at": {
+          "name": "stripe_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entered_past_due_at": {
+          "name": "entered_past_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_created": {
+          "name": "last_event_created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_subscription_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_cost": {
+          "name": "credit_cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_cost": {
+          "name": "raw_cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_records_user_created_idx": {
+          "name": "usage_records_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_records_created_idx": {
+          "name": "usage_records_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_user_id_users_id_fk": {
+          "name": "usage_records_user_id_users_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_records_conversation_id_advisor_conversations_id_fk": {
+          "name": "usage_records_conversation_id_advisor_conversations_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "advisor_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "usage_records_message_id_advisor_messages_id_fk": {
+          "name": "usage_records_message_id_advisor_messages_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "advisor_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_transactions": {
+      "name": "wallet_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_record_id": {
+          "name": "usage_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_transactions_user_created_idx": {
+          "name": "wallet_transactions_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transactions_payment_intent_idx": {
+          "name": "wallet_transactions_payment_intent_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_transactions_user_id_users_id_fk": {
+          "name": "wallet_transactions_user_id_users_id_fk",
+          "tableFrom": "wallet_transactions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_transactions_usage_record_id_usage_records_id_fk": {
+          "name": "wallet_transactions_usage_record_id_usage_records_id_fk",
+          "tableFrom": "wallet_transactions",
+          "tableTo": "usage_records",
+          "columnsFrom": ["usage_record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "wallet_transactions_kind_chk": {
+          "name": "wallet_transactions_kind_chk",
+          "value": "\"wallet_transactions\".\"kind\" IN ('credit', 'debit', 'reversal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "reserved": {
+          "name": "reserved",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallets_user_id_users_id_fk": {
+          "name": "wallets_user_id_users_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "wallets_reserved_nonneg_chk": {
+          "name": "wallets_reserved_nonneg_chk",
+          "value": "\"wallets\".\"reserved\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_events_stripe_event_id_unique": {
+          "name": "webhook_events_stripe_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_event_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webhook_events_status_chk": {
+          "name": "webhook_events_status_chk",
+          "value": "\"webhook_events\".\"status\" IN ('received', 'processed', 'ignored', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1785962349981,
       "tag": "0025_account_default_risk_percent",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1785986843966,
+      "tag": "0026_user_reporting_timezone",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema/users.schema.ts
+++ b/apps/api/src/db/schema/users.schema.ts
@@ -21,6 +21,18 @@ export const users = pgTable(
     // existing rows as verified, D10). Registration always writes the value explicitly.
     emailVerified: boolean('email_verified').notNull().default(true),
     displayCurrency: varchar('display_currency', { length: 3 }),
+    // The user's REPORTING timezone (user-onboarding R2): the zone P&L is bucketed
+    // into by day, week and month. It is not a display format — nothing renders a
+    // timestamp in it. NOT the same thing as accounts.timezone,
+    // which is the account's *trading-day boundary* and defaults to America/New_York
+    // because that is where NYSE, NASDAQ and NYSE Arca run. This one is seeded from
+    // the browser at registration and follows the person, not the market. Neither is
+    // derived from the other (R2.7).
+    // Nullable with no backfill: NULL marks a pre-migration row and is resolved at
+    // read time by resolveTimezone (R2.5). No CHECK constraint enumerating zones —
+    // validity is decided by resolveTimezone, and a hardcoded list would reject
+    // legitimate Etc/* zones.
+    timezone: varchar('timezone', { length: 64 }),
     taxJurisdiction: varchar('tax_jurisdiction', { length: 8 }),
     theme: varchar('theme', { length: 8 }).notNull().default('system'),
     // Which account figure the position-sizing calculator's buying-power cap is

--- a/apps/api/src/features/auth/auth.query.ts
+++ b/apps/api/src/features/auth/auth.query.ts
@@ -8,9 +8,14 @@ type DB = Database | Transaction;
 // `emailVerified` is OPTIONAL (MN-3): registration passes it explicitly
 // (Component 7); callers that omit it (db/seed/demo.ts, any future path)
 // inherit the DB default `true` — drizzle emits SQL DEFAULT for undefined.
+//
+// `timezone` is likewise optional. The column has no DB default, so omitting it
+// stores NULL — indistinguishable from a pre-migration row, which then resolves
+// through `getReportingTimezone` (user-onboarding R2.5). Registration always
+// passes a value (browser-detected or the default, R2.3).
 export function insertUser(
   db: DB,
-  data: { email: string; passwordHash: string; emailVerified?: boolean },
+  data: { email: string; passwordHash: string; emailVerified?: boolean; timezone?: string },
 ) {
   return db
     .insert(users)
@@ -18,9 +23,29 @@ export function insertUser(
       email: data.email,
       passwordHash: data.passwordHash,
       emailVerified: data.emailVerified,
+      timezone: data.timezone,
     })
     .returning()
     .then((rows) => rows[0]);
+}
+
+/**
+ * Raw read of the user's reporting timezone. Returns the column verbatim —
+ * `null` for a pre-migration row, `undefined` for no such user. Resolving
+ * either to a usable zone is `getReportingTimezone`'s job, not this one's.
+ */
+export function selectUserTimezone(db: DB, userId: string) {
+  return db
+    .select({ timezone: users.timezone })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1)
+    .then((rows) => rows[0]?.timezone);
+}
+
+/** Persist the reporting timezone. Zone validity is the route's Zod duty. */
+export function updateUserTimezone(db: DB, userId: string, timezone: string) {
+  return db.update(users).set({ timezone, updatedAt: new Date() }).where(eq(users.id, userId));
 }
 
 export function selectUserByEmail(db: DB, email: string) {

--- a/apps/api/src/features/auth/auth.route.ts
+++ b/apps/api/src/features/auth/auth.route.ts
@@ -4,6 +4,7 @@ import { eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { setCookie, getCookie } from 'hono/cookie';
 
+import { UserTimezoneSchema } from '@tradr/shared';
 import { RegisterSchema, LoginSchema } from '@tradr/shared/schemas/auth';
 
 import { db } from '@/db';
@@ -13,7 +14,20 @@ import { validate } from '@/lib/validation';
 import { authMiddleware } from '@/middleware/auth.middleware';
 import { createRateLimiter } from '@/middleware/rate-limit.middleware';
 
-import { registerUser, loginUser, logoutUser } from './auth.service';
+import {
+  registerUser,
+  loginUser,
+  logoutUser,
+  getReportingTimezone,
+  setReportingTimezone,
+} from './auth.service';
+
+type AuthEnv = {
+  Variables: {
+    userId: string;
+    isAdmin: boolean;
+  };
+};
 
 const auth = new Hono();
 
@@ -40,6 +54,16 @@ const auth = new Hono();
  *             properties:
  *               email: { type: string, format: email }
  *               password: { type: string, minLength: 8, maxLength: 72 }
+ *               timezone:
+ *                 type: string
+ *                 maxLength: 64
+ *                 description: >
+ *                   Optional IANA zone the client detected in the browser, stored
+ *                   as the user's reporting timezone. Omit it and the account is
+ *                   created with the default, `UTC`; it is changeable afterwards
+ *                   via `PUT /api/users/me/timezone`. Unrelated to an account's
+ *                   trading-day timezone.
+ *                 example: Europe/London
  *     responses:
  *       201:
  *         description: The new user. The `session` cookie is set.
@@ -67,8 +91,10 @@ auth.post(
   createRateLimiter({ name: 'register', max: 5, windowMs: 15 * 60 * 1000, fallbackMax: 3 }),
   validate('json', RegisterSchema),
   async (c) => {
-    const { email, password } = c.req.valid('json');
-    const { user, token } = await registerUser(email, password);
+    // `timezone` is optional and absent for every scripted or e2e registration
+    // that predates it; registerUser substitutes the default (R2.3).
+    const { email, password, timezone } = c.req.valid('json');
+    const { user, token } = await registerUser(email, password, timezone);
 
     setCookie(c, 'session', token, sessionCookieOptions());
 
@@ -230,6 +256,105 @@ auth.get('/me', authMiddleware, async (c) => {
     { id: userId, email: result[0].email, isAdmin, emailVerified: result[0].emailVerified },
     200,
   );
+});
+
+// ---------------------------------------------------------------------------
+// User reporting timezone
+//
+// A stored per-user preference, so it follows the established
+// `/api/users/me/<preference>` convention rather than inventing another one —
+// as with `/users/me/buying-power-basis` (calculator), `/users/me/display-currency`
+// (accounting) and `/users/me/tax-jurisdiction` (expenses).
+//
+// It gets its OWN router because that path is absolute: `auth` is mounted at
+// `/api/auth`, so a `/users/me/...` path declared on it would resolve to
+// `/api/auth/users/me/...`. Mounted bare at `/api` in app.ts. It lives in the
+// auth slice because the auth slice is the one that owns the `users` row —
+// `registerUser` seeds this very column — and a whole feature slice for one
+// scalar preference would be the invention the convention exists to avoid.
+// ---------------------------------------------------------------------------
+
+export const userPreferencesRouter = new Hono<AuthEnv>();
+
+userPreferencesRouter.use(authMiddleware);
+
+/**
+ * @swagger
+ * /api/users/me/timezone:
+ *   get:
+ *     summary: Get the reporting timezone.
+ *     description: >
+ *       Authed. The IANA zone the user's P&L is bucketed into by day, week and
+ *       month. It does not affect how individual timestamps are displayed.
+ *       `timezone` is never null: accounts created before the preference
+ *       existed store nothing and read as the default `UTC`, with `stored`
+ *       false to say so. This is not an account's trading-day timezone — that
+ *       one defaults to US Eastern because that is where the US equity venues
+ *       run, and setting either leaves the other untouched.
+ *     tags: [Auth]
+ *     responses:
+ *       200:
+ *         description: The resolved reporting timezone, and whether it is the user's own.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 timezone: { type: string, example: Europe/London }
+ *                 stored:
+ *                   type: boolean
+ *                   description: >
+ *                     True when `timezone` is the value held on the user's row.
+ *                     False when the column is unset — a row predating the
+ *                     preference — and the server default is being substituted;
+ *                     a client may then seed the column once from the zone it
+ *                     detects, which is what that user was already bucketing by.
+ *                   example: true
+ *       401: { description: Authentication required. }
+ */
+userPreferencesRouter.get('/users/me/timezone', async (c) => {
+  const userId = c.get('userId');
+  const { timezone, stored } = await getReportingTimezone(userId);
+  return c.json({ timezone, stored }, 200);
+});
+
+/**
+ * @swagger
+ * /api/users/me/timezone:
+ *   put:
+ *     summary: Set the reporting timezone.
+ *     description: >
+ *       Authed. Changes which calendar day each trade is counted in for daily,
+ *       weekly and monthly figures. It rewrites no stored timestamp — every
+ *       fill keeps the instant it happened — it does not change how timestamps
+ *       are displayed, and it does not touch any account's trading-day
+ *       timezone.
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [timezone]
+ *             properties:
+ *               timezone:
+ *                 type: string
+ *                 maxLength: 64
+ *                 description: An IANA zone name, such as `Europe/London` or `UTC`.
+ *                 example: Europe/London
+ *     responses:
+ *       200: { description: The stored reporting timezone. }
+ *       400: { description: Not a valid IANA timezone name. }
+ *       401: { description: Authentication required. }
+ */
+userPreferencesRouter.put('/users/me/timezone', validate('json', UserTimezoneSchema), async (c) => {
+  const userId = c.get('userId');
+  const { timezone } = c.req.valid('json');
+  await setReportingTimezone(userId, timezone);
+  // Same shape as the GET, so one client type covers both. `stored` is true by
+  // construction here: the write just put this value on the row.
+  return c.json({ timezone, stored: true }, 200);
 });
 
 export default auth;

--- a/apps/api/src/features/auth/auth.service.ts
+++ b/apps/api/src/features/auth/auth.service.ts
@@ -2,6 +2,8 @@ import crypto from 'node:crypto';
 
 import bcrypt from 'bcrypt';
 
+import { DEFAULT_REPORTING_TIMEZONE } from '@tradr/shared';
+
 import { db } from '@/db';
 import { isEmailConfigured } from '@/lib/config';
 import { ConflictError, UnauthorizedError } from '@/lib/errors';
@@ -17,6 +19,8 @@ import {
   deleteSessionByTokenHash,
   countUserSessions,
   deleteOldestSession,
+  selectUserTimezone,
+  updateUserTimezone,
 } from './auth.query';
 import { issueEmailToken, VERIFY_TOKEN_TTL_MS } from './email-tokens.service';
 
@@ -35,7 +39,7 @@ export async function hashPassword(plain: string) {
   return bcrypt.hash(plain, BCRYPT_COST);
 }
 
-export async function registerUser(email: string, password: string) {
+export async function registerUser(email: string, password: string, timezone?: string) {
   const passwordHash = await hashPassword(password);
 
   let user;
@@ -43,7 +47,17 @@ export async function registerUser(email: string, password: string) {
     // Verified-at-creation on email-less instances (REQ-6.4(a)'s
     // zero-persistence branch, D10): configured ⇒ false (verification email
     // follows below); unconfigured ⇒ true (nothing is ever demanded).
-    user = await insertUser(db, { email, passwordHash, emailVerified: !isEmailConfigured() });
+    //
+    // The reporting zone (user-onboarding R2.2/R2.3) is seeded from the
+    // client's browser-detected value, or from the defined default when the
+    // client sends none — never left NULL to be guessed at later. A NULL
+    // column is reserved for rows that predate the column (R2.5).
+    user = await insertUser(db, {
+      email,
+      passwordHash,
+      emailVerified: !isEmailConfigured(),
+      timezone: timezone ?? DEFAULT_REPORTING_TIMEZONE,
+    });
   } catch (error: unknown) {
     if (error instanceof Error && 'code' in error && (error as { code: string }).code === '23505') {
       throw new ConflictError('An account with this email already exists');
@@ -130,4 +144,36 @@ export async function loginUser(email: string, password: string) {
 
 export async function logoutUser(tokenHash: string) {
   await deleteSessionByTokenHash(db, tokenHash);
+}
+
+/**
+ * The user's REPORTING timezone — the zone P&L is bucketed into by day, week
+ * and month (user-onboarding R2). Distinct from `accounts.timezone`, the
+ * account's trading-day boundary; neither is derived from the other (R2.7).
+ *
+ * Always resolves to a usable zone, never null. `users.timezone` is nullable
+ * with no DB default, so NULL means the row predates the column; registration
+ * has seeded a value since (R2.3), so the fallback here is the pre-migration
+ * path (R2.5) plus the missing-row case of a deleted user racing a request. It
+ * is the SAME constant registration falls back to, so the two paths cannot
+ * drift apart.
+ *
+ * `stored` reports WHICH of those two happened, and exists because the resolved
+ * zone alone cannot tell a client "never set" from "deliberately UTC" — and the
+ * client needs that distinction to seed a pre-migration row once with the zone
+ * the user was already bucketing by, without ever overwriting a chosen one
+ * (R2.5). The read itself stays side-effect-free: the server does not backfill.
+ */
+export async function getReportingTimezone(
+  userId: string,
+): Promise<{ timezone: string; stored: boolean }> {
+  const stored = await selectUserTimezone(db, userId);
+  return stored == null
+    ? { timezone: DEFAULT_REPORTING_TIMEZONE, stored: false }
+    : { timezone: stored, stored: true };
+}
+
+/** Persist the reporting timezone. Zone validity is the route's Zod duty. */
+export async function setReportingTimezone(userId: string, timezone: string): Promise<void> {
+  await updateUserTimezone(db, userId, timezone);
 }

--- a/apps/api/src/features/auth/user-timezone.test.ts
+++ b/apps/api/src/features/auth/user-timezone.test.ts
@@ -1,0 +1,281 @@
+import { readFile } from 'node:fs/promises';
+
+import { eq } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_REPORTING_TIMEZONE } from '@tradr/shared';
+
+import app from '@/app';
+import { db } from '@/db';
+import { users } from '@/db/schema';
+
+// A sibling of auth.test.ts rather than an addition to it: that file's closing
+// test pins the four frozen auth response shapes byte-for-byte, and the
+// reporting timezone is a separate preference surface that happens to be seeded
+// by the same register call.
+
+let testCounter = 0;
+const testRunId = Date.now();
+function uniqueEmail() {
+  return `tz-test${testRunId}-${++testCounter}@example.com`;
+}
+
+// Own /8 sub-range (auth.test.ts owns 10.0, password-reset 10.20,
+// verification 10.30) so the register limiter never sees a shared client.
+let ipCounter = 0;
+function uniqueIp() {
+  return `10.31.${Math.floor(ipCounter / 250)}.${(ipCounter++ % 250) + 1}`;
+}
+
+function getCookieValue(res: Response, name: string): string | undefined {
+  for (const header of res.headers.getSetCookie()) {
+    const match = header.match(new RegExp(`${name}=([^;]*)`));
+    if (match) return match[1];
+  }
+  return undefined;
+}
+
+function register(body: Record<string, unknown>) {
+  return app.request('/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-Forwarded-For': uniqueIp() },
+    body: JSON.stringify(body),
+  });
+}
+
+async function registerAndGetCookie(
+  extra: Record<string, unknown> = {},
+): Promise<{ cookie: string; email: string }> {
+  const email = uniqueEmail();
+  const res = await register({ email, password: 'password123', ...extra });
+  expect(res.status).toBe(201);
+  const cookie = getCookieValue(res, 'session');
+  expect(cookie).toBeDefined();
+  return { cookie: cookie!, email };
+}
+
+function authedRequest(method: string, path: string, cookie: string, body?: unknown) {
+  const headers: Record<string, string> = {
+    Cookie: `session=${cookie}`,
+    'X-Forwarded-For': uniqueIp(),
+  };
+  if (body !== undefined) headers['Content-Type'] = 'application/json';
+  return app.request(path, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+/** The column verbatim — `null` distinguishes a pre-migration row from a seed. */
+function storedTimezone(email: string) {
+  return db
+    .select({ timezone: users.timezone })
+    .from(users)
+    .where(eq(users.email, email))
+    .then((rows) => rows[0]?.timezone);
+}
+
+async function getTimezoneBody(cookie: string): Promise<{ timezone: string; stored: boolean }> {
+  const res = await authedRequest('GET', '/api/users/me/timezone', cookie);
+  expect(res.status).toBe(200);
+  return await res.json();
+}
+
+async function getTimezone(cookie: string) {
+  return (await getTimezoneBody(cookie)).timezone;
+}
+
+describe('registration seeds the reporting timezone', () => {
+  it('persists a browser-detected zone supplied at registration', async () => {
+    const { cookie, email } = await registerAndGetCookie({ timezone: 'Europe/London' });
+    expect(await storedTimezone(email)).toBe('Europe/London');
+    expect(await getTimezone(cookie)).toBe('Europe/London');
+  });
+
+  it('falls back to the default when no zone is supplied', async () => {
+    // R2.3: absent ⇒ a defined default is STORED, not left null to be guessed
+    // at later. The stored value, not just the read, is asserted.
+    const { cookie, email } = await registerAndGetCookie();
+    expect(await storedTimezone(email)).toBe(DEFAULT_REPORTING_TIMEZONE);
+    expect(await getTimezone(cookie)).toBe(DEFAULT_REPORTING_TIMEZONE);
+  });
+
+  it('rejects an invalid zone at registration without creating the user', async () => {
+    const email = uniqueEmail();
+    const res = await register({ email, password: 'password123', timezone: 'Mars/Olympus_Mons' });
+    expect(res.status).toBe(400);
+    expect(await storedTimezone(email)).toBeUndefined();
+  });
+
+  it('accepts a zone Intl.supportedValuesOf omits', async () => {
+    // Etc/* and bare UTC are real zones the picker list does not carry; the
+    // register path must not narrow to that list.
+    const { email } = await registerAndGetCookie({ timezone: 'Etc/GMT+5' });
+    expect(await storedTimezone(email)).toBe('Etc/GMT+5');
+  });
+});
+
+describe('GET/PUT /api/users/me/timezone', () => {
+  it('resolves a pre-migration NULL column to the default, flagged as NOT stored', async () => {
+    // R2.5: rows that predate the column read without erroring. NULLing the
+    // column directly is the only way to reach that state now that
+    // registration always seeds one.
+    const { cookie, email } = await registerAndGetCookie({ timezone: 'Asia/Tokyo' });
+    await db.update(users).set({ timezone: null }).where(eq(users.email, email));
+    expect(await storedTimezone(email)).toBeNull();
+
+    // `stored: false` is what lets a client tell "never set" from "deliberately
+    // UTC" and seed the row once with the zone that user was already bucketed
+    // by. Without it the two are the same response and no backfill is safe.
+    expect(await getTimezoneBody(cookie)).toEqual({
+      timezone: DEFAULT_REPORTING_TIMEZONE,
+      stored: false,
+    });
+    // The read stays side-effect-free — it must not backfill the column.
+    expect(await storedTimezone(email)).toBeNull();
+  });
+
+  it('flags a deliberately-UTC row as stored, distinguishing it from a NULL one', async () => {
+    // The pair this endpoint has to keep apart: both read `timezone: 'UTC'`,
+    // and only one of them may be overwritten by a client-side backfill.
+    const { cookie } = await registerAndGetCookie({ timezone: 'UTC' });
+    expect(await getTimezoneBody(cookie)).toEqual({ timezone: 'UTC', stored: true });
+  });
+
+  it('flags a seeded zone as stored', async () => {
+    const { cookie } = await registerAndGetCookie({ timezone: 'Europe/London' });
+    expect(await getTimezoneBody(cookie)).toEqual({ timezone: 'Europe/London', stored: true });
+  });
+
+  it('round-trips a change through PUT', async () => {
+    const { cookie, email } = await registerAndGetCookie();
+
+    const put = await authedRequest('PUT', '/api/users/me/timezone', cookie, {
+      timezone: 'Australia/Sydney',
+    });
+    expect(put.status).toBe(200);
+    // Same shape as the GET; a write makes the value stored by construction.
+    expect(await put.json()).toEqual({ timezone: 'Australia/Sydney', stored: true });
+
+    expect(await getTimezoneBody(cookie)).toEqual({
+      timezone: 'Australia/Sydney',
+      stored: true,
+    });
+    expect(await storedTimezone(email)).toBe('Australia/Sydney');
+  });
+
+  it('turns a pre-migration NULL into a stored zone once written', async () => {
+    // The exact transition the one-time client backfill drives: `stored: false`
+    // → PUT the browser zone → `stored: true`, after which nothing may
+    // overwrite it again.
+    const { cookie, email } = await registerAndGetCookie();
+    await db.update(users).set({ timezone: null }).where(eq(users.email, email));
+    expect((await getTimezoneBody(cookie)).stored).toBe(false);
+
+    const put = await authedRequest('PUT', '/api/users/me/timezone', cookie, {
+      timezone: 'America/New_York',
+    });
+    expect(put.status).toBe(200);
+
+    expect(await getTimezoneBody(cookie)).toEqual({
+      timezone: 'America/New_York',
+      stored: true,
+    });
+  });
+
+  it('rejects an invalid zone with 400 and leaves the stored value alone', async () => {
+    const { cookie, email } = await registerAndGetCookie({ timezone: 'Europe/Paris' });
+
+    const res = await authedRequest('PUT', '/api/users/me/timezone', cookie, {
+      timezone: 'Not/AZone',
+    });
+    expect(res.status).toBe(400);
+    expect(await storedTimezone(email)).toBe('Europe/Paris');
+  });
+
+  it('rejects the Unicode-extension bypass and an over-length value', async () => {
+    const { cookie } = await registerAndGetCookie();
+
+    const decorated = await authedRequest('PUT', '/api/users/me/timezone', cookie, {
+      timezone: 'America/New_York-u-ca-japanese',
+    });
+    expect(decorated.status).toBe(400);
+
+    const tooLong = await authedRequest('PUT', '/api/users/me/timezone', cookie, {
+      timezone: `America/${'x'.repeat(64)}`,
+    });
+    expect(tooLong.status).toBe(400);
+  });
+
+  it('rejects a missing body field', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const res = await authedRequest('PUT', '/api/users/me/timezone', cookie, {});
+    expect(res.status).toBe(400);
+  });
+
+  it('requires authentication on both verbs', async () => {
+    const get = await app.request('/api/users/me/timezone', {
+      headers: { 'X-Forwarded-For': uniqueIp() },
+    });
+    expect(get.status).toBe(401);
+
+    const put = await app.request('/api/users/me/timezone', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', 'X-Forwarded-For': uniqueIp() },
+      body: JSON.stringify({ timezone: 'Europe/London' }),
+    });
+    expect(put.status).toBe(401);
+  });
+
+  it('is scoped to the calling user and ignores a userId in the body', async () => {
+    const a = await registerAndGetCookie({ timezone: 'Europe/Lisbon' });
+    const b = await registerAndGetCookie({ timezone: 'Asia/Kolkata' });
+
+    const bRow = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.email, b.email))
+      .then((rows) => rows[0]);
+
+    // A names B and asks for B's zone to change. The endpoint takes its subject
+    // from the session only, so this writes A's row and leaves B's untouched.
+    const res = await authedRequest('PUT', '/api/users/me/timezone', a.cookie, {
+      userId: bRow.id,
+      timezone: 'Pacific/Auckland',
+    });
+    expect(res.status).toBe(200);
+
+    expect(await storedTimezone(a.email)).toBe('Pacific/Auckland');
+    expect(await storedTimezone(b.email)).toBe('Asia/Kolkata');
+
+    // And neither session can read the other's value.
+    expect(await getTimezone(a.cookie)).toBe('Pacific/Auckland');
+    expect(await getTimezone(b.cookie)).toBe('Asia/Kolkata');
+  });
+});
+
+// The zone is a BUCKETING zone and nothing else. Timestamps are rendered by
+// `lib/format.ts` in the browser zone, by `optionContract.ts` in UTC and by
+// `reopenWindow.ts` in the ACCOUNT zone — so any surface claiming this column
+// is "the zone timestamps are displayed in" is stating something false about
+// three other modules. The claim was written into five places at once and
+// corrected in four; only this test stops the fifth from drifting back.
+describe('the reporting timezone is documented as a bucketing zone, not a display zone', () => {
+  const SURFACES = [
+    'db/migrations/0026_user_reporting_timezone.sql',
+    'db/schema/users.schema.ts',
+    'features/auth/auth.route.ts',
+  ];
+
+  it.each(SURFACES)('%s describes bucketing and never claims a display zone', async (relPath) => {
+    const source = await readFile(new URL(`../../${relPath}`, import.meta.url), 'utf8');
+    // Strip the comment markers and collapse the wrapping before matching: the
+    // original claim was split across two comment lines ("…and timestamps\n--
+    // are displayed in…"), so a naive regex over the raw file misses it.
+    const prose = source.replace(/^[ \t]*(?:--|\/\/|\*|\/\*)+/gm, ' ').replace(/\s+/g, ' ');
+
+    expect(prose).toMatch(/bucketed/);
+    expect(prose).not.toMatch(/timestamps? (?:are|is) displayed in/i);
+  });
+});

--- a/apps/docs/src/content/docs/self-hosting/reference/db-schema.mdx
+++ b/apps/docs/src/content/docs/self-hosting/reference/db-schema.mdx
@@ -6,9 +6,9 @@ description: Every table Tradr creates, its columns, and how they reference each
 {/* GENERATED FILE — do not edit.
     Source: apps/api/src/db/migrations/meta/ (latest snapshot) · Generator: apps/docs/scripts/gen-db-schema.mjs */}
 
-Tradr's schema is **32 tables**, created by **26 migrations** that run
+Tradr's schema is **32 tables**, created by **27 migrations** that run
 automatically when the api boots. This page is generated from the Drizzle snapshot
-for the latest migration (`0025_account_default_risk_percent`), so it describes the schema the migrations
+for the latest migration (`0026_user_reporting_timezone`), so it describes the schema the migrations
 actually produce.
 
 You do not need any of this to run Tradr. It is here for writing queries against
@@ -32,6 +32,7 @@ a query you write against these tables may need updating on any release.
 | `is_admin` | `boolean` | not null, default `false` |
 | `email_verified` | `boolean` | not null, default `true` |
 | `display_currency` | `varchar(3)` | — |
+| `timezone` | `varchar(64)` | — |
 | `tax_jurisdiction` | `varchar(8)` | — |
 | `theme` | `varchar(8)` | not null, default `'system'` |
 | `buying_power_basis` | `varchar(7)` | not null, default `'cash'` |

--- a/apps/docs/src/openapi/tradr-api.json
+++ b/apps/docs/src/openapi/tradr-api.json
@@ -1727,6 +1727,12 @@
                     "maxLength": 72,
                     "minLength": 8,
                     "type": "string"
+                  },
+                  "timezone": {
+                    "description": "Optional IANA zone the client detected in the browser, stored as the user's reporting timezone. Omit it and the account is created with the default, `UTC`; it is changeable afterwards via `PUT /api/users/me/timezone`. Unrelated to an account's trading-day timezone.\n",
+                    "example": "Europe/London",
+                    "maxLength": 64,
+                    "type": "string"
                   }
                 },
                 "required": [
@@ -4365,6 +4371,80 @@
         "summary": "Set the tax jurisdiction.",
         "tags": [
           "Expenses"
+        ]
+      }
+    },
+    "/api/users/me/timezone": {
+      "get": {
+        "description": "Authed. The IANA zone the user's P&L is bucketed into by day, week and month. It does not affect how individual timestamps are displayed. `timezone` is never null: accounts created before the preference existed store nothing and read as the default `UTC`, with `stored` false to say so. This is not an account's trading-day timezone — that one defaults to US Eastern because that is where the US equity venues run, and setting either leaves the other untouched.\n",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "stored": {
+                      "description": "True when `timezone` is the value held on the user's row. False when the column is unset — a row predating the preference — and the server default is being substituted; a client may then seed the column once from the zone it detects, which is what that user was already bucketing by.\n",
+                      "example": true,
+                      "type": "boolean"
+                    },
+                    "timezone": {
+                      "example": "Europe/London",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The resolved reporting timezone, and whether it is the user's own."
+          },
+          "401": {
+            "description": "Authentication required."
+          }
+        },
+        "summary": "Get the reporting timezone.",
+        "tags": [
+          "Auth"
+        ]
+      },
+      "put": {
+        "description": "Authed. Changes which calendar day each trade is counted in for daily, weekly and monthly figures. It rewrites no stored timestamp — every fill keeps the instant it happened — it does not change how timestamps are displayed, and it does not touch any account's trading-day timezone.\n",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "timezone": {
+                    "description": "An IANA zone name, such as `Europe/London` or `UTC`.",
+                    "example": "Europe/London",
+                    "maxLength": 64,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "timezone"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The stored reporting timezone."
+          },
+          "400": {
+            "description": "Not a valid IANA timezone name."
+          },
+          "401": {
+            "description": "Authentication required."
+          }
+        },
+        "summary": "Set the reporting timezone.",
+        "tags": [
+          "Auth"
         ]
       }
     }

--- a/apps/web/src/components/ReportingTimezoneSelect.test.tsx
+++ b/apps/web/src/components/ReportingTimezoneSelect.test.tsx
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  query: {
+    current: {
+      data: { timezone: 'Europe/London', stored: true },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as Record<string, unknown>,
+  },
+  mutate: vi.fn(),
+  refetch: vi.fn(),
+}));
+
+vi.mock('@/hooks/useUserTimezone', () => ({
+  useUserTimezoneQuery: () => state.query.current,
+  useUserTimezoneMutation: () => ({ mutate: state.mutate, isPending: false }),
+}));
+
+// Native <select> stand-in for the shadcn primitive — Radix's pointer-capture
+// machinery is browser-only (same approach as BuyingPowerBasisSelect.test.tsx).
+vi.mock('@/components/ui/select', () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value?: string;
+    onValueChange?: (v: string) => void;
+    children: React.ReactNode;
+  }) => (
+    <>
+      <select
+        data-testid="timezone-select"
+        // A native <select> with no matching option silently selects its first
+        // one, so `.value` cannot tell "no value passed" from "first option".
+        // This mirrors back what the component actually passed.
+        data-value={value ?? ''}
+        value={value ?? ''}
+        onChange={(e) => onValueChange?.(e.target.value)}
+      >
+        {children}
+      </select>
+      {/* Escape hatch. A <select> can only emit values it renders, and so can
+          a Radix Select — but the component's own validation guard has to be
+          reachable with an arbitrary string to be tested at all. */}
+      <input data-testid="timezone-raw" onChange={(e) => onValueChange?.(e.target.value)} />
+    </>
+  ),
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
+import { ReportingTimezoneSelect } from './ReportingTimezoneSelect';
+
+beforeEach(() => {
+  state.query.current = {
+    data: { timezone: 'Europe/London', stored: true },
+    isLoading: false,
+    isError: false,
+    refetch: state.refetch,
+  };
+  state.mutate.mockClear();
+  state.refetch.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ReportingTimezoneSelect', () => {
+  it('displays the stored zone', () => {
+    render(<ReportingTimezoneSelect />);
+    expect(screen.getByTestId<HTMLSelectElement>('timezone-select').value).toBe('Europe/London');
+  });
+
+  it('saves a change through the mutation (the PUT)', () => {
+    render(<ReportingTimezoneSelect />);
+    fireEvent.change(screen.getByTestId('timezone-select'), { target: { value: 'Asia/Tokyo' } });
+    expect(state.mutate).toHaveBeenCalledWith('Asia/Tokyo');
+  });
+
+  it('renders a stored zone the picker list omits — UTC is the server default', () => {
+    // Intl.supportedValuesOf('timeZone') contains no `Etc/*` entry and no bare
+    // `UTC`, yet UTC is what every pre-migration row resolves to. Without the
+    // stored zone being added as an option the control would show its
+    // placeholder to the largest group of users there is.
+    state.query.current = {
+      data: { timezone: 'UTC', stored: true },
+      isLoading: false,
+      isError: false,
+      refetch: state.refetch,
+    };
+    render(<ReportingTimezoneSelect />);
+
+    const select = screen.getByTestId<HTMLSelectElement>('timezone-select');
+    expect(select.value).toBe('UTC');
+    expect(Array.from(select.options).some((o) => o.value === 'UTC')).toBe(true);
+    // It is offered once, not duplicated into the picker list.
+    expect(Array.from(select.options).filter((o) => o.value === 'UTC').length).toBe(1);
+  });
+
+  it('does not duplicate a stored zone the picker list already contains', () => {
+    render(<ReportingTimezoneSelect />);
+    const select = screen.getByTestId<HTMLSelectElement>('timezone-select');
+    expect(Array.from(select.options).filter((o) => o.value === 'Europe/London').length).toBe(1);
+  });
+
+  it('refuses to submit a zone that is not a real IANA name', () => {
+    render(<ReportingTimezoneSelect />);
+    fireEvent.change(screen.getByTestId('timezone-raw'), {
+      target: { value: 'Mars/Olympus_Mons' },
+    });
+    expect(state.mutate).not.toHaveBeenCalled();
+    expect(document.body.textContent).toMatch(/valid IANA timezone/i);
+  });
+
+  it('rejects the Unicode-extension bypass the shared schema catches', () => {
+    // Intl would silently strip the extension and resolve this to
+    // America/New_York; UserTimezoneSchema does not.
+    render(<ReportingTimezoneSelect />);
+    fireEvent.change(screen.getByTestId('timezone-raw'), {
+      target: { value: 'America/New_York-u-ca-japanese' },
+    });
+    expect(state.mutate).not.toHaveBeenCalled();
+  });
+
+  it('clears the validation message once a valid zone is chosen', () => {
+    render(<ReportingTimezoneSelect />);
+    fireEvent.change(screen.getByTestId('timezone-raw'), { target: { value: 'nonsense' } });
+    expect(document.body.textContent).toMatch(/valid IANA timezone/i);
+
+    fireEvent.change(screen.getByTestId('timezone-select'), { target: { value: 'Asia/Tokyo' } });
+    expect(state.mutate).toHaveBeenCalledWith('Asia/Tokyo');
+    expect(document.body.textContent).not.toMatch(/valid IANA timezone/i);
+  });
+
+  it('states the distinction from the account trading-day timezone (R2.8)', () => {
+    // The failure this copy exists to prevent: a user setting this one and
+    // concluding they have set their accounts' trading-day zone too.
+    render(<ReportingTimezoneSelect />);
+    const text = document.body.textContent ?? '';
+    expect(text).toMatch(/not an account's trading-day timezone/i);
+    expect(text).toMatch(/re-entered the same day/i);
+    expect(text).toMatch(/leaves every account's trading-day timezone untouched/i);
+    expect(text).toMatch(/leaves this one untouched/i);
+  });
+
+  it('describes ONLY what this zone does — it must not promise timestamp display', () => {
+    // Nothing renders a timestamp in this zone: lib/format.ts uses the browser
+    // zone, optionContract.ts uses UTC, reopenWindow.ts uses the ACCOUNT zone.
+    // Copy describing unbuilt behaviour is the defect this assertion pins.
+    render(<ReportingTimezoneSelect />);
+    const text = document.body.textContent ?? '';
+    expect(text).toMatch(/bucketed into by day, week and month/i);
+    expect(text).not.toMatch(/timestamps are shown/i);
+    expect(text).not.toMatch(/timestamps are rendered/i);
+  });
+
+  it('renders a skeleton instead of a wrong value while loading', () => {
+    state.query.current = {
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      refetch: state.refetch,
+    };
+    render(<ReportingTimezoneSelect />);
+    expect(screen.queryByTestId('timezone-select')).toBeNull();
+  });
+
+  it('says the read failed rather than showing an empty control with no explanation', () => {
+    state.query.current = {
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: state.refetch,
+    };
+    render(<ReportingTimezoneSelect />);
+
+    expect(document.body.textContent).toMatch(/couldn't load your saved timezone/i);
+    // The control stays usable — a PUT may succeed where the GET did not — but
+    // it is handed no value, because there is no stored value to claim.
+    const select = screen.getByTestId<HTMLSelectElement>('timezone-select');
+    expect(select.getAttribute('data-value')).toBe('');
+    fireEvent.change(select, { target: { value: 'Asia/Tokyo' } });
+    expect(state.mutate).toHaveBeenCalledWith('Asia/Tokyo');
+  });
+
+  it('offers a retry that refetches', () => {
+    state.query.current = {
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: state.refetch,
+    };
+    render(<ReportingTimezoneSelect />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(state.refetch).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/ReportingTimezoneSelect.tsx
+++ b/apps/web/src/components/ReportingTimezoneSelect.tsx
@@ -1,0 +1,120 @@
+import { useMemo, useState } from 'react';
+
+import { IANA_TIMEZONES, UserTimezoneSchema } from '@tradr/shared';
+
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useUserTimezoneMutation, useUserTimezoneQuery } from '@/hooks/useUserTimezone';
+
+/**
+ * The user's reporting timezone (user-onboarding R2.6), viewable and changeable
+ * from settings on its own, independent of onboarding.
+ *
+ * Lives in `components/` rather than a feature slice for the same reason
+ * `hooks/useUserTimezone.ts` does: the zone is not owned by any one feature —
+ * the dashboard widgets, the performance page and the position drawer all
+ * bucket by it. Its two neighbours on this tab sit under the slice that owns
+ * their endpoint (`accounting`, `calculator`); this preference has no such
+ * slice.
+ *
+ * The copy carries R2.8. The two timezones in this product are different
+ * quantities and neither is derived from the other, so the failure this
+ * component has to prevent is a user setting one and believing they have set
+ * the other.
+ */
+export function ReportingTimezoneSelect() {
+  const { data, isLoading, isError, refetch } = useUserTimezoneQuery();
+  const mutation = useUserTimezoneMutation();
+  const [error, setError] = useState<string | null>(null);
+
+  const selected = data?.timezone;
+
+  // IANA_TIMEZONES is the PICKER list, not the set of valid zones:
+  // `Intl.supportedValuesOf('timeZone')` omits every `Etc/*` entry and bare
+  // `UTC`, all of which are real zones the server will happily store — and
+  // `UTC` is the server's own default, so every row predating the column
+  // resolves to a value this array does not contain. Without this the Select
+  // would find no matching item and fall back to its placeholder, showing an
+  // empty control to the user whose zone is the most common one of all.
+  const options = useMemo(() => {
+    if (!selected || IANA_TIMEZONES.includes(selected)) return IANA_TIMEZONES;
+    return [selected, ...IANA_TIMEZONES];
+  }, [selected]);
+
+  function handleChange(value: string) {
+    // The options are all resolvable, so this only fires if something else
+    // put a value on the control. Validate with the same schema the PUT
+    // validates against rather than sending a zone the server will reject.
+    const parsed = UserTimezoneSchema.safeParse({ timezone: value });
+    if (!parsed.success) {
+      setError(parsed.error.issues[0]?.message ?? 'Must be a valid IANA timezone name');
+      return;
+    }
+    setError(null);
+    mutation.mutate(parsed.data.timezone);
+  }
+
+  return (
+    <div className="space-y-4 rounded-md border p-4">
+      <div>
+        <h2 className="text-lg font-semibold">Reporting timezone</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          The zone your P&amp;L is bucketed into by day, week and month on your dashboard,
+          performance page and position drawer. It follows you, so those figures stay the same
+          wherever you open Tradr. Updating it re-cuts them.
+        </p>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="reportingTimezone">Reporting timezone</Label>
+        {isLoading ? (
+          <Skeleton className="h-9 w-64" />
+        ) : (
+          <Select value={selected} onValueChange={handleChange} disabled={mutation.isPending}>
+            <SelectTrigger id="reportingTimezone" className="w-64 cursor-pointer">
+              <SelectValue placeholder="Select a timezone" />
+            </SelectTrigger>
+            <SelectContent>
+              {options.map((tz) => (
+                <SelectItem key={tz} value={tz}>
+                  {tz}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+        {/* The read failed after its retries. The control is left usable —
+            a PUT may well succeed where the GET did not — but it shows its
+            placeholder rather than a zone, because claiming a stored value we
+            could not read would be the one thing worse than saying so. */}
+        {isError && (
+          <p className="text-sm text-destructive">
+            Couldn&apos;t load your saved timezone.{' '}
+            <button
+              type="button"
+              onClick={() => void refetch()}
+              className="cursor-pointer underline"
+            >
+              Retry
+            </button>
+          </p>
+        )}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <p className="text-sm text-muted-foreground">
+          This is not an account&apos;s trading-day timezone. Each account carries its own separate
+          timezone, which decides whether a position can be re-entered the same day and defaults to
+          US Eastern because that is where NYSE, NASDAQ and NYSE Arca operate. Updating the zone
+          here leaves every account&apos;s trading-day timezone untouched, and updating an
+          account&apos;s leaves this one untouched — an account&apos;s timezone is edited on the
+          account itself.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/Sidebar.admin-link.test.tsx
+++ b/apps/web/src/components/layout/Sidebar.admin-link.test.tsx
@@ -31,6 +31,12 @@ vi.mock('@/components/layout/ThemeToggle', () => ({
   ThemeToggle: () => null,
 }));
 
+// The stored reporting timezone (user-onboarding R2.4) is a useQuery; stub it
+// so the sidebar mounts standalone and the Performance item is navigable.
+vi.mock('@/hooks/useUserTimezone', () => ({
+  useUserTimezone: () => 'America/New_York',
+}));
+
 // The Sidebar's changelog badge query also needs a QueryClient; stub the
 // module covering BOTH consumed exports (a hook-only factory would TypeError).
 vi.mock('@/features/changelog/hooks/useChangelog', () => ({

--- a/apps/web/src/components/layout/Sidebar.docs-link.test.tsx
+++ b/apps/web/src/components/layout/Sidebar.docs-link.test.tsx
@@ -30,6 +30,12 @@ vi.mock('@/features/changelog/hooks/useChangelog', () => ({
 
 vi.mock('@/components/layout/ThemeToggle', () => ({ ThemeToggle: () => null }));
 
+// The stored reporting timezone (user-onboarding R2.4) is a useQuery; stub it
+// so the sidebar mounts standalone.
+vi.mock('@/hooks/useUserTimezone', () => ({
+  useUserTimezone: () => 'America/New_York',
+}));
+
 import { DOCS_BASE_URL, docsUrl } from '@/lib/docs';
 
 import { Sidebar } from './Sidebar';

--- a/apps/web/src/components/layout/Sidebar.test.tsx
+++ b/apps/web/src/components/layout/Sidebar.test.tsx
@@ -15,27 +15,44 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // `to="/performanc2"` regression would surface in both the rendered href AND
 // the captured click target.
 const linkClicks: Array<{ to: string }> = [];
+// The `search` prop each Link was last rendered with, keyed by destination.
+// The Performance link seeds the route's default window, so this is how we
+// assert WHICH timezone that window is anchored at.
+const linkSearch = new Map<string, unknown>();
 vi.mock('@tanstack/react-router', () => ({
   Link: ({
     to,
     children,
     className,
+    search,
   }: {
     to: string;
     children: React.ReactNode;
     className?: string;
-  }) => (
-    <a
-      href={to}
-      className={className}
-      onClick={(e) => {
-        e.preventDefault();
-        linkClicks.push({ to });
-      }}
-    >
-      {children}
-    </a>
-  ),
+    search?: unknown;
+  }) => {
+    linkSearch.set(to, search);
+    return (
+      <a
+        href={to}
+        className={className}
+        onClick={(e) => {
+          e.preventDefault();
+          linkClicks.push({ to });
+        }}
+      >
+        {children}
+      </a>
+    );
+  },
+}));
+
+// The stored reporting timezone (user-onboarding R2.4). The real hook is a
+// useQuery and would throw without a provider; `value: undefined` reproduces
+// the in-flight window.
+const timezoneState = vi.hoisted(() => ({ value: undefined as string | undefined }));
+vi.mock('@/hooks/useUserTimezone', () => ({
+  useUserTimezone: () => timezoneState.value,
 }));
 
 // useAuth pulls in TanStack Query + Router internals; stub it with a static
@@ -93,8 +110,10 @@ function unmount(container: HTMLElement, root: Root): void {
 
 beforeEach(() => {
   linkClicks.length = 0;
+  linkSearch.clear();
   localStorage.clear();
   changelogState.result = { data: undefined, isError: false };
+  timezoneState.value = 'Europe/Berlin';
 });
 
 function releasesData(publishedAt: string, lastViewedAt: string) {
@@ -187,6 +206,74 @@ describe('Sidebar — Performance link', () => {
       (a) => a.getAttribute('href') === '/performance',
     );
     expect(performanceLink?.className).toContain('cursor-pointer');
+
+    unmount(container, root);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// user-onboarding R2.4 — the default performance window is anchored at the
+// user's STORED reporting timezone, never at the browser's.
+// ---------------------------------------------------------------------------
+
+describe('Sidebar — Performance defaults anchor at the stored timezone', () => {
+  it('seeds the search params with the stored zone', () => {
+    timezoneState.value = 'Asia/Tokyo';
+    const { container, root } = mountWith(<Sidebar />);
+
+    const search = linkSearch.get('/performance');
+    expect(typeof search).toBe('function');
+    const params = (
+      search as () => { granularity: string; start: string; end: string; tz: string }
+    )();
+
+    expect(params.tz).toBe('Asia/Tokyo');
+    // The rest of the monthly preset still comes through unchanged.
+    expect(params.granularity).toBe('month');
+    expect(params.start).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(params.end).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    unmount(container, root);
+  });
+
+  it('derives a different window for a different stored zone', () => {
+    timezoneState.value = 'Pacific/Kiritimati';
+    const first = mountWith(<Sidebar />);
+    const kiritimati = (linkSearch.get('/performance') as () => { start: string })();
+    unmount(first.container, first.root);
+
+    timezoneState.value = 'Pacific/Midway';
+    const second = mountWith(<Sidebar />);
+    const midway = (linkSearch.get('/performance') as () => { start: string })();
+    unmount(second.container, second.root);
+
+    // +14 vs -11 puts the month boundaries on different UTC instants — proof
+    // the zone actually reaches `derivePresetRange` rather than being ignored.
+    expect(kiritimati.start).not.toBe(midway.start);
+  });
+
+  it('renders an inert Performance item while the stored zone is in flight', () => {
+    timezoneState.value = undefined;
+    const { container, root } = mountWith(<Sidebar />);
+
+    // No destination exists yet, so there must be no navigable link…
+    const performanceLink = Array.from(container.querySelectorAll('a')).find(
+      (a) => a.getAttribute('href') === '/performance',
+    );
+    expect(performanceLink).toBeUndefined();
+    expect(linkSearch.has('/performance')).toBe(false);
+
+    // …but the nav item stays in place so the rail does not reflow.
+    const inert = container.querySelector('nav span[aria-disabled="true"]');
+    expect(inert).not.toBeNull();
+    expect(inert?.textContent).toContain('Performance');
+
+    // The inert state has to be perceivable and reachable, not just visually
+    // dimmed: `aria-disabled` on a role-less span is announced to nobody, and
+    // with no tab stop a keyboard user skips the item without learning it
+    // exists.
+    expect(inert?.getAttribute('role')).toBe('link');
+    expect(inert?.getAttribute('tabindex')).toBe('0');
 
     unmount(container, root);
   });

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -16,21 +16,25 @@ import { Button } from '@/components/ui/button';
 import { hasNewReleases, useChangelogReleases } from '@/features/changelog/hooks/useChangelog';
 import { derivePresetRange } from '@/features/performance/utils/derivePresetRange';
 import { useAuth } from '@/hooks/useAuth';
+import { useUserTimezone } from '@/hooks/useUserTimezone';
 import { docsUrl } from '@/lib/docs';
 import { cn } from '@/lib/utils';
 
 // Default search params for the Performance route. The route's
 // `validateSearch` requires `granularity`, `start`, and `end`; the sidebar
 // is the entry point so it has to seed sensible defaults. We use the
-// `monthly` preset (12m window) anchored at the user's browser timezone.
-function buildPerformanceDefaults(): {
+// `monthly` preset (12m window) anchored at the user's STORED reporting
+// timezone (user-onboarding R2.4).
+//
+// `tz` is a parameter rather than something this function derives: it comes
+// from `useUserTimezone()`, and a hook cannot be read from module scope. The
+// caller reads it inside the component and passes it down.
+function buildPerformanceDefaults(tz: string): {
   granularity: 'day' | 'week' | 'month' | 'year';
   start: string;
   end: string;
   tz: string;
 } {
-  const tz =
-    (typeof Intl !== 'undefined' && Intl.DateTimeFormat().resolvedOptions().timeZone) || 'UTC';
   const range = derivePresetRange(
     'monthly',
     { earliestClosedAt: null, mostRecentClosedAt: null, totalClosedPositions: 0 },
@@ -43,8 +47,19 @@ function buildPerformanceDefaults(): {
 
 const COLLAPSED_KEY = 'sidebar-collapsed';
 
+const PERFORMANCE_NAV_CLASS = cn(
+  'cursor-pointer flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent',
+  '[&.active]:bg-primary/10 [&.active]:text-primary [&.active]:font-medium',
+);
+
 export function Sidebar() {
   const { user, logout } = useAuth();
+  // The stored reporting timezone anchors the Performance route's default
+  // window. `undefined` until the preference query settles — and unlike the
+  // widgets there is no query here to disable, only a destination to seed, so
+  // the item is inert until there is a correct destination. Linking with the
+  // browser's zone (or a client-side 'UTC') is the defect R2.4 removes.
+  const timezone = useUserTimezone();
   // Badge data: error/loading mean no `data`, so the badge is simply absent
   // (REQ-5(a)(5)) — the hook's `retry: false` keeps failures quiet.
   const changelogReleases = useChangelogReleases();
@@ -130,17 +145,32 @@ export function Sidebar() {
           <span>∑</span>
           {!collapsed && <span>Calculator</span>}
         </Link>
-        <Link
-          to="/performance"
-          search={buildPerformanceDefaults}
-          className={cn(
-            'cursor-pointer flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent',
-            '[&.active]:bg-primary/10 [&.active]:text-primary [&.active]:font-medium',
-          )}
-        >
-          <LineChart className="h-4 w-4" aria-hidden="true" />
-          {!collapsed && <span>Performance</span>}
-        </Link>
+        {timezone ? (
+          <Link
+            to="/performance"
+            search={() => buildPerformanceDefaults(timezone)}
+            className={PERFORMANCE_NAV_CLASS}
+          >
+            <LineChart className="h-4 w-4" aria-hidden="true" />
+            {!collapsed && <span>Performance</span>}
+          </Link>
+        ) : (
+          // `role` and `tabIndex` are what make the inert state perceivable:
+          // `aria-disabled` on a bare <span> is announced to nobody, and
+          // without a tab stop a keyboard user skips the item entirely and
+          // never learns it is there. Focusable-but-disabled (rather than
+          // removed from the tab order) is the pattern that keeps the nav's
+          // tab sequence stable across the in-flight window.
+          <span
+            role="link"
+            aria-disabled="true"
+            tabIndex={0}
+            className={cn(PERFORMANCE_NAV_CLASS, 'pointer-events-none opacity-50')}
+          >
+            <LineChart className="h-4 w-4" aria-hidden="true" />
+            {!collapsed && <span>Performance</span>}
+          </span>
+        )}
         <Link
           to="/options"
           className={cn(

--- a/apps/web/src/features/accounts/components/AccountDialog.test.tsx
+++ b/apps/web/src/features/accounts/components/AccountDialog.test.tsx
@@ -385,6 +385,24 @@ describe('AccountDialog — default risk %', () => {
   });
 });
 
+// This dialog is one of the two places both timezones are visible to the same
+// user (user-onboarding R2.8); the settings control is the other, and disclaims
+// this one in return.
+describe('AccountDialog — telling the two timezones apart', () => {
+  it('names the boundary this field governs and disclaims the reporting zone', () => {
+    renderPersistentDialog(true, null);
+
+    // A bare "Timezone" label invites exactly the wrong conclusion: that
+    // setting it has set the zone the P&L is bucketed into.
+    expect(screen.getByLabelText('Trading-day timezone')).toBeTruthy();
+    expect(screen.queryByLabelText('Timezone')).toBeNull();
+
+    const text = document.body.textContent ?? '';
+    expect(text).toMatch(/re-entered the same day/i);
+    expect(text).toMatch(/not your reporting timezone/i);
+  });
+});
+
 // The re-seed on open covers every field, not just the risk rule. Currency and
 // timezone carry hardcoded fallbacks ('USD' / 'America/New_York'), so a dialog
 // that failed to re-seed would display those over the account's stored values
@@ -411,7 +429,7 @@ describe('AccountDialog — re-seeding on open', () => {
     });
 
     expect(fieldValue('Currency')).toBe('GBP');
-    expect(fieldValue('Timezone')).toBe('Europe/London');
+    expect(fieldValue('Trading-day timezone')).toBe('Europe/London');
     expect(fieldValue('Brokerage')).toBe(BROKERAGE_A);
 
     // The corruption itself: an untouched save must not write the create
@@ -450,7 +468,7 @@ describe('AccountDialog — re-seeding on open', () => {
     rerender({ open: true, account: second });
 
     expect(fieldValue('Currency')).toBe('JPY');
-    expect(fieldValue('Timezone')).toBe('Asia/Tokyo');
+    expect(fieldValue('Trading-day timezone')).toBe('Asia/Tokyo');
     expect(fieldValue('Brokerage')).toBe(BROKERAGE_B);
     expect(fieldValue('Name')).toBe('Prop Firm');
     expect(fieldValue('Default risk %')).toBe('2.00');

--- a/apps/web/src/features/accounts/components/AccountDialog.tsx
+++ b/apps/web/src/features/accounts/components/AccountDialog.tsx
@@ -228,9 +228,15 @@ export function AccountDialog({ open, onOpenChange, account }: AccountDialogProp
                 edit — unlike starting balance this stays editable, since it
                 only affects subsequent trading-day evaluations. The option
                 list is the runtime's own IANA set (shared with the server-side
-                validator), so anything picked here always validates. */}
+                validator), so anything picked here always validates.
+
+                The label names the boundary it governs, and the helper text
+                disclaims the reporting timezone, because this dialog is one of
+                the two places both zones are visible to the same user
+                (user-onboarding R2.8) — the other being the settings control
+                that disclaims this one in return. */}
             <div className="space-y-2">
-              <Label htmlFor="timezone">Timezone</Label>
+              <Label htmlFor="timezone">Trading-day timezone</Label>
               <Select
                 value={form.watch('timezone') ?? DEFAULT_ACCOUNT_TIMEZONE}
                 onValueChange={(val) => form.setValue('timezone', val)}
@@ -248,7 +254,8 @@ export function AccountDialog({ open, onOpenChange, account }: AccountDialogProp
               </Select>
               <p className="text-sm text-muted-foreground">
                 Defines the trading day for this account — used to decide whether a position can be
-                re-entered the same day.
+                re-entered the same day. It is not your reporting timezone, which buckets your
+                P&amp;L and is set in settings.
               </p>
               {form.formState.errors.timezone && (
                 <p className="text-sm text-destructive">{form.formState.errors.timezone.message}</p>

--- a/apps/web/src/features/csv-import/components/ImportPage.tsx
+++ b/apps/web/src/features/csv-import/components/ImportPage.tsx
@@ -28,10 +28,6 @@ function previewErrorMessage(err: unknown): string {
   return e.error?.message ?? e.message ?? 'Preview failed. Please try again.';
 }
 
-function browserTimezone(): string {
-  return (typeof Intl !== 'undefined' && Intl.DateTimeFormat().resolvedOptions().timeZone) || 'UTC';
-}
-
 const initialMapper = (): ColumnMapperValue => ({
   presetId: null,
   rowShape: 'execution',
@@ -118,12 +114,10 @@ export function ImportPage() {
     preview.mutate({ file, request });
   }
 
-  // Default the timezone to the browser zone on first mount as a hint, while
-  // keeping UTC available; REQ-7.4 wants UTC default for correction, so we keep
-  // UTC unless the user changes it. (Browser tz is offered in the selector.)
-  useEffect(() => {
-    void browserTimezone();
-  }, []);
+  // NOTE: the import timezone stays UTC by default (csv-import REQ-7.4) — it
+  // describes the CSV's own timestamps, not the user's reporting zone
+  // (user-onboarding R2.4), so it is deliberately NOT seeded from
+  // `useUserTimezone`. The mapper's selector is where it gets corrected.
 
   return (
     <div className="mx-auto max-w-3xl space-y-6 p-6">

--- a/apps/web/src/features/dashboard/widgets/EquityCurveWidget.timezone.test.tsx
+++ b/apps/web/src/features/dashboard/widgets/EquityCurveWidget.timezone.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+//
+// user-onboarding R2.4 — the equity curve must bucket by the user's STORED
+// reporting timezone, not by whatever zone the current device reports.
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useDisplayCurrencyQuery } from '@/features/accounting/hooks/useDisplayCurrency';
+import { usePerformance } from '@/features/performance/hooks/usePerformance';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@/features/accounting/hooks/useDisplayCurrency', () => ({
+  useDisplayCurrencyQuery: vi.fn(),
+}));
+vi.mock('@/features/performance/hooks/usePerformance', () => ({
+  usePerformance: vi.fn(),
+}));
+
+const timezoneState = vi.hoisted(() => ({ value: undefined as string | undefined }));
+vi.mock('@/hooks/useUserTimezone', () => ({
+  useUserTimezone: () => timezoneState.value,
+}));
+
+import EquityCurveWidget from './EquityCurveWidget';
+
+type PerformanceResult = ReturnType<typeof usePerformance>;
+type DisplayCurrencyResult = ReturnType<typeof useDisplayCurrencyQuery>;
+
+function mountWith(ui: React.ReactElement): { container: HTMLElement; root: Root } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+  return { container, root };
+}
+
+function unmount(container: HTMLElement, root: Root): void {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+beforeEach(() => {
+  timezoneState.value = 'America/New_York';
+  vi.mocked(useDisplayCurrencyQuery).mockReturnValue({
+    data: { currency: 'USD' },
+    isLoading: false,
+  } as unknown as DisplayCurrencyResult);
+  vi.mocked(usePerformance).mockReset();
+  vi.mocked(usePerformance).mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  } as unknown as PerformanceResult);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('EquityCurveWidget — reporting timezone', () => {
+  it('sends the stored zone as `tz`', () => {
+    timezoneState.value = 'Europe/Berlin';
+
+    const { container, root } = mountWith(<EquityCurveWidget />);
+    expect(vi.mocked(usePerformance).mock.calls[0]?.[0]).toMatchObject({
+      tz: 'Europe/Berlin',
+      granularity: 'month',
+      currency: 'USD',
+    });
+    unmount(container, root);
+  });
+
+  it('passes null (query disabled) and holds the skeleton while the zone is in flight', () => {
+    timezoneState.value = undefined;
+
+    const { container, root } = mountWith(<EquityCurveWidget />);
+    expect(vi.mocked(usePerformance).mock.calls[0]?.[0]).toBeNull();
+    expect(container.textContent).not.toContain('Close a position');
+    expect(container.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0);
+    unmount(container, root);
+  });
+});

--- a/apps/web/src/features/dashboard/widgets/EquityCurveWidget.tsx
+++ b/apps/web/src/features/dashboard/widgets/EquityCurveWidget.tsx
@@ -9,15 +9,7 @@ import {
   DEFAULT_CURRENCY_HISTORY_RANGE,
   derivePresetRange,
 } from '@/features/performance/utils/derivePresetRange';
-
-/** Resolve the browser's IANA timezone, falling back to UTC. */
-function resolveBrowserTimezone(): string {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
-  } catch {
-    return 'UTC';
-  }
-}
+import { useUserTimezone } from '@/hooks/useUserTimezone';
 
 /**
  * EquityCurveWidget — dashboard widget rendering the cumulative net P&L
@@ -25,9 +17,12 @@ function resolveBrowserTimezone(): string {
  *
  * Data flow mirrors `StatsSummaryWidget` (Task 37):
  *   1. Resolve `displayCurrency` from `useDisplayCurrencyQuery()`.
- *   2. Compute {start, end} via `derivePresetRange('all-time', ...)`. On first
- *      render we use `DEFAULT_CURRENCY_HISTORY_RANGE` (§B) + browser tz.
- *   3. Fetch via `usePerformance({ granularity: 'month', ... })`.
+ *   2. Compute {start, end} via `derivePresetRange('all-time', ...)` anchored at
+ *      the user's stored reporting timezone (`useUserTimezone`,
+ *      user-onboarding R2.4 — NOT the browser's zone). On first render we use
+ *      `DEFAULT_CURRENCY_HISTORY_RANGE` (§B).
+ *   3. Fetch via `usePerformance({ granularity: 'month', ... })`, passing `null`
+ *      until the stored zone lands so nothing is bucketed by a guess.
  *   4. Pick the currency entry via `response.currencies.find(c => c.code === displayCurrency)`
  *      (§A — array form, NOT record indexing) and read `.equityCurve`.
  */
@@ -35,24 +30,32 @@ function EquityCurveWidget() {
   const { data: displayCurrencyData } = useDisplayCurrencyQuery();
   const displayCurrency = displayCurrencyData?.currency ?? null;
 
-  const browserTz = resolveBrowserTimezone();
+  const timezone = useUserTimezone();
   const defaultWeekStart = 1 as const;
 
-  const bootstrapRange = derivePresetRange(
-    'all-time',
-    DEFAULT_CURRENCY_HISTORY_RANGE,
-    new Date(),
-    browserTz,
-    defaultWeekStart,
-  );
+  // `derivePresetRange` resolves calendar boundaries through `Intl`, so it
+  // cannot run before the stored zone is known.
+  const bootstrapRange = timezone
+    ? derivePresetRange(
+        'all-time',
+        DEFAULT_CURRENCY_HISTORY_RANGE,
+        new Date(),
+        timezone,
+        defaultWeekStart,
+      )
+    : null;
 
-  const performanceQuery = usePerformance({
-    granularity: 'month',
-    start: bootstrapRange.start,
-    end: bootstrapRange.end,
-    tz: browserTz,
-    ...(displayCurrency ? { currency: displayCurrency } : {}),
-  });
+  const performanceQuery = usePerformance(
+    timezone && bootstrapRange
+      ? {
+          granularity: 'month',
+          start: bootstrapRange.start,
+          end: bootstrapRange.end,
+          tz: timezone,
+          ...(displayCurrency ? { currency: displayCurrency } : {}),
+        }
+      : null,
+  );
 
   const { data: response, isLoading, isError, error, refetch } = performanceQuery;
 
@@ -62,7 +65,10 @@ function EquityCurveWidget() {
       ? (response?.currencies.find((c) => c.code === displayCurrency) ?? null)
       : null;
 
-  if (isLoading) {
+  // A disabled query reports `isLoading: false`, so the wait for the stored
+  // zone has to be spelled out here — otherwise the widget would drop through
+  // to its empty state before the first fetch.
+  if (timezone === undefined || isLoading) {
     return <Skeleton className="h-[320px] w-full" />;
   }
 

--- a/apps/web/src/features/dashboard/widgets/PerformanceChartWidget.timezone.test.tsx
+++ b/apps/web/src/features/dashboard/widgets/PerformanceChartWidget.timezone.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+//
+// user-onboarding R2.4 — the per-bucket P&L chart must bucket by the user's
+// STORED reporting timezone. The configured timeframe still decides the
+// granularity; only the zone the buckets are cut in changed.
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { WidgetPlacement } from '@tradr/shared';
+
+import { useDisplayCurrencyQuery } from '@/features/accounting/hooks/useDisplayCurrency';
+import { usePerformance } from '@/features/performance/hooks/usePerformance';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@/features/accounting/hooks/useDisplayCurrency', () => ({
+  useDisplayCurrencyQuery: vi.fn(),
+}));
+vi.mock('@/features/performance/hooks/usePerformance', () => ({
+  usePerformance: vi.fn(),
+}));
+
+const timezoneState = vi.hoisted(() => ({ value: undefined as string | undefined }));
+vi.mock('@/hooks/useUserTimezone', () => ({
+  useUserTimezone: () => timezoneState.value,
+}));
+
+import PerformanceChartWidget from './PerformanceChartWidget';
+
+type PerformanceResult = ReturnType<typeof usePerformance>;
+type DisplayCurrencyResult = ReturnType<typeof useDisplayCurrencyQuery>;
+
+const placement = {
+  id: '00000000-0000-4000-8000-000000000001',
+  type: 'performance-chart',
+  x: 0,
+  y: 0,
+  w: 6,
+  h: 4,
+  config: { timeframe: 'weekly' },
+} as unknown as WidgetPlacement;
+
+function mountWith(ui: React.ReactElement): { container: HTMLElement; root: Root } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+  return { container, root };
+}
+
+function unmount(container: HTMLElement, root: Root): void {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+beforeEach(() => {
+  timezoneState.value = 'America/New_York';
+  vi.mocked(useDisplayCurrencyQuery).mockReturnValue({
+    data: { currency: 'USD' },
+    isLoading: false,
+  } as unknown as DisplayCurrencyResult);
+  vi.mocked(usePerformance).mockReset();
+  vi.mocked(usePerformance).mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  } as unknown as PerformanceResult);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('PerformanceChartWidget — reporting timezone', () => {
+  it('sends the stored zone as `tz` and keeps the configured granularity', () => {
+    timezoneState.value = 'Australia/Sydney';
+
+    const { container, root } = mountWith(
+      <PerformanceChartWidget placement={placement} onUpdateConfig={vi.fn()} />,
+    );
+    expect(vi.mocked(usePerformance).mock.calls[0]?.[0]).toMatchObject({
+      tz: 'Australia/Sydney',
+      // `weekly` still maps to week buckets — the preset logic is untouched.
+      granularity: 'week',
+      currency: 'USD',
+    });
+    unmount(container, root);
+  });
+
+  it('passes null (query disabled) and holds the skeleton while the zone is in flight', () => {
+    timezoneState.value = undefined;
+
+    const { container, root } = mountWith(
+      <PerformanceChartWidget placement={placement} onUpdateConfig={vi.fn()} />,
+    );
+    expect(vi.mocked(usePerformance).mock.calls[0]?.[0]).toBeNull();
+    expect(container.textContent).not.toContain('Close a position');
+    expect(container.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0);
+    unmount(container, root);
+  });
+});

--- a/apps/web/src/features/dashboard/widgets/PerformanceChartWidget.tsx
+++ b/apps/web/src/features/dashboard/widgets/PerformanceChartWidget.tsx
@@ -15,17 +15,9 @@ import {
   derivePresetRange,
   type PerformancePreset,
 } from '@/features/performance/utils/derivePresetRange';
+import { useUserTimezone } from '@/hooks/useUserTimezone';
 
 import { widgetRegistry } from './registry';
-
-/** Resolve the browser's IANA timezone, falling back to UTC. */
-function resolveBrowserTimezone(): string {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
-  } catch {
-    return 'UTC';
-  }
-}
 
 const DEFAULT_TIMEFRAME: PerformancePreset = 'monthly';
 
@@ -43,10 +35,13 @@ export interface PerformanceChartWidgetProps {
  *      On failure render with `defaultConfig` AND emit a fix-up via `onUpdateConfig`
  *      (§K — the fix-up flows through the debounced layout state; NO separate PUT).
  *   2. Resolve `displayCurrency` from `useDisplayCurrencyQuery()`.
- *   3. Compute {granularity, start, end} via `derivePresetRange(config.timeframe, ...)`.
+ *   3. Compute {granularity, start, end} via `derivePresetRange(config.timeframe, ...)`
+ *      anchored at the user's stored reporting timezone (`useUserTimezone`,
+ *      user-onboarding R2.4 — NOT the browser's zone).
  *      The historyRange comes from the previous response's `currencyData.historyRange`
  *      (§B — first render bootstraps with `DEFAULT_CURRENCY_HISTORY_RANGE`).
- *   4. Fetch via `usePerformance`.
+ *   4. Fetch via `usePerformance`, passing `null` until the stored zone lands so
+ *      nothing is bucketed by a guess.
  *   5. Pick the currency entry via `response.currencies.find(c => c.code === displayCurrency)`
  *      (§A — array form, NOT record indexing) and read `.series`.
  */
@@ -74,28 +69,36 @@ function PerformanceChartWidget({ placement, onUpdateConfig }: PerformanceChartW
   const { data: displayCurrencyData } = useDisplayCurrencyQuery();
   const displayCurrency = displayCurrencyData?.currency ?? null;
 
-  const browserTz = resolveBrowserTimezone();
+  const timezone = useUserTimezone();
   const defaultWeekStart = 1 as const;
 
   // Derive the query window. On first render we have no response, so the
   // historyRange falls back to DEFAULT_CURRENCY_HISTORY_RANGE (§B). Once the
   // response lands we re-derive with the currency's real historyRange and
-  // resolved tz/week-start (Design §10.4 cycle-prevention note).
-  const performanceQueryBootstrap = derivePresetRange(
-    config.timeframe,
-    DEFAULT_CURRENCY_HISTORY_RANGE,
-    new Date(),
-    browserTz,
-    defaultWeekStart,
-  );
+  // resolved week-start (Design §10.4 cycle-prevention note).
+  // `derivePresetRange` resolves calendar boundaries through `Intl`, so it
+  // cannot run before the stored zone is known.
+  const performanceQueryBootstrap = timezone
+    ? derivePresetRange(
+        config.timeframe,
+        DEFAULT_CURRENCY_HISTORY_RANGE,
+        new Date(),
+        timezone,
+        defaultWeekStart,
+      )
+    : null;
 
-  const performanceQuery = usePerformance({
-    granularity: performanceQueryBootstrap.granularity,
-    start: performanceQueryBootstrap.start,
-    end: performanceQueryBootstrap.end,
-    tz: browserTz,
-    ...(displayCurrency ? { currency: displayCurrency } : {}),
-  });
+  const performanceQuery = usePerformance(
+    timezone && performanceQueryBootstrap
+      ? {
+          granularity: performanceQueryBootstrap.granularity,
+          start: performanceQueryBootstrap.start,
+          end: performanceQueryBootstrap.end,
+          tz: timezone,
+          ...(displayCurrency ? { currency: displayCurrency } : {}),
+        }
+      : null,
+  );
 
   const { data: response, isLoading, isError, error, refetch } = performanceQuery;
 
@@ -109,7 +112,10 @@ function PerformanceChartWidget({ placement, onUpdateConfig }: PerformanceChartW
     onUpdateConfig({ timeframe: next });
   });
 
-  if (isLoading) {
+  // A disabled query reports `isLoading: false`, so the wait for the stored
+  // zone has to be spelled out here — otherwise the widget would drop through
+  // to its empty state before the first fetch.
+  if (timezone === undefined || isLoading) {
     return <Skeleton className="h-[320px] w-full" />;
   }
 

--- a/apps/web/src/features/dashboard/widgets/StatsSummaryWidget.timezone.test.tsx
+++ b/apps/web/src/features/dashboard/widgets/StatsSummaryWidget.timezone.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+//
+// user-onboarding R2.4 — this widget must bucket by the user's STORED
+// reporting timezone. It used to read `Intl.DateTimeFormat().resolvedOptions()
+// .timeZone` at render time, so the same account showed different daily and
+// weekly figures from a second machine, a VPN, or a trip abroad.
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useDisplayCurrencyQuery } from '@/features/accounting/hooks/useDisplayCurrency';
+import { usePerformance } from '@/features/performance/hooks/usePerformance';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@/features/accounting/hooks/useDisplayCurrency', () => ({
+  useDisplayCurrencyQuery: vi.fn(),
+}));
+vi.mock('@/features/performance/hooks/usePerformance', () => ({
+  usePerformance: vi.fn(),
+}));
+
+// `undefined` is the in-flight window the real hook exposes; it carries no
+// client-side fallback on purpose.
+const timezoneState = vi.hoisted(() => ({ value: undefined as string | undefined }));
+vi.mock('@/hooks/useUserTimezone', () => ({
+  useUserTimezone: () => timezoneState.value,
+}));
+
+import StatsSummaryWidget from './StatsSummaryWidget';
+
+type PerformanceResult = ReturnType<typeof usePerformance>;
+type DisplayCurrencyResult = ReturnType<typeof useDisplayCurrencyQuery>;
+
+function mountWith(ui: React.ReactElement): { container: HTMLElement; root: Root } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+  return { container, root };
+}
+
+function unmount(container: HTMLElement, root: Root): void {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+beforeEach(() => {
+  timezoneState.value = 'America/New_York';
+  vi.mocked(useDisplayCurrencyQuery).mockReturnValue({
+    data: { currency: 'USD' },
+    isLoading: false,
+  } as unknown as DisplayCurrencyResult);
+  vi.mocked(usePerformance).mockReset();
+  vi.mocked(usePerformance).mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  } as unknown as PerformanceResult);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('StatsSummaryWidget — reporting timezone', () => {
+  it('sends the stored zone as `tz`', () => {
+    timezoneState.value = 'Asia/Tokyo';
+
+    const { container, root } = mountWith(<StatsSummaryWidget />);
+    expect(vi.mocked(usePerformance).mock.calls[0]?.[0]).toMatchObject({
+      tz: 'Asia/Tokyo',
+      granularity: 'year',
+      currency: 'USD',
+    });
+    unmount(container, root);
+  });
+
+  it('derives a different all-time window for a different stored zone', () => {
+    timezoneState.value = 'Pacific/Kiritimati';
+    const first = mountWith(<StatsSummaryWidget />);
+    const kiritimati = vi.mocked(usePerformance).mock.calls[0]?.[0];
+    unmount(first.container, first.root);
+
+    vi.mocked(usePerformance).mockClear();
+    timezoneState.value = 'Pacific/Midway';
+    const second = mountWith(<StatsSummaryWidget />);
+    const midway = vi.mocked(usePerformance).mock.calls[0]?.[0];
+    unmount(second.container, second.root);
+
+    // +14 vs -11: the month boundary lands on a different UTC instant, which
+    // is exactly the bucket shift this task removes.
+    expect(kiritimati?.end).not.toBe(midway?.end);
+  });
+
+  it('passes null (query disabled) and holds the skeleton while the zone is in flight', () => {
+    timezoneState.value = undefined;
+
+    const { container, root } = mountWith(<StatsSummaryWidget />);
+    expect(vi.mocked(usePerformance).mock.calls[0]?.[0]).toBeNull();
+    // A disabled query reports isLoading:false, so without an explicit wait the
+    // widget would flash its "Close a position…" empty state.
+    expect(container.textContent).not.toContain('Close a position');
+    expect(container.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0);
+    unmount(container, root);
+  });
+});

--- a/apps/web/src/features/dashboard/widgets/StatsSummaryWidget.tsx
+++ b/apps/web/src/features/dashboard/widgets/StatsSummaryWidget.tsx
@@ -12,15 +12,7 @@ import {
   derivePresetRange,
 } from '@/features/performance/utils/derivePresetRange';
 import { formatProfitFactor } from '@/features/performance/utils/formatPerformance';
-
-/** Resolve the browser's IANA timezone, falling back to UTC. */
-function resolveBrowserTimezone(): string {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
-  } catch {
-    return 'UTC';
-  }
-}
+import { useUserTimezone } from '@/hooks/useUserTimezone';
 
 interface StatTile {
   label: string;
@@ -33,10 +25,13 @@ interface StatTile {
  *
  * Data flow:
  *   1. Resolve `displayCurrency` from `useDisplayCurrencyQuery()`.
- *   2. Compute {start, end} via `derivePresetRange('all-time', historyRange, ...)`.
+ *   2. Compute {start, end} via `derivePresetRange('all-time', historyRange, ...)`
+ *      anchored at the user's stored reporting timezone (`useUserTimezone`,
+ *      user-onboarding R2.4 — NOT the browser's zone).
  *      On first render `historyRange = DEFAULT_CURRENCY_HISTORY_RANGE` (§B);
  *      once the response lands we use the currency entry's `historyRange`.
- *   3. Fetch via `usePerformance({ granularity: 'year', start, end, tz, currency })`.
+ *   3. Fetch via `usePerformance({ granularity: 'year', start, end, tz, currency })`,
+ *      passing `null` until the stored zone lands so nothing is bucketed by a guess.
  *   4. Pick the currency entry via `response.currencies.find(c => c.code === displayCurrency)`
  *      (§A — array form, NOT record indexing) and read `.stats`.
  */
@@ -44,29 +39,37 @@ function StatsSummaryWidget() {
   const { data: displayCurrencyData } = useDisplayCurrencyQuery();
   const displayCurrency = displayCurrencyData?.currency ?? null;
 
-  // Browser-resolved tz/week-start are the bootstrap values; once a response
-  // lands we prefer its `resolvedTimezone` / `resolvedWeekStartDay`.
-  const browserTz = resolveBrowserTimezone();
+  // The user's STORED reporting timezone (user-onboarding R2.4) — `undefined`
+  // until that query settles. Week-start is the bootstrap value; once a
+  // response lands we prefer its `resolvedWeekStartDay`.
+  const timezone = useUserTimezone();
   const defaultWeekStart = 1 as const;
 
   // -------- First-render bootstrap ----------
-  // We don't yet have a response, so we can't read historyRange or resolvedTz
-  // from it. Use DEFAULT_CURRENCY_HISTORY_RANGE + browser tz.
-  const bootstrapRange = derivePresetRange(
-    'all-time',
-    DEFAULT_CURRENCY_HISTORY_RANGE,
-    new Date(),
-    browserTz,
-    defaultWeekStart,
-  );
+  // We don't yet have a response, so we can't read historyRange from it. Use
+  // DEFAULT_CURRENCY_HISTORY_RANGE. `derivePresetRange` resolves calendar
+  // boundaries through `Intl`, so it cannot run before the zone is known.
+  const bootstrapRange = timezone
+    ? derivePresetRange(
+        'all-time',
+        DEFAULT_CURRENCY_HISTORY_RANGE,
+        new Date(),
+        timezone,
+        defaultWeekStart,
+      )
+    : null;
 
-  const performanceQuery = usePerformance({
-    granularity: 'year',
-    start: bootstrapRange.start,
-    end: bootstrapRange.end,
-    tz: browserTz,
-    ...(displayCurrency ? { currency: displayCurrency } : {}),
-  });
+  const performanceQuery = usePerformance(
+    timezone && bootstrapRange
+      ? {
+          granularity: 'year',
+          start: bootstrapRange.start,
+          end: bootstrapRange.end,
+          tz: timezone,
+          ...(displayCurrency ? { currency: displayCurrency } : {}),
+        }
+      : null,
+  );
 
   const { data: response, isLoading, isError, error, refetch } = performanceQuery;
 
@@ -76,7 +79,10 @@ function StatsSummaryWidget() {
       ? (response?.currencies.find((c) => c.code === displayCurrency) ?? null)
       : null;
 
-  if (isLoading) {
+  // A disabled query reports `isLoading: false`, so the wait for the stored
+  // zone has to be spelled out here — otherwise the widget would drop through
+  // to its empty state and flash "Close a position…" before the first fetch.
+  if (timezone === undefined || isLoading) {
     return (
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
         {Array.from({ length: 5 }).map((_, idx) => (

--- a/apps/web/src/features/drawer/components/QuickStatsTab.pnl.test.tsx
+++ b/apps/web/src/features/drawer/components/QuickStatsTab.pnl.test.tsx
@@ -22,6 +22,11 @@ vi.mock('@/features/positions/hooks/usePositions', () => ({
 vi.mock('@/hooks/useNow', () => ({
   useNow: vi.fn(() => new Date('2026-05-27T12:00:00.000Z')),
 }));
+// The stored reporting timezone (user-onboarding R2.4) is a useQuery; a fixed
+// zone keeps this suite about P&L rendering, not the bucketing window.
+vi.mock('@/hooks/useUserTimezone', () => ({
+  useUserTimezone: () => 'America/New_York',
+}));
 
 import { QuickStatsTab } from './QuickStatsTab';
 

--- a/apps/web/src/features/drawer/components/QuickStatsTab.test.tsx
+++ b/apps/web/src/features/drawer/components/QuickStatsTab.test.tsx
@@ -32,6 +32,13 @@ vi.mock('@/hooks/useNow', () => ({
   useNow: vi.fn(() => new Date('2026-05-27T12:00:00.000Z')),
 }));
 
+// The user's stored reporting timezone (user-onboarding R2.4) — the zone this
+// tab buckets by. `undefined` reproduces the in-flight window.
+const timezoneState = vi.hoisted(() => ({ value: undefined as string | undefined }));
+vi.mock('@/hooks/useUserTimezone', () => ({
+  useUserTimezone: () => timezoneState.value,
+}));
+
 import { QuickStatsTab } from './QuickStatsTab';
 
 // ---------------------------------------------------------------------------
@@ -123,6 +130,7 @@ beforeEach(() => {
   vi.mocked(usePositions).mockReset();
   vi.mocked(useNow).mockReset();
   vi.mocked(useNow).mockReturnValue(new Date('2026-05-27T12:00:00.000Z'));
+  timezoneState.value = 'America/New_York';
 });
 
 afterEach(() => {
@@ -363,6 +371,58 @@ describe('QuickStatsTab', () => {
     expect(container.querySelector('[data-testid="quick-stats-avg-win-value"]')).toBeNull();
     expect(container.querySelector('[data-testid="quick-stats-avg-loss-value"]')).toBeNull();
     expect(container.querySelector('[data-testid="quick-stats-open-notional-value"]')).toBeNull();
+    unmount(container, root);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// user-onboarding R2.4 — bucket by the STORED reporting timezone.
+// ---------------------------------------------------------------------------
+
+describe('QuickStatsTab — reporting timezone', () => {
+  it('sends the stored zone as `tz`, not the browser zone', () => {
+    timezoneState.value = 'Asia/Tokyo';
+    mockUSDDisplayCurrency();
+    vi.mocked(usePerformance).mockReturnValue({
+      data: makePerformanceData([]),
+      isLoading: false,
+      error: null,
+    } as unknown as PerformanceResult);
+    vi.mocked(usePositions).mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    } as unknown as PositionsResult);
+
+    const { container, root } = mountWith(<QuickStatsTab />);
+    expect(vi.mocked(usePerformance).mock.calls[0]?.[0]).toMatchObject({
+      tz: 'Asia/Tokyo',
+      granularity: 'month',
+      currency: 'USD',
+    });
+    unmount(container, root);
+  });
+
+  it('passes null (query disabled) and shows skeletons while the zone is in flight', () => {
+    timezoneState.value = undefined;
+    mockUSDDisplayCurrency();
+    vi.mocked(usePerformance).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    } as unknown as PerformanceResult);
+    vi.mocked(usePositions).mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    } as unknown as PositionsResult);
+
+    const { container, root } = mountWith(<QuickStatsTab />);
+    // No request may be issued against a zone the user never chose.
+    expect(vi.mocked(usePerformance).mock.calls[0]?.[0]).toBeNull();
+    // …and the tab must not fall through to values while it waits.
+    expect(container.querySelector('[data-testid="quick-stats-win-rate-skeleton"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="quick-stats-win-rate-value"]')).toBeNull();
     unmount(container, root);
   });
 });

--- a/apps/web/src/features/drawer/components/QuickStatsTab.tsx
+++ b/apps/web/src/features/drawer/components/QuickStatsTab.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/features/performance/utils/derivePresetRange';
 import { usePositions } from '@/features/positions/hooks/usePositions';
 import { useNow } from '@/hooks/useNow';
+import { useUserTimezone } from '@/hooks/useUserTimezone';
 
 function openNotional(positions: PositionListItem[], displayCurrency: string): number {
   return positions
@@ -61,26 +62,40 @@ export function QuickStatsTab() {
   const displayCurrency = displayCurrencyData?.currency ?? null;
 
   const now = useNow(60_000);
-  const browserTz = useMemo(() => Intl.DateTimeFormat().resolvedOptions().timeZone, []);
+  // The user's STORED reporting timezone (user-onboarding R2.4), `undefined`
+  // until that query settles. `derivePresetRange` resolves calendar boundaries
+  // through `Intl`, so it cannot run before the zone is known.
+  const timezone = useUserTimezone();
   const range = useMemo(
-    () => derivePresetRange('all-time', DEFAULT_CURRENCY_HISTORY_RANGE, now, browserTz, 1),
-    [now, browserTz],
+    () =>
+      timezone
+        ? derivePresetRange('all-time', DEFAULT_CURRENCY_HISTORY_RANGE, now, timezone, 1)
+        : null,
+    [now, timezone],
   );
 
-  const performanceQuery = usePerformance({
-    granularity: range.granularity,
-    start: range.start,
-    end: range.end,
-    tz: browserTz,
-    ...(displayCurrency ? { currency: displayCurrency } : {}),
-  });
+  const performanceQuery = usePerformance(
+    timezone && range
+      ? {
+          granularity: range.granularity,
+          start: range.start,
+          end: range.end,
+          tz: timezone,
+          ...(displayCurrency ? { currency: displayCurrency } : {}),
+        }
+      : null,
+  );
   const positionsQuery = usePositions({ status: 'open' });
 
   const currencyEntry = displayCurrency
     ? performanceQuery.data?.currencies.find((c) => c.code === displayCurrency)
     : undefined;
 
+  // `timezone === undefined` joins the predicate for the same reason
+  // `displayCurrency === null` already does: the performance query is disabled
+  // until it lands, and a disabled query reports `isLoading: false`.
   const isLoading =
+    timezone === undefined ||
     performanceQuery.isLoading ||
     positionsQuery.isLoading ||
     isDisplayCurrencyLoading ||

--- a/apps/web/src/features/performance/hooks/usePerformance.ts
+++ b/apps/web/src/features/performance/hooks/usePerformance.ts
@@ -171,13 +171,24 @@ export function handlePerformanceQueryError(
   queryClient.invalidateQueries({ queryKey: ['performance'] });
 }
 
-export function usePerformance(params: PerformanceQueryInput) {
+/**
+ * `params` is `null` while the caller is still waiting on a value it must not
+ * guess — today that is the user's stored reporting timezone
+ * (user-onboarding R2.4, `useUserTimezone`). A `null` disables the query
+ * outright rather than firing one bucketed by a zone the user never chose, and
+ * it means there is no placeholder tz that could leak into a request.
+ */
+export function usePerformance(params: PerformanceQueryInput | null) {
   const queryClient = useQueryClient();
   const queryKey = ['performance', 'detail', params] as const;
 
   return useQuery<PerformanceResponse>({
     queryKey,
+    enabled: params !== null,
     queryFn: async ({ signal }) => {
+      // `enabled` already guarantees this; the guard narrows the type locally
+      // rather than asserting non-null.
+      if (params === null) throw new Error('performance query ran without params');
       // If the session has already seen INVALID_TIMEZONE, omit `tz` from
       // subsequent requests so the server falls back to its default.
       const omitTz = readInvalidTzSeen();

--- a/apps/web/src/hooks/useUserTimezone.test.ts
+++ b/apps/web/src/hooks/useUserTimezone.test.ts
@@ -1,0 +1,401 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { toast } from 'sonner';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { api } from '@/lib/api';
+import { detectBrowserTimezone } from '@/lib/browserTimezone';
+
+import {
+  useReportingTimezoneBackfill,
+  useUserTimezone,
+  useUserTimezoneMutation,
+  useUserTimezoneQuery,
+} from './useUserTimezone';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@/lib/api', () => ({
+  api: { get: vi.fn(), put: vi.fn() },
+}));
+
+vi.mock('@/lib/browserTimezone', () => ({
+  detectBrowserTimezone: vi.fn(() => 'America/New_York'),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), dismiss: vi.fn() },
+}));
+
+function makeClient() {
+  return new QueryClient({
+    // `retryDelay`, not `retry` — the timezone query sets its own bounded
+    // `retry: 2`, which a client default cannot override. Zeroing the delay
+    // lets the terminal state be reached without three seconds of backoff.
+    defaultOptions: { queries: { retry: false, retryDelay: 0 }, mutations: { retry: false } },
+  });
+}
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: qc }, children);
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(detectBrowserTimezone).mockReturnValue('America/New_York');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe('useUserTimezone', () => {
+  it('returns the STORED zone read from GET /users/me/timezone', async () => {
+    vi.mocked(api.get).mockResolvedValue({ timezone: 'Europe/London', stored: true });
+    const qc = makeClient();
+
+    const { result } = renderHook(() => useUserTimezone(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(result.current).toBe('Europe/London');
+    });
+    expect(api.get).toHaveBeenCalledWith('/users/me/timezone');
+  });
+
+  it('caches under the ["users","me","timezone"] key (the per-preference convention)', async () => {
+    vi.mocked(api.get).mockResolvedValue({ timezone: 'Asia/Tokyo', stored: true });
+    const qc = makeClient();
+
+    renderHook(() => useUserTimezoneQuery(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(qc.getQueryData(['users', 'me', 'timezone'])).toEqual({
+        timezone: 'Asia/Tokyo',
+        stored: true,
+      });
+    });
+  });
+
+  it('is undefined until the query settles — no client-side default to disagree with the server', async () => {
+    let resolveGet: (value: { timezone: string; stored: boolean }) => void = () => {};
+    vi.mocked(api.get).mockReturnValue(
+      new Promise<{ timezone: string; stored: boolean }>((resolve) => {
+        resolveGet = resolve;
+      }),
+    );
+    const qc = makeClient();
+
+    const { result } = renderHook(() => useUserTimezone(), { wrapper: makeWrapper(qc) });
+
+    // In flight: NOT 'UTC', not the browser zone — undefined, so a consumer
+    // gates its bucketed query instead of bucketing by a guess.
+    expect(result.current).toBeUndefined();
+
+    resolveGet({ timezone: 'America/Chicago', stored: true });
+    await waitFor(() => {
+      expect(result.current).toBe('America/Chicago');
+    });
+  });
+});
+
+// ---- Terminal-failure path --------------------------------------------------
+// Without one, a failed read leaves every consumer on `undefined` forever: five
+// bucketing surfaces stuck on skeletons and an inert Performance nav item, with
+// nothing said to the user.
+
+describe('useUserTimezone when the read fails outright', () => {
+  it('retries a bounded number of times rather than forever or not at all', async () => {
+    vi.mocked(api.get).mockRejectedValue(new Error('network down'));
+    const qc = makeClient();
+
+    const { result } = renderHook(() => useUserTimezone(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(result.current).toBeDefined();
+    });
+    // One attempt plus two retries. A transient blip self-heals; a real outage
+    // still REACHES a terminal state instead of hanging.
+    expect(api.get).toHaveBeenCalledTimes(3);
+  });
+
+  it('degrades to the browser zone and SAYS SO, with a retry', async () => {
+    vi.mocked(api.get).mockRejectedValue(new Error('network down'));
+    const qc = makeClient();
+
+    const { result } = renderHook(() => useUserTimezone(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(result.current).toBe('America/New_York');
+    });
+
+    const [message, options] = vi.mocked(toast.error).mock.calls.at(-1) as [
+      string,
+      { id: string; duration: number; action: { label: string; onClick: () => void } },
+    ];
+    // The zone in use is NAMED. A silent substitution is the thing that must
+    // not happen — the user has to be able to see and correct what they are
+    // being bucketed by.
+    expect(message).toContain('America/New_York');
+    expect(options.action.label).toBe('Retry');
+    // One id, so six mounted consumers raise one notice, and it stays up.
+    expect(options.id).toBe('reporting-timezone-unavailable');
+    expect(options.duration).toBe(Infinity);
+  });
+
+  it('falls back to the SHARED default when even detection yields nothing', async () => {
+    // Not a second source of truth: this is the same constant the server
+    // defaults to, reached only once the server has stopped answering.
+    vi.mocked(detectBrowserTimezone).mockReturnValue(undefined);
+    vi.mocked(api.get).mockRejectedValue(new Error('network down'));
+    const qc = makeClient();
+
+    const { result } = renderHook(() => useUserTimezone(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(result.current).toBe('UTC');
+    });
+  });
+
+  it('is dismissible — a notice that never expires needs a way out', async () => {
+    vi.mocked(api.get).mockRejectedValue(new Error('network down'));
+    const qc = makeClient();
+
+    const { result } = renderHook(() => useUserTimezone(), { wrapper: makeWrapper(qc) });
+    await waitFor(() => {
+      expect(result.current).toBe('America/New_York');
+    });
+
+    const [, options] = vi.mocked(toast.error).mock.calls.at(-1) as [
+      string,
+      { closeButton?: boolean },
+    ];
+    // Set per-toast, not on the shared Toaster: `duration: Infinity` with no
+    // close button leaves the user stuck with a banner they cannot clear, and
+    // arming `closeButton` globally would put an X on every other toast too.
+    expect(options.closeButton).toBe(true);
+  });
+
+  it('does not outlive the tree that raised it — unmounting (logout) clears the notice', async () => {
+    vi.mocked(api.get).mockRejectedValue(new Error('network down'));
+    const qc = makeClient();
+
+    const { result, unmount } = renderHook(() => useUserTimezone(), { wrapper: makeWrapper(qc) });
+    await waitFor(() => {
+      expect(result.current).toBe('America/New_York');
+    });
+    // Still up while the consumer is mounted — the degrade is ongoing.
+    expect(toast.dismiss).not.toHaveBeenCalled();
+
+    unmount();
+
+    // Without this, the `duration: Infinity` toast survives logout and sits on
+    // the login screen telling a signed-out visitor about their bucketing.
+    expect(toast.dismiss).toHaveBeenCalledWith('reporting-timezone-unavailable');
+  });
+
+  it('leaves the toaster alone while the read is succeeding', async () => {
+    vi.mocked(api.get).mockResolvedValue({ timezone: 'Europe/London', stored: true });
+    const qc = makeClient();
+
+    const { result } = renderHook(() => useUserTimezone(), { wrapper: makeWrapper(qc) });
+    await waitFor(() => {
+      expect(result.current).toBe('Europe/London');
+    });
+
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(toast.dismiss).not.toHaveBeenCalled();
+  });
+
+  it('clears the notice once a retry succeeds', async () => {
+    vi.mocked(api.get).mockRejectedValue(new Error('network down'));
+    const qc = makeClient();
+
+    const { result } = renderHook(() => useUserTimezone(), { wrapper: makeWrapper(qc) });
+    await waitFor(() => {
+      expect(result.current).toBe('America/New_York');
+    });
+
+    vi.mocked(api.get).mockResolvedValue({ timezone: 'Asia/Tokyo', stored: true });
+    await qc.refetchQueries({ queryKey: ['users', 'me', 'timezone'] });
+
+    await waitFor(() => {
+      expect(result.current).toBe('Asia/Tokyo');
+    });
+    expect(toast.dismiss).toHaveBeenCalledWith('reporting-timezone-unavailable');
+  });
+});
+
+// ---- One-time backfill (R2.5) -----------------------------------------------
+// Every row predating the column reads as the server default `UTC`, but those
+// users were previously bucketed by their BROWSER zone. Left alone, a New York
+// trader's days would silently shift four or five hours on deploy.
+
+describe('useReportingTimezoneBackfill', () => {
+  it('seeds a pre-migration row with the zone that user was already bucketed by', async () => {
+    vi.mocked(api.get).mockResolvedValue({ timezone: 'UTC', stored: false });
+    vi.mocked(api.put).mockResolvedValue({ timezone: 'America/New_York', stored: true });
+    const qc = makeClient();
+    const invalidate = vi.spyOn(qc, 'invalidateQueries');
+
+    renderHook(() => useReportingTimezoneBackfill(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(api.put).toHaveBeenCalledWith('/users/me/timezone', {
+        timezone: 'America/New_York',
+      });
+    });
+    await waitFor(() => {
+      expect(invalidate).toHaveBeenCalledWith({ queryKey: ['users', 'me', 'timezone'] });
+    });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['performance'] });
+  });
+
+  it('NEVER overwrites a zone the user actually chose — including a deliberate UTC', async () => {
+    // The response body is otherwise identical to the pre-migration one. Only
+    // `stored` tells the two apart, which is the entire reason it exists.
+    vi.mocked(api.get).mockResolvedValue({ timezone: 'UTC', stored: true });
+    const qc = makeClient();
+
+    const { result } = renderHook(() => useUserTimezoneQuery(), { wrapper: makeWrapper(qc) });
+    renderHook(() => useReportingTimezoneBackfill(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual({ timezone: 'UTC', stored: true });
+    });
+    expect(api.put).not.toHaveBeenCalled();
+  });
+
+  it('runs at most once — re-renders and further unset reads do not write again', async () => {
+    vi.mocked(api.get).mockResolvedValue({ timezone: 'UTC', stored: false });
+    vi.mocked(api.put).mockResolvedValue({ timezone: 'America/New_York', stored: true });
+    const qc = makeClient();
+
+    const { rerender } = renderHook(() => useReportingTimezoneBackfill(), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await waitFor(() => {
+      expect(api.put).toHaveBeenCalledTimes(1);
+    });
+
+    rerender();
+    rerender();
+
+    // A second unset read lands — the write has not become visible yet. The
+    // payload differs only so that react-query's structural sharing hands the
+    // effect a genuinely new value and it actually re-runs; the guard, not a
+    // stable object identity, is what has to stop the second write.
+    vi.mocked(api.get).mockResolvedValue({ timezone: 'Etc/UTC', stored: false });
+    await qc.refetchQueries({ queryKey: ['users', 'me', 'timezone'] });
+    rerender();
+
+    expect(api.put).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes nothing when detection yields nothing — omit, never send a null', async () => {
+    vi.mocked(detectBrowserTimezone).mockReturnValue(undefined);
+    vi.mocked(api.get).mockResolvedValue({ timezone: 'UTC', stored: false });
+    const qc = makeClient();
+
+    const { result } = renderHook(() => useUserTimezoneQuery(), { wrapper: makeWrapper(qc) });
+    renderHook(() => useReportingTimezoneBackfill(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    // The server default already covers this case; there is nothing better to
+    // store, and `timezone: null` would simply 400.
+    expect(api.put).not.toHaveBeenCalled();
+  });
+
+  it('is harmless when the write fails: no toast, no throw, nothing blocked', async () => {
+    vi.mocked(api.get).mockResolvedValue({ timezone: 'UTC', stored: false });
+    vi.mocked(api.put).mockRejectedValue(new Error('write failed'));
+    const qc = makeClient();
+
+    const { result } = renderHook(
+      () => {
+        useReportingTimezoneBackfill();
+        return useUserTimezone();
+      },
+      { wrapper: makeWrapper(qc) },
+    );
+
+    await waitFor(() => {
+      expect(api.put).toHaveBeenCalledTimes(1);
+    });
+    // The read still works, and the user is told nothing about a write they
+    // never asked for.
+    expect(result.current).toBe('UTC');
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it('does not delay the value it is seeding — the write is not on the render path', async () => {
+    let resolvePut: (value: { timezone: string; stored: boolean }) => void = () => {};
+    vi.mocked(api.get).mockResolvedValue({ timezone: 'UTC', stored: false });
+    vi.mocked(api.put).mockReturnValue(
+      new Promise<{ timezone: string; stored: boolean }>((resolve) => {
+        resolvePut = resolve;
+      }),
+    );
+    const qc = makeClient();
+
+    const { result } = renderHook(
+      () => {
+        useReportingTimezoneBackfill();
+        return useUserTimezone();
+      },
+      { wrapper: makeWrapper(qc) },
+    );
+
+    // Consumers already have a zone while the backfill PUT is still in flight.
+    await waitFor(() => {
+      expect(result.current).toBe('UTC');
+    });
+    expect(api.put).toHaveBeenCalledTimes(1);
+
+    resolvePut({ timezone: 'America/New_York', stored: true });
+  });
+});
+
+describe('useUserTimezoneMutation', () => {
+  it('PUTs the zone, then drops both the preference and the figures cut in the old zone', async () => {
+    vi.mocked(api.put).mockResolvedValue({ timezone: 'Asia/Tokyo', stored: true });
+    const qc = makeClient();
+    const invalidate = vi.spyOn(qc, 'invalidateQueries');
+
+    const { result } = renderHook(() => useUserTimezoneMutation(), { wrapper: makeWrapper(qc) });
+    await result.current.mutateAsync('Asia/Tokyo');
+
+    expect(api.put).toHaveBeenCalledWith('/users/me/timezone', { timezone: 'Asia/Tokyo' });
+    await waitFor(() => {
+      expect(invalidate).toHaveBeenCalledWith({ queryKey: ['users', 'me', 'timezone'] });
+    });
+    // The five bucketing surfaces all read through usePerformance, whose key
+    // carries the zone — so the entries cut in the old zone have to go, or a
+    // revisit paints figures the user no longer asked for.
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['performance'] });
+    expect(toast.success).toHaveBeenCalledWith('Reporting timezone updated');
+  });
+
+  it('surfaces the server message on failure and leaves the caches alone', async () => {
+    vi.mocked(api.put).mockRejectedValue({
+      error: { message: 'Must be a valid IANA timezone name' },
+    });
+    const qc = makeClient();
+    const invalidate = vi.spyOn(qc, 'invalidateQueries');
+
+    const { result } = renderHook(() => useUserTimezoneMutation(), { wrapper: makeWrapper(qc) });
+    await result.current.mutateAsync('Mars/Olympus_Mons').catch(() => {});
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Must be a valid IANA timezone name');
+    });
+    expect(invalidate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/useUserTimezone.ts
+++ b/apps/web/src/hooks/useUserTimezone.ts
@@ -1,0 +1,209 @@
+// useUserTimezone — the one read of the user's STORED reporting timezone
+// (user-onboarding R2.4): the zone P&L is bucketed into by day, week and month.
+// It is not a display format — nothing renders a timestamp in it. Every surface
+// that buckets by day reads from here. Nothing outside `lib/browserTimezone.ts`
+// may call Intl.DateTimeFormat().resolvedOptions().timeZone — a per-device
+// guess is exactly what moves a trade between calendar days when the user opens
+// Tradr from another machine.
+//
+// This is NOT the account trading-day timezone (accounts.timezone, default
+// America/New_York because that is where the US venues run). Neither is
+// derived from the other (R2.7).
+//
+// NO CLIENT-SIDE DEFAULT ON THE SUCCESS PATH. GET /api/users/me/timezone always
+// answers with a resolved zone — a NULL column (a row predating the migration)
+// comes back as the server's DEFAULT_REPORTING_TIMEZONE, flagged `stored:
+// false` — so a `?? 'UTC'` here would be a second source of truth that silently
+// disagrees with the server the day that default changes. Until the query
+// settles the value is `undefined`; consumers gate on it (`enabled:
+// !!timezone`) rather than bucketing a figure by a zone the user never chose.
+// The one exception is the ANNOUNCED degraded value below, which only applies
+// once the read has failed outright and the user has been told.
+//
+// Shape mirrors useBuyingPowerBasisQuery (features/calculator/hooks): the same
+// /api/users/me/<preference> endpoint convention, the same
+// ['users', 'me', <preference>] query key.
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+import { toast } from 'sonner';
+
+import { DEFAULT_REPORTING_TIMEZONE } from '@tradr/shared';
+
+import { api } from '@/lib/api';
+import { detectBrowserTimezone } from '@/lib/browserTimezone';
+
+export interface UserTimezoneResponse {
+  timezone: string;
+  // False when the column is unset (a row predating the preference) and the
+  // server substituted its default; true when the zone is the user's own. The
+  // resolved zone alone cannot tell "never set" from "deliberately UTC", and
+  // the backfill below turns on exactly that distinction.
+  stored: boolean;
+}
+
+// One id, so the six consumers of useUserTimezone() that are mounted at once
+// raise ONE notice between them rather than six stacked copies.
+const FAILURE_TOAST_ID = 'reporting-timezone-unavailable';
+
+function getErrorMessage(err: unknown, fallback: string): string {
+  if (typeof err === 'object' && err !== null && 'error' in err) {
+    const e = err as { error?: { message?: string } };
+    if (e.error?.message) return e.error.message;
+  }
+  return fallback;
+}
+
+export function useUserTimezoneQuery() {
+  return useQuery<UserTimezoneResponse>({
+    queryKey: ['users', 'me', 'timezone'],
+    queryFn: () => api.get<UserTimezoneResponse>('/users/me/timezone'),
+    // Bounded, so a blip still self-heals but a real outage REACHES a terminal
+    // state instead of retrying forever. The default policy would leave
+    // `isError` false indefinitely, and every consumer below gates on the zone
+    // — the whole app would sit on skeletons with nothing said to anyone.
+    retry: 2,
+  });
+}
+
+/**
+ * The stored zone; `undefined` while the query is in flight.
+ *
+ * On TERMINAL failure it degrades to a browser-detected zone (the server
+ * default only if even that is unavailable) and says so, with a retry. The
+ * alternative — staying `undefined` — leaves all five bucketing surfaces on
+ * permanent skeletons and the sidebar's Performance item permanently inert,
+ * which is a worse outcome than figures cut in a zone the user can see named
+ * and correct. This is not the client-side default the header rules out: it
+ * never applies while the server is answering, it is announced rather than
+ * silent, and its last resort is the SAME shared constant the server defaults
+ * to, so there is still only one default in the system.
+ */
+export function useUserTimezone(): string | undefined {
+  const { data, isError, refetch } = useUserTimezoneQuery();
+
+  useEffect(() => {
+    // The happy path must not touch the toaster at all.
+    if (!isError) return;
+
+    toast.error(
+      `Couldn't load your reporting timezone. Figures are bucketed in ${degradedTimezone()} until it loads.`,
+      {
+        id: FAILURE_TOAST_ID,
+        duration: Infinity,
+        // Per-toast, NOT on the shared Toaster: this is the only notice in the
+        // app that never expires, so it is the only one that needs a manual
+        // way out. Turning `closeButton` on globally would put an X on every
+        // transient success toast in the app to fix one permanent error one.
+        closeButton: true,
+        action: { label: 'Retry', onClick: () => void refetch() },
+      },
+    );
+
+    // A `duration: Infinity` toast that nothing tears down outlives the tree
+    // that raised it — after logout it sits on the login screen telling a
+    // signed-out visitor about their bucketing. The cleanup covers BOTH exits:
+    // recovery (`isError` goes false) and unmount (logout, or navigating away
+    // from the surface). Dismissing is idempotent and the id is shared, so the
+    // other consumers unmounting alongside this one cost nothing; a consumer
+    // that outlives this one re-raises the notice the next time any consumer
+    // mounts against the still-errored query.
+    return () => {
+      toast.dismiss(FAILURE_TOAST_ID);
+    };
+  }, [isError, refetch]);
+
+  if (data) return data.timezone;
+  return isError ? degradedTimezone() : undefined;
+}
+
+// The zone the user was already being bucketed by before this preference
+// existed. Only ever reached with the preference read in a terminal error
+// state, and only after the notice above has named it.
+function degradedTimezone(): string {
+  return detectBrowserTimezone() ?? DEFAULT_REPORTING_TIMEZONE;
+}
+
+/**
+ * The ONE-TIME backfill of a pre-migration row (R2.5). Mounted once, in the
+ * authenticated layout.
+ *
+ * Every row that predates the column reads as the server default, `UTC` — but
+ * before this preference existed those users were bucketed by their BROWSER
+ * zone, so leaving them on UTC would silently move a New York trader's days by
+ * four or five hours and shift trades across day boundaries. That is a bigger
+ * change than the per-device behaviour ever caused, which is what R2.5 forbids.
+ * So the first authenticated load stores the zone they were already using.
+ *
+ *   - At most once per user: `stored: false` is the trigger, and a successful
+ *     write makes it true forever. The ref additionally holds it to one attempt
+ *     per mount, so React's double-invoked effects cannot double-write.
+ *   - Never overwrites a chosen zone: `stored: true` — including a deliberate
+ *     `UTC` — returns immediately. This is the whole reason the flag exists.
+ *   - Never blocks rendering: it is an effect that returns nothing and gates
+ *     nothing; the layout paints whether or not it has run.
+ *   - Harmless when it fails: the rejection is swallowed, the user is not
+ *     told about a write they did not ask for, and the row simply stays unset
+ *     for another attempt on a later load.
+ *   - Sends nothing when detection yields nothing: the field is OMITTED (the
+ *     write is skipped entirely) rather than sent as null, exactly as
+ *     registration does — the server default already covers that case.
+ */
+export function useReportingTimezoneBackfill(): void {
+  const { data } = useUserTimezoneQuery();
+  const queryClient = useQueryClient();
+  const attempted = useRef(false);
+
+  useEffect(() => {
+    if (!data || data.stored || attempted.current) return;
+
+    const detected = detectBrowserTimezone();
+    if (!detected) return;
+
+    // Set BEFORE the await, or React's double-invoked effects race two writes.
+    attempted.current = true;
+
+    void api
+      .put<UserTimezoneResponse>('/users/me/timezone', { timezone: detected })
+      .then(() => {
+        queryClient.invalidateQueries({ queryKey: ['users', 'me', 'timezone'] });
+        // Same reason as the mutation below: the bucketed figures carry the
+        // zone inside their key, so the entries cut in the substituted default
+        // have to go.
+        queryClient.invalidateQueries({ queryKey: ['performance'] });
+      })
+      .catch(() => {
+        // Deliberately silent. Nothing the user did failed, and the row is
+        // still readable — it just keeps resolving to the default.
+      });
+  }, [data, queryClient]);
+}
+
+// Write the reporting timezone (R2.6). Mirrors useBuyingPowerBasisMutation's
+// shape — same PUT /api/users/me/<preference> convention, same toast handling.
+//
+// TWO invalidations, and the second one is not redundant. The preference key
+// re-reads the stored zone, which is what every consumer of useUserTimezone()
+// renders from. `['performance']` is invalidated because the five surfaces that
+// bucket by this zone all read through usePerformance, whose key carries the
+// zone inside its params — so a change lands on a NEW key and leaves the
+// entries cut in the OLD zone sitting in the cache. Dropping them keeps a
+// later revisit from painting figures bucketed in a zone the user has since
+// left before the refetch arrives. Same direct-invalidation shape as
+// useDisplayCurrencyMutation; the event bus is not used because this touches
+// exactly one other prefix, not a fan-out across features.
+export function useUserTimezoneMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (timezone: string) =>
+      api.put<UserTimezoneResponse>('/users/me/timezone', { timezone }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['users', 'me', 'timezone'] });
+      queryClient.invalidateQueries({ queryKey: ['performance'] });
+      toast.success('Reporting timezone updated');
+    },
+    onError: (err: unknown) => {
+      toast.error(getErrorMessage(err, 'Failed to update reporting timezone'));
+    },
+  });
+}

--- a/apps/web/src/lib/browserTimezone.ts
+++ b/apps/web/src/lib/browserTimezone.ts
@@ -1,0 +1,42 @@
+import { ReportingTimezoneField } from '@tradr/shared';
+
+/**
+ * The app's ONLY browser timezone detection (user-onboarding R2.2/R2.5). Every
+ * render-time read of the reporting zone goes through `useUserTimezone`
+ * instead, because a per-device guess is what moves a trade between calendar
+ * days when the user opens Tradr elsewhere.
+ *
+ * It has exactly three callers, all of them writes or last resorts, never a
+ * render-time bucketing input:
+ *
+ *  1. `routes/register.tsx` — seeds `users.timezone` at sign-up.
+ *  2. `hooks/useUserTimezone.ts` — the ONE-TIME backfill of a pre-migration row
+ *     (`stored: false`), which stores the very zone that user was already being
+ *     bucketed by before the column existed.
+ *  3. `hooks/useUserTimezone.ts` — the announced degraded value after the
+ *     preference read has failed outright.
+ *
+ * `undefined` means OMIT THE FIELD, never send `timezone: null` —
+ * `RegisterSchema.timezone` is optional but not nullable, so an explicit null
+ * would 400 a registration with nothing wrong with it. There are two ways to
+ * get there:
+ *
+ *  1. Intl is missing or throws (locked-down or exotic runtime).
+ *  2. The browser reports a zone the server would reject — over 64 characters,
+ *     or the `-u-` Unicode-extension form. That is checked HERE, with the same
+ *     shared validator the API uses (`ReportingTimezoneField`), so an odd
+ *     browser zone quietly falls back to the server default instead of making
+ *     the person unable to create an account at all. A best-effort guess must
+ *     never be the reason a signup fails; the zone is correctable in settings
+ *     afterwards.
+ */
+export function detectBrowserTimezone(): string | undefined {
+  let zone: string | undefined;
+  try {
+    zone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch {
+    return undefined;
+  }
+  if (!zone) return undefined;
+  return ReportingTimezoneField.safeParse(zone).success ? zone : undefined;
+}

--- a/apps/web/src/routes/_auth.settings.profile.tsx
+++ b/apps/web/src/routes/_auth.settings.profile.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { z } from 'zod';
 
+import { ReportingTimezoneSelect } from '@/components/ReportingTimezoneSelect';
 import { DisplayCurrencySelect } from '@/features/accounting/components/DisplayCurrencySelect';
 import { ExchangeRatesPage } from '@/features/accounting/components/ExchangeRatesPage';
 import { BuyingPowerBasisSelect } from '@/features/calculator/components/BuyingPowerBasisSelect';
@@ -17,6 +18,9 @@ function SettingsProfile() {
     <div className="space-y-8">
       <DisplayCurrencySelect />
       <BuyingPowerBasisSelect />
+      {/* Reporting timezone (user-onboarding R2.6) — viewable and changeable
+          here whether or not the user ever saw onboarding. */}
+      <ReportingTimezoneSelect />
       <ExchangeRatesPage initialBase={base} initialQuote={quote} />
     </div>
   );

--- a/apps/web/src/routes/_auth.tsx
+++ b/apps/web/src/routes/_auth.tsx
@@ -5,10 +5,16 @@ import { DrawerToggleRefProvider } from '@/components/layout/DrawerToggleRefCont
 import { Sidebar } from '@/components/layout/Sidebar';
 import { SideDrawer } from '@/components/layout/SideDrawer';
 import { useAuth } from '@/hooks/useAuth';
+import { useReportingTimezoneBackfill } from '@/hooks/useUserTimezone';
 import { EventBusBridge } from '@/stores/EventBusBridge';
 
 function AuthLayout() {
   const { isLoading, isAuthenticated } = useAuth();
+  // One-time seeding of a pre-migration reporting timezone (user-onboarding
+  // R2.5). Here because this is the one component every authenticated view
+  // mounts under, and exactly once. It returns nothing and gates nothing — the
+  // early returns below run whether or not it has anything to do.
+  useReportingTimezoneBackfill();
 
   if (isLoading) {
     return (

--- a/apps/web/src/routes/register.test.tsx
+++ b/apps/web/src/routes/register.test.tsx
@@ -87,6 +87,38 @@ let resendResponse: () => Response;
 
 let fetchSpy: MockInstance | null = null;
 
+// ---- Browser-zone stub ------------------------------------------------------
+// register.tsx is the ONE place still allowed to detect the browser zone (R2.2).
+// Only the ZERO-ARG call is that detection; calls carrying arguments are
+// delegated to the real implementation, because the shared
+// ReportingTimezoneField validator decides validity with
+// `new Intl.DateTimeFormat('en-US', { timeZone })`.
+const RealDateTimeFormat = Intl.DateTimeFormat;
+let intlSpy: MockInstance | null = null;
+
+function installIntlStub(resolvedOptions: () => { timeZone: string | undefined }) {
+  const impl = (...args: unknown[]) =>
+    args.length > 0 ? Reflect.construct(RealDateTimeFormat, args) : { resolvedOptions };
+  intlSpy = vi
+    .spyOn(Intl, 'DateTimeFormat')
+    .mockImplementation(impl as unknown as typeof Intl.DateTimeFormat);
+}
+
+function stubBrowserZone(zone: string | undefined) {
+  installIntlStub(() => ({ timeZone: zone }));
+}
+
+function stubBrowserZoneThrows() {
+  installIntlStub(() => {
+    throw new Error('Intl unavailable in this runtime');
+  });
+}
+
+function registerBody(): Record<string, unknown> {
+  const call = fetchSpy!.mock.calls.find((args) => String(args[0]).includes('/auth/register'));
+  return JSON.parse(String((call![1] as RequestInit).body)) as Record<string, unknown>;
+}
+
 beforeEach(() => {
   meUser = null;
   registered = { id: 'u1', email: 'new@user.dev', isAdmin: false, emailVerified: false };
@@ -108,6 +140,8 @@ afterEach(() => {
   cleanup();
   fetchSpy?.mockRestore();
   fetchSpy = null;
+  intlSpy?.mockRestore();
+  intlSpy = null;
 });
 
 async function fillAndSubmit() {
@@ -226,5 +260,45 @@ describe('register route', () => {
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Too many requests — try again later.');
     });
+  });
+
+  // ---- Reporting-timezone seeding (R2.2) ------------------------------------
+
+  it('case 5: sends the browser-detected reporting timezone in the registration payload', async () => {
+    stubBrowserZone('Europe/London');
+    await registerToCheckYourEmail();
+
+    expect(registerBody()).toEqual({
+      email: 'new@user.dev',
+      password: 'password-123',
+      timezone: 'Europe/London',
+    });
+  });
+
+  it('case 6: OMITS the key when detection yields nothing — never sends timezone: null, which RegisterSchema rejects', async () => {
+    stubBrowserZone(undefined);
+    await registerToCheckYourEmail();
+
+    const body = registerBody();
+    expect('timezone' in body).toBe(false);
+    expect(body).toEqual({ email: 'new@user.dev', password: 'password-123' });
+  });
+
+  it('case 7: registration still succeeds when detection throws', async () => {
+    stubBrowserZoneThrows();
+    await registerToCheckYourEmail();
+
+    expect('timezone' in registerBody()).toBe(false);
+  });
+
+  it('case 8: a zone the server would reject is dropped, not sent — a bad guess must not block signing up', async () => {
+    // The Unicode-extension bypass resolveTimezone refuses; the shared
+    // validator catches it client-side, so the signup goes through without it
+    // rather than 400ing on a value the user never typed.
+    stubBrowserZone('America/New_York-u-ca-japanese');
+    await registerToCheckYourEmail();
+
+    expect('timezone' in registerBody()).toBe(false);
+    expect(screen.getByText('Check your email')).toBeTruthy();
   });
 });

--- a/apps/web/src/routes/register.tsx
+++ b/apps/web/src/routes/register.tsx
@@ -14,6 +14,7 @@ import { Label } from '@/components/ui/label';
 import { useAuth } from '@/hooks/useAuth';
 import { useResendVerification } from '@/hooks/useResendVerification';
 import { api } from '@/lib/api';
+import { detectBrowserTimezone } from '@/lib/browserTimezone';
 
 const RegisterFormSchema = RegisterSchema.extend({
   confirmPassword: z.string(),
@@ -101,9 +102,13 @@ function RegisterPage() {
   const onSubmit = async (data: RegisterFormInput) => {
     setApiError('');
     try {
+      const detectedTimezone = detectBrowserTimezone();
       const response = await api.post<{ user: User }>('/auth/register', {
         email: data.email,
         password: data.password,
+        // Spread, not `timezone: detectedTimezone ?? null` — see
+        // detectBrowserTimezone: the key must be absent, not null.
+        ...(detectedTimezone ? { timezone: detectedTimezone } : {}),
       });
       if (response.user.emailVerified) {
         // Email not configured on this instance — today's flow, unchanged.

--- a/e2e/tests/fixtures/performance-fixtures.ts
+++ b/e2e/tests/fixtures/performance-fixtures.ts
@@ -237,6 +237,16 @@ export async function mockAppShell(page: Page): Promise<void> {
   await page.route('**/api/users/me/buying-power-basis', (route) =>
     route.fulfill(json({ basis: 'cash' })),
   );
+  // The reporting timezone is read on every authenticated view — the auth
+  // layout, the sidebar, and each P&L-bucketing surface — so it is app-shell
+  // surface too, and unmocked it fails the same way the note above describes.
+  //
+  // `stored: true` is what keeps this a single GET: it tells the client the
+  // user already has a zone on their row, so the one-time backfill does not
+  // fire a PUT that would 401 against the mocked session.
+  await page.route('**/api/users/me/timezone', (route) =>
+    route.fulfill(json({ timezone: 'UTC', stored: true })),
+  );
   // Quick Stats tab fetches /performance; the route-under-test mock (registered
   // later by the performance specs) overrides this benign empty default.
   await page.route(/\/api\/performance(\?.*)?$/, (route) =>

--- a/packages/shared/src/constants/timezones.ts
+++ b/packages/shared/src/constants/timezones.ts
@@ -13,3 +13,16 @@ export const IANA_TIMEZONES: readonly string[] = Intl.supportedValuesOf('timeZon
 // Default account trading-day zone (position-lifecycle R1 amendment) — mirrors
 // the `accounts.timezone` column default.
 export const DEFAULT_ACCOUNT_TIMEZONE = 'America/New_York';
+
+// Default user REPORTING zone (user-onboarding R2.3, R2.5). Used on two paths
+// that must agree: the registration write when the client sends no
+// browser-detected zone, and the read of a pre-migration NULL column.
+//
+// It is deliberately NOT `DEFAULT_ACCOUNT_TIMEZONE`. That one is
+// 'America/New_York' because NYSE, NASDAQ and NYSE Arca run there, which says
+// where the *market* is, not where the *person* is; deriving one from the other
+// is exactly what R2.7 forbids. 'UTC' is also the fallback the six
+// timezone-bucketing surfaces already use when `Intl` yields nothing, so a
+// pre-migration row resolves to the value that path would have produced anyway
+// (R2.5). Any other zone would be an unfounded claim about the user's location.
+export const DEFAULT_REPORTING_TIMEZONE = 'UTC';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -260,6 +260,8 @@ export type {
   ChangelogReleasesResponse,
   MarkChangelogViewedResponse,
 } from './schemas/changelog';
+export { ReportingTimezoneField, UserTimezoneSchema } from './schemas/user';
+export type { UserTimezoneInput } from './schemas/user';
 export type { CanonicalPart, CanonicalMessage, ProviderModel } from './lib/advisor/types';
 export { uuidv5, uuidv5Batch, WIDGET_DEFAULT_NAMESPACE } from './utils/uuidv5';
 export { DEFAULT_WIDGETS, BODY_LIMIT_BYTES } from './constants/dashboard-defaults';

--- a/packages/shared/src/schemas/auth.ts
+++ b/packages/shared/src/schemas/auth.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { ReportingTimezoneField } from './user';
+
 // Normalized email: transform-BEFORE-validate (trim + lowercase, then .email()),
 // so the parsed output matches the stored lowercase form (REQ-3.8) — the corrected
 // order the SEED_ADMIN_EMAIL comment in apps/api/src/lib/config.ts documents.
@@ -18,6 +20,12 @@ export const LoginSchema = z.object({
 export const RegisterSchema = z.object({
   email: z.string().email().trim().toLowerCase(),
   password: z.string().min(8).max(72),
+  // Browser-detected reporting timezone (user-onboarding R2.2). OPTIONAL and
+  // must stay that way: scripted registrations and the existing e2e helpers
+  // post without it, and an absent value falls back to a defined default
+  // server-side rather than being stored as null-and-guessed-later (R2.3).
+  // Not the account trading-day timezone — see schemas/user.ts.
+  timezone: ReportingTimezoneField.optional(),
 });
 
 export const PasswordResetRequestSchema = z.object({

--- a/packages/shared/src/schemas/user.test.ts
+++ b/packages/shared/src/schemas/user.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import { RegisterSchema } from './auth';
+import { UserTimezoneSchema } from './user';
+
+const baseRegister = { email: 'trader@example.com', password: 'correct-horse' };
+
+describe('UserTimezoneSchema', () => {
+  it.each(['America/New_York', 'Asia/Tokyo', 'Europe/London', 'Australia/Sydney', 'Pacific/Apia'])(
+    'accepts %s',
+    (tz) => {
+      const result = UserTimezoneSchema.safeParse({ timezone: tz });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.timezone).toBe(tz);
+    },
+  );
+
+  // The whole reason validation goes through resolveTimezone rather than
+  // IANA_TIMEZONES.includes(): Intl.supportedValuesOf('timeZone') omits every
+  // Etc/* zone and bare UTC, all of which are real zones a client may send.
+  it.each(['UTC', 'Etc/UTC', 'Etc/GMT', 'Etc/GMT+5', 'Etc/GMT-9'])(
+    'accepts %s even though the picker list omits it',
+    (tz) => {
+      expect(UserTimezoneSchema.safeParse({ timezone: tz }).success).toBe(true);
+    },
+  );
+
+  // Intl silently strips Unicode extensions, so `America/New_York-u-ca-japanese`
+  // would otherwise resolve and be stored verbatim. resolveTimezone rejects it.
+  it.each(['America/New_York-u-ca-japanese', 'UTC-u-ca-buddhist'])(
+    'rejects the Unicode-extension bypass %s',
+    (tz) => {
+      expect(UserTimezoneSchema.safeParse({ timezone: tz }).success).toBe(false);
+    },
+  );
+
+  it.each(['Not/AZone', 'America/Nowhere', 'EST5EDT5', 'abc', '../../etc/passwd'])(
+    'rejects junk %s',
+    (tz) => {
+      expect(UserTimezoneSchema.safeParse({ timezone: tz }).success).toBe(false);
+    },
+  );
+
+  it('rejects an empty string', () => {
+    expect(UserTimezoneSchema.safeParse({ timezone: '' }).success).toBe(false);
+  });
+
+  // Bounded to the users.timezone varchar(64) column.
+  it('rejects a string longer than the 64-char column', () => {
+    expect(UserTimezoneSchema.safeParse({ timezone: 'A'.repeat(65) }).success).toBe(false);
+  });
+
+  it('reports the failure on the timezone field', () => {
+    const result = UserTimezoneSchema.safeParse({ timezone: 'Not/AZone' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.path).toEqual(['timezone']);
+    }
+  });
+
+  it('requires the field — an explicit preference write with no zone has no meaning', () => {
+    expect(UserTimezoneSchema.safeParse({}).success).toBe(false);
+    expect(UserTimezoneSchema.safeParse({ timezone: null }).success).toBe(false);
+  });
+});
+
+describe('RegisterSchema.timezone', () => {
+  // Scripted registrations and the existing e2e helpers post without it (R2.3).
+  it('is optional — registering without it still parses', () => {
+    const result = RegisterSchema.safeParse(baseRegister);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.timezone).toBeUndefined();
+  });
+
+  it('accepts a body with a browser-detected zone', () => {
+    const result = RegisterSchema.safeParse({ ...baseRegister, timezone: 'Asia/Tokyo' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.timezone).toBe('Asia/Tokyo');
+  });
+
+  it.each(['UTC', 'Etc/GMT+5'])('accepts %s at registration', (tz) => {
+    expect(RegisterSchema.safeParse({ ...baseRegister, timezone: tz }).success).toBe(true);
+  });
+
+  it.each(['America/New_York-u-ca-japanese', 'Not/AZone', '', 'A'.repeat(65)])(
+    'rejects %j with a field error',
+    (tz) => {
+      const result = RegisterSchema.safeParse({ ...baseRegister, timezone: tz });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.some((i) => i.path[0] === 'timezone')).toBe(true);
+      }
+    },
+  );
+
+  // The email/password chain is frozen — adding the field must not have moved
+  // which raw inputs the endpoint accepts. `.email()` runs BEFORE `.trim()`
+  // here (unlike EmailField), so a padded address is rejected rather than
+  // trimmed into validity; that asymmetry is the thing the auth.ts comment
+  // protects, so assert it alongside the parts that do normalize.
+  it('leaves the frozen email/password chain unmoved', () => {
+    const result = RegisterSchema.safeParse({
+      email: 'Trader@Example.COM',
+      password: 'correct-horse',
+      timezone: 'Europe/London',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.email).toBe('trader@example.com');
+
+    expect(
+      RegisterSchema.safeParse({ ...baseRegister, email: '  trader@example.com  ' }).success,
+    ).toBe(false);
+    expect(RegisterSchema.safeParse({ ...baseRegister, password: 'short' }).success).toBe(false);
+  });
+});

--- a/packages/shared/src/schemas/user.ts
+++ b/packages/shared/src/schemas/user.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+
+import { resolveTimezone } from './performance';
+
+// The user's REPORTING timezone (user-onboarding R2): the zone P&L is bucketed
+// into by day, week and month. It follows the person, not the market. It is
+// NOT a display format — nothing renders a timestamp in it.
+//
+// Deliberately NOT the same thing as `accounts.timezone`, which is the
+// account's trading-day boundary and defaults to 'America/New_York' because
+// that is where the US equity venues run. Neither is derived from the other
+// (R2.7) — a user in Tokyo trading US equities correctly has an account
+// timezone of America/New_York and a reporting timezone of Asia/Tokyo at the
+// same time.
+//
+// Bounded to the users.timezone varchar(64) column, exactly as the account
+// field is bounded to its own. Validation reuses `resolveTimezone` for the
+// reasons set out at length in schemas/account.ts: Intl is the IANA authority,
+// so there is no hand-maintained list to rot, and it already rejects the
+// Unicode-extension bypass (`America/New_York-u-ca-japanese`) that Intl would
+// otherwise silently strip. Deliberately NOT `IANA_TIMEZONES.includes(v)` —
+// `Intl.supportedValuesOf('timeZone')` omits every `Etc/*` zone and bare
+// `UTC`, which are real zones a client may legitimately send. That array is
+// the picker's list, not the definition of validity.
+export const ReportingTimezoneField = z
+  .string()
+  .max(64)
+  .refine(
+    (v) => {
+      try {
+        resolveTimezone(v);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { message: 'Must be a valid IANA timezone name' },
+  );
+
+// Body for PUT /api/users/me/timezone (R2.6). Mirrors the established
+// per-user-preference endpoint shape — `{ basis }` on
+// /api/users/me/buying-power-basis — rather than inventing a new convention.
+//
+// Required here, unlike on RegisterSchema: an explicit preference write with
+// no zone in it has no meaning. Clearing the preference is not offered, since
+// a NULL column only ever means "predates the column" (R2.5).
+export const UserTimezoneSchema = z.object({ timezone: ReportingTimezoneField });
+
+export type UserTimezoneInput = z.infer<typeof UserTimezoneSchema>;


### PR DESCRIPTION
Re-lands the change from #39, which was merged into its stacked base rather than into `main` and so never arrived here. Same commits, reviewed there, cherry-picked onto current `main`.

Tradr decides which day a trade's P&L belongs to using a timezone. Until now that zone was read from the browser at render time, on every surface that buckets figures — so the same account showed different daily and weekly numbers depending on where you opened it. Travelling, using a VPN, or switching laptops silently regrouped your history.

This stores the zone against the user instead.

## What changed

- `users.timezone` — a new nullable column holding the user's reporting timezone, seeded from the browser at registration and editable in profile settings.
- `GET` / `PUT /api/users/me/timezone`, following the existing per-user preference endpoint shape.
- The surfaces that bucket P&L — the dashboard stats, performance chart and equity curve widgets, the drawer's quick stats, and the performance page defaults — now read the stored value.
- Existing users keep the bucketing they have today: on first load after upgrading, an account that has never had a zone stored is backfilled once with the browser's zone. Nobody's daily figures move underneath them.
- If the preference cannot be fetched after retries, the app says so and falls back rather than sitting on skeletons.

## Two timezones, deliberately

Tradr now has two, and they are not the same thing:

- An **account's** timezone is the trading-day boundary — it decides whether a position can be re-entered the same day. It defaults to US Eastern because that is where NYSE, NASDAQ and NYSE Arca operate.
- A **user's** reporting timezone is how P&L is grouped into days and weeks.

Neither is derived from the other, and both controls now say so, so setting one cannot be mistaken for setting the other.

## Checks

Typecheck across all packages; the migrations, api and web suites; eslint; and the generated reference artifacts regenerate to a clean tree.
