### PR TITLE
feat(onboarding): store onboarding preference per user

### DIFF
--- a/apps/api/src/db/migrations/0027_user_onboarding_preference.sql
+++ b/apps/api/src/db/migrations/0027_user_onboarding_preference.sql
@@ -1,0 +1,24 @@
+-- Onboarding PREFERENCE state (user-onboarding R4.5, R4.6, R4.7, R7.2):
+-- walkthrough status, the first-calculator-use timestamp, and the set of coach
+-- marks already seen. See users.schema.ts and
+-- packages/shared/src/schemas/onboarding.ts.
+--
+-- PREFERENCE ONLY. Per-item checklist completion is DERIVED from the user's
+-- real data (account count, position count, closed-position count) and is never
+-- stored here (R4.2), so it cannot disagree with reality or need repair.
+-- calculator_first_used_at is the single named exception and is a timestamp
+-- recording a fact, not a completion flag — the calculator writes nothing else,
+-- so checklist item 2 has no other data trace.
+--
+-- One jsonb column rather than three scalar columns because coachMarksSeen is a
+-- growing SET of surface keys; as columns it would eventually need its own
+-- table for what is a UI preference. Follows the dashboard_layouts.widgets
+-- precedent.
+--
+-- NOT NULL DEFAULT '{}' with NO backfill: PostgreSQL's fast default makes every
+-- existing row valid without rewriting the table, and '{}' parses to sensible
+-- defaults (status 'pending', coachMarksSeen []) because every field in
+-- OnboardingStateSchema is optional-with-a-default. Contrast users.timezone in
+-- 0026, which is nullable precisely so NULL can mean "predates the column" —
+-- here there is nothing to signal, only a preference nobody has expressed yet.
+ALTER TABLE "users" ADD COLUMN "onboarding" jsonb DEFAULT '{}'::jsonb NOT NULL;

--- a/apps/api/src/db/migrations/meta/0027_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0027_snapshot.json
@@ -1,0 +1,3436 @@
+{
+  "id": "ec4b13ec-ef6e-488c-9578-c4f3c893c7b9",
+  "prevId": "77aeedbc-6e86-481a-946e-1efac99a285f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.exchange_rates": {
+      "name": "exchange_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_currency": {
+          "name": "base_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_currency": {
+          "name": "quote_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(24, 12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exchange_rates_user_pair_date_unique": {
+          "name": "exchange_rates_user_pair_date_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "base_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exchange_rates_user_id_users_id_fk": {
+          "name": "exchange_rates_user_id_users_id_fk",
+          "tableFrom": "exchange_rates",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "exchange_rates_distinct_currencies_chk": {
+          "name": "exchange_rates_distinct_currencies_chk",
+          "value": "\"exchange_rates\".\"base_currency\" <> \"exchange_rates\".\"quote_currency\""
+        },
+        "exchange_rates_rate_positive_chk": {
+          "name": "exchange_rates_rate_positive_chk",
+          "value": "\"exchange_rates\".\"rate\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ledger_entries": {
+      "name": "ledger_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_id": {
+          "name": "position_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reverses_group_id": {
+          "name": "reverses_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ledger_user_id_idx": {
+          "name": "ledger_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_account_id_idx": {
+          "name": "ledger_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_user_account_occurred_pnl_idx": {
+          "name": "ledger_user_account_occurred_pnl_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"occurred_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ledger_entries\".\"entry_type\" IN ('position_pnl', 'position_pnl_reversal', 'balance_adjustment')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_user_account_direction_amount_pnl_idx": {
+          "name": "ledger_user_account_direction_amount_pnl_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ledger_entries\".\"entry_type\" IN ('position_pnl', 'position_pnl_reversal', 'balance_adjustment')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_reverses_group_id_idx": {
+          "name": "ledger_reverses_group_id_idx",
+          "columns": [
+            {
+              "expression": "reverses_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ledger_entries\".\"reverses_group_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ledger_entries_user_id_users_id_fk": {
+          "name": "ledger_entries_user_id_users_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ledger_entries_account_id_accounts_id_fk": {
+          "name": "ledger_entries_account_id_accounts_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "ledger_entries_position_id_positions_id_fk": {
+          "name": "ledger_entries_position_id_positions_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "positions",
+          "columnsFrom": ["position_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ledger_amount_nonneg_chk": {
+          "name": "ledger_amount_nonneg_chk",
+          "value": "\"ledger_entries\".\"amount\" >= 0"
+        },
+        "ledger_direction_chk": {
+          "name": "ledger_direction_chk",
+          "value": "\"ledger_entries\".\"direction\" IN ('credit', 'debit')"
+        },
+        "ledger_entry_type_chk": {
+          "name": "ledger_entry_type_chk",
+          "value": "\"ledger_entries\".\"entry_type\" IN ('position_pnl', 'position_pnl_reversal', 'balance_adjustment')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "brokerage_id": {
+          "name": "brokerage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_balance": {
+          "name": "starting_balance",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "default_risk_percent": {
+          "name": "default_risk_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_id_name_unique": {
+          "name": "accounts_user_id_name_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_brokerage_id_idx": {
+          "name": "accounts_brokerage_id_idx",
+          "columns": [
+            {
+              "expression": "brokerage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_brokerage_id_brokerages_id_fk": {
+          "name": "accounts_brokerage_id_brokerages_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "brokerages",
+          "columnsFrom": ["brokerage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_email": {
+          "name": "target_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_created_idx": {
+          "name": "admin_audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_actor_user_id_users_id_fk": {
+          "name": "admin_audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_users_id_fk": {
+          "name": "admin_audit_log_target_user_id_users_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["target_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "admin_audit_log_action_chk": {
+          "name": "admin_audit_log_action_chk",
+          "value": "\"admin_audit_log\".\"action\" IN ('admin_toggle')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.advisor_image_counters": {
+      "name": "advisor_image_counters",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_count": {
+          "name": "image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "advisor_image_counters_user_id_users_id_fk": {
+          "name": "advisor_image_counters_user_id_users_id_fk",
+          "tableFrom": "advisor_image_counters",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "advisor_image_counters_user_id_period_key_pk": {
+          "name": "advisor_image_counters_user_id_period_key_pk",
+          "columns": ["user_id", "period_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_turn_counters": {
+      "name": "advisor_turn_counters",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "allowance_turns": {
+          "name": "allowance_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "advisor_turn_counters_user_id_users_id_fk": {
+          "name": "advisor_turn_counters_user_id_users_id_fk",
+          "tableFrom": "advisor_turn_counters",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "advisor_turn_counters_user_id_period_key_pk": {
+          "name": "advisor_turn_counters_user_id_period_key_pk",
+          "columns": ["user_id", "period_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_conversations": {
+      "name": "advisor_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_conversations_user_updated_idx": {
+          "name": "advisor_conversations_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_conversations_user_id_users_id_fk": {
+          "name": "advisor_conversations_user_id_users_id_fk",
+          "tableFrom": "advisor_conversations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "advisor_conversations_persona_id_advisor_personas_id_fk": {
+          "name": "advisor_conversations_persona_id_advisor_personas_id_fk",
+          "tableFrom": "advisor_conversations",
+          "tableTo": "advisor_personas",
+          "columnsFrom": ["persona_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_messages": {
+      "name": "advisor_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_parts": {
+          "name": "content_parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_message_id": {
+          "name": "client_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_messages_conv_created_idx": {
+          "name": "advisor_messages_conv_created_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "advisor_messages_idem": {
+          "name": "advisor_messages_idem",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "role = 'user' AND client_message_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "advisor_messages_assistant_pair_uniq": {
+          "name": "advisor_messages_assistant_pair_uniq",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "role = 'assistant' AND client_message_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_messages_conversation_id_advisor_conversations_id_fk": {
+          "name": "advisor_messages_conversation_id_advisor_conversations_id_fk",
+          "tableFrom": "advisor_messages",
+          "tableTo": "advisor_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "advisor_messages_role_chk": {
+          "name": "advisor_messages_role_chk",
+          "value": "\"advisor_messages\".\"role\" IN ('user', 'assistant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.advisor_personas": {
+      "name": "advisor_personas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_personas_one_default_per_user": {
+          "name": "advisor_personas_one_default_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true AND user_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_personas_user_id_users_id_fk": {
+          "name": "advisor_personas_user_id_users_id_fk",
+          "tableFrom": "advisor_personas",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_provider_keys": {
+      "name": "advisor_provider_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hint_tail": {
+          "name": "key_hint_tail",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_provider_keys_user_provider_uniq": {
+          "name": "advisor_provider_keys_user_provider_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_provider_keys_user_id_users_id_fk": {
+          "name": "advisor_provider_keys_user_id_users_id_fk",
+          "tableFrom": "advisor_provider_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_summaries": {
+      "name": "advisor_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prose": {
+          "name": "prose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trade_data_figures": {
+          "name": "trade_data_figures",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered_through_message_id": {
+          "name": "covered_through_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered_through_created_at": {
+          "name": "covered_through_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_summaries_conversation_uniq": {
+          "name": "advisor_summaries_conversation_uniq",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_summaries_conversation_id_advisor_conversations_id_fk": {
+          "name": "advisor_summaries_conversation_id_advisor_conversations_id_fk",
+          "tableFrom": "advisor_summaries",
+          "tableTo": "advisor_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_api_keys": {
+      "name": "external_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hint_tail": {
+          "name": "key_hint_tail",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_api_keys_user_provider_uniq": {
+          "name": "external_api_keys_user_provider_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_api_keys_user_id_users_id_fk": {
+          "name": "external_api_keys_user_id_users_id_fk",
+          "tableFrom": "external_api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brokerages": {
+      "name": "brokerages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brokerages_user_id_idx": {
+          "name": "brokerages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brokerages_user_id_name_unique": {
+          "name": "brokerages_user_id_name_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"brokerages\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brokerages_system_name_unique": {
+          "name": "brokerages_system_name_unique",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"brokerages\".\"is_system\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brokerages_user_id_users_id_fk": {
+          "name": "brokerages_user_id_users_id_fk",
+          "tableFrom": "brokerages",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_schedules": {
+      "name": "fee_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "brokerage_id": {
+          "name": "brokerage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_per_share_commission": {
+          "name": "stock_per_share_commission",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "stock_min_per_fill": {
+          "name": "stock_min_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "stock_max_per_fill": {
+          "name": "stock_max_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_per_contract_commission": {
+          "name": "options_per_contract_commission",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_per_contract_exchange_fee": {
+          "name": "options_per_contract_exchange_fee",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_min_per_fill": {
+          "name": "options_min_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_max_per_fill": {
+          "name": "options_max_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_schedules_brokerage_id_brokerages_id_fk": {
+          "name": "fee_schedules_brokerage_id_brokerages_id_fk",
+          "tableFrom": "fee_schedules",
+          "tableTo": "brokerages",
+          "columnsFrom": ["brokerage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_schedules_brokerage_id_unique": {
+          "name": "fee_schedules_brokerage_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["brokerage_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.csv_import_counters": {
+      "name": "csv_import_counters",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "committed_count": {
+          "name": "committed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "csv_import_counters_user_id_users_id_fk": {
+          "name": "csv_import_counters_user_id_users_id_fk",
+          "tableFrom": "csv_import_counters",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.csv_import_staging": {
+      "name": "csv_import_staging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'staged'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committed_result": {
+          "name": "committed_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "csv_import_staging_one_active_per_user_idx": {
+          "name": "csv_import_staging_one_active_per_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"csv_import_staging\".\"status\" IN ('staged', 'committing')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "csv_import_staging_user_id_idx": {
+          "name": "csv_import_staging_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "csv_import_staging_expires_at_idx": {
+          "name": "csv_import_staging_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "csv_import_staging_user_id_users_id_fk": {
+          "name": "csv_import_staging_user_id_users_id_fk",
+          "tableFrom": "csv_import_staging",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "csv_import_staging_account_id_accounts_id_fk": {
+          "name": "csv_import_staging_account_id_accounts_id_fk",
+          "tableFrom": "csv_import_staging",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_layouts": {
+      "name": "dashboard_layouts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgets": {
+          "name": "widgets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_layouts_user_id_users_id_fk": {
+          "name": "dashboard_layouts_user_id_users_id_fk",
+          "tableFrom": "dashboard_layouts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_tokens": {
+      "name": "email_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_tokens_user_purpose_idx": {
+          "name": "email_tokens_user_purpose_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_tokens_one_live_per_user_purpose": {
+          "name": "email_tokens_one_live_per_user_purpose",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "consumed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_tokens_user_id_users_id_fk": {
+          "name": "email_tokens_user_id_users_id_fk",
+          "tableFrom": "email_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_tokens_token_hash_unique": {
+          "name": "email_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_tokens_purpose_chk": {
+          "name": "email_tokens_purpose_chk",
+          "value": "\"email_tokens\".\"purpose\" IN ('password_reset','email_verification')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.expenses": {
+      "name": "expenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "expenses_user_id_idx": {
+          "name": "expenses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "expenses_user_occurred_idx": {
+          "name": "expenses_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"occurred_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "expenses_user_id_users_id_fk": {
+          "name": "expenses_user_id_users_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "expenses_amount_positive_chk": {
+          "name": "expenses_amount_positive_chk",
+          "value": "\"expenses\".\"amount\" > 0"
+        },
+        "expenses_category_chk": {
+          "name": "expenses_category_chk",
+          "value": "category IN ('data_subscription', 'platform_fee', 'software', 'education', 'hardware', 'other')"
+        },
+        "expenses_currency_chk": {
+          "name": "expenses_currency_chk",
+          "value": "currency IN ('USD', 'EUR', 'GBP', 'CAD', 'AUD', 'JPY', 'CHF', 'HKD', 'SGD', 'NZD', 'SEK', 'NOK', 'DKK', 'MXN', 'BRL', 'INR', 'KRW', 'TWD', 'ZAR')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public._post_migrations_journal": {
+      "name": "_post_migrations_journal",
+      "schema": "",
+      "columns": {
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fills": {
+      "name": "fills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "position_id": {
+          "name": "position_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fees": {
+          "name": "fees",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filled_at": {
+          "name": "filled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fills_position_id_idx": {
+          "name": "fills_position_id_idx",
+          "columns": [
+            {
+              "expression": "position_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fills_position_id_positions_id_fk": {
+          "name": "fills_position_id_positions_id_fk",
+          "tableFrom": "fills",
+          "tableTo": "positions",
+          "columnsFrom": ["position_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.positions": {
+      "name": "positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_price": {
+          "name": "target_price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_loss": {
+          "name": "stop_loss",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_flat_at": {
+          "name": "last_flat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_flat_net_pnl": {
+          "name": "last_flat_net_pnl",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "positions_user_id_idx": {
+          "name": "positions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "positions_account_id_idx": {
+          "name": "positions_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "positions_user_id_status_updated_at_idx": {
+          "name": "positions_user_id_status_updated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "positions_user_status_closed_at_idx": {
+          "name": "positions_user_status_closed_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "positions_user_id_users_id_fk": {
+          "name": "positions_user_id_users_id_fk",
+          "tableFrom": "positions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "positions_account_id_accounts_id_fk": {
+          "name": "positions_account_id_accounts_id_fk",
+          "tableFrom": "positions",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "positions_closed_at_when_closed_chk": {
+          "name": "positions_closed_at_when_closed_chk",
+          "value": "\"positions\".\"status\" <> 'closed' OR \"positions\".\"closed_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.symbol_sync_state": {
+      "name": "symbol_sync_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "smallint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncing": {
+          "name": "syncing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "syncing_started_at": {
+          "name": "syncing_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "symbol_count": {
+          "name": "symbol_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "symbol_sync_state_singleton": {
+          "name": "symbol_sync_state_singleton",
+          "value": "\"symbol_sync_state\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.symbols": {
+      "name": "symbols",
+      "schema": "",
+      "columns": {
+        "ticker": {
+          "name": "ticker",
+          "type": "varchar(16)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exchange": {
+          "name": "exchange",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cik": {
+          "name": "cik",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "symbols_ticker_prefix_idx": {
+          "name": "symbols_ticker_prefix_idx",
+          "columns": [
+            {
+              "expression": "ticker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "varchar_pattern_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed": {
+          "name": "last_accessed",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_currency": {
+          "name": "display_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_jurisdiction": {
+          "name": "tax_jurisdiction",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "buying_power_basis": {
+          "name": "buying_power_basis",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cash'"
+        },
+        "advisor_default_persona_id": {
+          "name": "advisor_default_persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advisor_trade_data_consent": {
+          "name": "advisor_trade_data_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "writable_account_id": {
+          "name": "writable_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changelog_viewed_at": {
+          "name": "changelog_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding": {
+          "name": "onboarding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_tax_jurisdiction_chk": {
+          "name": "users_tax_jurisdiction_chk",
+          "value": "\"users\".\"tax_jurisdiction\" IS NULL OR \"users\".\"tax_jurisdiction\" IN ('US', 'CA', 'other')"
+        },
+        "users_theme_chk": {
+          "name": "users_theme_chk",
+          "value": "\"users\".\"theme\" IN ('light','dark','system')"
+        },
+        "users_buying_power_basis_chk": {
+          "name": "users_buying_power_basis_chk",
+          "value": "\"users\".\"buying_power_basis\" IN ('cash','balance')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_customers": {
+      "name": "billing_customers",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_customers_user_id_users_id_fk": {
+          "name": "billing_customers_user_id_users_id_fk",
+          "tableFrom": "billing_customers",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_customers_stripe_customer_id_unique": {
+          "name": "billing_customers_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_customer_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_unit_amount": {
+          "name": "price_unit_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_currency": {
+          "name": "price_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_created_at": {
+          "name": "stripe_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entered_past_due_at": {
+          "name": "entered_past_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_created": {
+          "name": "last_event_created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_subscription_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_cost": {
+          "name": "credit_cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_cost": {
+          "name": "raw_cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_records_user_created_idx": {
+          "name": "usage_records_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_records_created_idx": {
+          "name": "usage_records_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_user_id_users_id_fk": {
+          "name": "usage_records_user_id_users_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_records_conversation_id_advisor_conversations_id_fk": {
+          "name": "usage_records_conversation_id_advisor_conversations_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "advisor_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "usage_records_message_id_advisor_messages_id_fk": {
+          "name": "usage_records_message_id_advisor_messages_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "advisor_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_transactions": {
+      "name": "wallet_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_record_id": {
+          "name": "usage_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_transactions_user_created_idx": {
+          "name": "wallet_transactions_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transactions_payment_intent_idx": {
+          "name": "wallet_transactions_payment_intent_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_transactions_user_id_users_id_fk": {
+          "name": "wallet_transactions_user_id_users_id_fk",
+          "tableFrom": "wallet_transactions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_transactions_usage_record_id_usage_records_id_fk": {
+          "name": "wallet_transactions_usage_record_id_usage_records_id_fk",
+          "tableFrom": "wallet_transactions",
+          "tableTo": "usage_records",
+          "columnsFrom": ["usage_record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "wallet_transactions_kind_chk": {
+          "name": "wallet_transactions_kind_chk",
+          "value": "\"wallet_transactions\".\"kind\" IN ('credit', 'debit', 'reversal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "reserved": {
+          "name": "reserved",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallets_user_id_users_id_fk": {
+          "name": "wallets_user_id_users_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "wallets_reserved_nonneg_chk": {
+          "name": "wallets_reserved_nonneg_chk",
+          "value": "\"wallets\".\"reserved\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_events_stripe_event_id_unique": {
+          "name": "webhook_events_stripe_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_event_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webhook_events_status_chk": {
+          "name": "webhook_events_status_chk",
+          "value": "\"webhook_events\".\"status\" IN ('received', 'processed', 'ignored', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1785986843966,
       "tag": "0026_user_reporting_timezone",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1786041305065,
+      "tag": "0027_user_onboarding_preference",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema/users.schema.ts
+++ b/apps/api/src/db/schema/users.schema.ts
@@ -8,7 +8,10 @@ import {
   timestamp,
   index,
   check,
+  jsonb,
 } from 'drizzle-orm/pg-core';
+
+import type { StoredOnboardingState } from '@tradr/shared';
 
 export const users = pgTable(
   'users',
@@ -53,6 +56,24 @@ export const users = pgTable(
     // (the advisor_default_persona_id precedent above).
     writableAccountId: uuid('writable_account_id'),
     changelogViewedAt: timestamp('changelog_viewed_at', { withTimezone: true }),
+    // Onboarding PREFERENCE (user-onboarding R4.6): walkthrough status, the
+    // first-calculator-use timestamp, and the set of coach marks already seen.
+    // PREFERENCE ONLY — checklist item completion is DERIVED from the user's
+    // real data (account/position/closed-position counts) and is never stored
+    // here (R4.2). calculatorFirstUsedAt is the single named exception, and it
+    // is a timestamp recording a fact, not a per-item completion flag: the
+    // calculator writes nothing else, so item 2 has no other data trace.
+    // One jsonb column rather than three scalars because coachMarksSeen is a
+    // growing set that would otherwise need its own table for a UI preference
+    // — the dashboard_layouts.widgets precedent.
+    // NOT NULL DEFAULT '{}' so PostgreSQL's fast default makes every existing
+    // row valid with no backfill; '{}' parses to sensible defaults via
+    // OnboardingStateSchema. $type is the STORED shape (all keys optional),
+    // because '{}' is not a valid resolved OnboardingState — see onboarding.ts.
+    onboarding: jsonb('onboarding')
+      .notNull()
+      .$type<StoredOnboardingState>()
+      .default(sql`'{}'::jsonb`),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },

--- a/apps/api/src/features/auth/auth.query.ts
+++ b/apps/api/src/features/auth/auth.query.ts
@@ -1,4 +1,8 @@
 import { eq, lt, sql, count, asc, inArray } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
+
+import { MAX_COACH_MARKS_SEEN } from '@tradr/shared';
+import type { OnboardingPatch } from '@tradr/shared';
 
 import type { Database, Transaction } from '@/db';
 import { users, sessions } from '@/db/schema';
@@ -46,6 +50,81 @@ export function selectUserTimezone(db: DB, userId: string) {
 /** Persist the reporting timezone. Zone validity is the route's Zod duty. */
 export function updateUserTimezone(db: DB, userId: string, timezone: string) {
   return db.update(users).set({ timezone, updatedAt: new Date() }).where(eq(users.id, userId));
+}
+
+/**
+ * Raw read of the onboarding preference column. Returns the jsonb verbatim —
+ * `{}` for a row that predates the column or has never expressed a preference,
+ * `undefined` for no such user. Resolving that into a usable state is
+ * `getOnboardingState`'s job; every key here may be absent.
+ */
+export function selectUserOnboarding(db: DB, userId: string) {
+  return db
+    .select({ onboarding: users.onboarding })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1)
+    .then((rows) => rows[0]?.onboarding);
+}
+
+/**
+ * Merge a partial onboarding preference into the column IN SQL, as one
+ * statement. This is the whole point of the function and it is not the obvious
+ * shape, so: the alternative — SELECT, parse, spread, UPDATE the whole object —
+ * loses data twice over.
+ *
+ * 1. UNKNOWN KEYS. `OnboardingStateSchema` STRIPS keys it does not know
+ *    (deliberately, so an older deployment can read a newer one's rows). Round
+ *    -tripping the parsed object back into the column therefore DELETES any key
+ *    a newer deployment wrote — during a rolling deploy, the old container
+ *    silently destroys the new one's onboarding data. Rewriting only the named
+ *    keys with `||` and `jsonb_set` leaves everything else exactly as found.
+ * 2. CONCURRENT PATCHES. Two tabs appending different coach marks in a
+ *    read-modify-write both read the same array and the second write drops the
+ *    first's key. As one statement, PostgreSQL's row lock serialises them and
+ *    the second re-evaluates this expression against the first's committed
+ *    value, so both keys survive.
+ *
+ * Coach-mark append is idempotent by containment test, and capped: nothing ever
+ * removes a key, so an uncapped append is unbounded growth of one row's jsonb.
+ * Past the cap the append is a no-op rather than an error — a coach mark is a
+ * UI nicety and the cap is an order of magnitude above the surfaces R7.1 names.
+ */
+export function updateUserOnboarding(db: DB, userId: string, patch: OnboardingPatch) {
+  // Built from the column outwards. Each clause names only the keys it changes.
+  let merged: SQL = sql`${users.onboarding}`;
+
+  if (patch.coachMarkSeen !== undefined) {
+    const key = sql`to_jsonb(${patch.coachMarkSeen}::text)`;
+    const seen = sql`coalesce(${users.onboarding} -> 'coachMarksSeen', '[]'::jsonb)`;
+    merged = sql`
+      CASE
+        WHEN ${seen} @> ${key} OR jsonb_array_length(${seen}) >= ${MAX_COACH_MARKS_SEEN}
+        THEN ${merged}
+        ELSE jsonb_set(${merged}, '{coachMarksSeen}', ${seen} || ${key}, true)
+      END`;
+  }
+
+  // status and calculatorFirstUsedAt are plain scalars, so one `||` sets both.
+  // It runs after the coach-mark clause only because that clause reads the
+  // column directly; the two touch disjoint keys, so the order is immaterial.
+  const scalars: Record<string, string> = {};
+  if (patch.status !== undefined) scalars.status = patch.status;
+  if (patch.calculatorFirstUsedAt !== undefined) {
+    scalars.calculatorFirstUsedAt = patch.calculatorFirstUsedAt;
+  }
+  if (Object.keys(scalars).length > 0) {
+    merged = sql`${merged} || ${JSON.stringify(scalars)}::jsonb`;
+  }
+
+  // RETURNING gives the post-merge value without a second read — and without
+  // the read-your-own-write race a follow-up SELECT would reintroduce.
+  return db
+    .update(users)
+    .set({ onboarding: merged, updatedAt: new Date() })
+    .where(eq(users.id, userId))
+    .returning({ onboarding: users.onboarding })
+    .then((rows) => rows[0]?.onboarding);
 }
 
 export function selectUserByEmail(db: DB, email: string) {

--- a/apps/api/src/features/auth/auth.route.ts
+++ b/apps/api/src/features/auth/auth.route.ts
@@ -4,7 +4,7 @@ import { eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { setCookie, getCookie } from 'hono/cookie';
 
-import { UserTimezoneSchema } from '@tradr/shared';
+import { OnboardingPatchSchema, UserTimezoneSchema } from '@tradr/shared';
 import { RegisterSchema, LoginSchema } from '@tradr/shared/schemas/auth';
 
 import { db } from '@/db';
@@ -20,6 +20,8 @@ import {
   logoutUser,
   getReportingTimezone,
   setReportingTimezone,
+  getOnboardingState,
+  patchOnboardingState,
 } from './auth.service';
 
 type AuthEnv = {
@@ -356,5 +358,110 @@ userPreferencesRouter.put('/users/me/timezone', validate('json', UserTimezoneSch
   // construction here: the write just put this value on the row.
   return c.json({ timezone, stored: true }, 200);
 });
+
+// ---------------------------------------------------------------------------
+// Onboarding preference
+//
+// The second preference on this router (see the block above for why the router
+// exists). PATCH rather than PUT because the semantics are partial-merge: a
+// client sets a status, appends one coach mark, or records the first calculator
+// use, without knowing or resending the rest of the state. A PUT would make
+// every caller responsible for round-tripping keys it may not understand.
+// ---------------------------------------------------------------------------
+
+/**
+ * @swagger
+ * /api/users/me/onboarding:
+ *   get:
+ *     summary: Get the onboarding preference.
+ *     description: >
+ *       Authed. Whether the user has started, skipped or finished the guided
+ *       walkthrough, when they first used the calculator, and which contextual
+ *       coach marks they have already dismissed. Preference only — this does not
+ *       report checklist progress, which is derived from the user's accounts and
+ *       positions and so cannot disagree with their real data. Never null: a
+ *       user who has expressed no preference reads as `pending` with an empty
+ *       coach-mark list.
+ *     tags: [Auth]
+ *     responses:
+ *       200:
+ *         description: The resolved onboarding preference.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   enum: [pending, active, skipped, done]
+ *                   description: >
+ *                     `pending` not started, `active` running, `skipped`
+ *                     dismissed (recoverable — set it back to start again),
+ *                     `done` completed.
+ *                   example: pending
+ *                 calculatorFirstUsedAt:
+ *                   type: string
+ *                   format: date-time
+ *                   description: Absent until the calculator has been used.
+ *                 coachMarksSeen:
+ *                   type: array
+ *                   items: { type: string }
+ *                   description: Surface keys already dismissed, as a set.
+ *                   example: []
+ *       401: { description: Authentication required. }
+ */
+userPreferencesRouter.get('/users/me/onboarding', async (c) => {
+  const userId = c.get('userId');
+  return c.json(await getOnboardingState(userId), 200);
+});
+
+/**
+ * @swagger
+ * /api/users/me/onboarding:
+ *   patch:
+ *     summary: Update part of the onboarding preference.
+ *     description: >
+ *       Authed. Partial: send only what changes. The server merges the named
+ *       fields into the stored preference, so omitting a field leaves it as it
+ *       was — a body carrying only `status` does not clear the coach marks.
+ *       `coachMarkSeen` appends one key to the seen set and is idempotent;
+ *       sending the same key again is not an error and does not duplicate it.
+ *       At least one field is required.
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             minProperties: 1
+ *             additionalProperties: false
+ *             properties:
+ *               status: { type: string, enum: [pending, active, skipped, done] }
+ *               calculatorFirstUsedAt:
+ *                 type: string
+ *                 format: date-time
+ *                 description: When the calculator was first used.
+ *               coachMarkSeen:
+ *                 type: string
+ *                 maxLength: 64
+ *                 description: >
+ *                   One surface key to add to the seen set — singular, because
+ *                   the whole set is never sent. Ignored once the set holds 64
+ *                   keys.
+ *                 example: partial-close
+ *     responses:
+ *       200: { description: The merged onboarding preference, in the same shape as the GET. }
+ *       400: { description: Unknown field, empty body, or an invalid status or timestamp. }
+ *       401: { description: Authentication required. }
+ */
+userPreferencesRouter.patch(
+  '/users/me/onboarding',
+  validate('json', OnboardingPatchSchema),
+  async (c) => {
+    const userId = c.get('userId');
+    return c.json(await patchOnboardingState(userId, c.req.valid('json')), 200);
+  },
+);
 
 export default auth;

--- a/apps/api/src/features/auth/auth.service.ts
+++ b/apps/api/src/features/auth/auth.service.ts
@@ -2,7 +2,8 @@ import crypto from 'node:crypto';
 
 import bcrypt from 'bcrypt';
 
-import { DEFAULT_REPORTING_TIMEZONE } from '@tradr/shared';
+import { DEFAULT_REPORTING_TIMEZONE, OnboardingStateSchema } from '@tradr/shared';
+import type { OnboardingPatch, OnboardingState } from '@tradr/shared';
 
 import { db } from '@/db';
 import { isEmailConfigured } from '@/lib/config';
@@ -21,6 +22,8 @@ import {
   deleteOldestSession,
   selectUserTimezone,
   updateUserTimezone,
+  selectUserOnboarding,
+  updateUserOnboarding,
 } from './auth.query';
 import { issueEmailToken, VERIFY_TOKEN_TTL_MS } from './email-tokens.service';
 
@@ -176,4 +179,38 @@ export async function getReportingTimezone(
 /** Persist the reporting timezone. Zone validity is the route's Zod duty. */
 export async function setReportingTimezone(userId: string, timezone: string): Promise<void> {
   await updateUserTimezone(db, userId, timezone);
+}
+
+/**
+ * The user's onboarding PREFERENCE (user-onboarding R4.6) — walkthrough status,
+ * the first-calculator-use timestamp and the coach marks already seen. Never
+ * checklist item completion: that is derived from the user's real data (R4.2).
+ *
+ * The raw column is `{}` for anyone who has never expressed a preference,
+ * including every row that predates it, so the resolution is
+ * `OnboardingStateSchema`'s defaulting and nothing else. No `?? 'pending'`
+ * fallbacks here — a second copy of the defaults would drift from the schema's.
+ * `?? {}` covers only the missing-row case of a deleted user racing a request
+ * (the `getReportingTimezone` precedent).
+ *
+ * Side-effect-free, and must stay so: the SameSite=Lax cookie posture makes any
+ * side-effecting GET a CSRF vector.
+ */
+export async function getOnboardingState(userId: string): Promise<OnboardingState> {
+  const stored = await selectUserOnboarding(db, userId);
+  return OnboardingStateSchema.parse(stored ?? {});
+}
+
+/**
+ * Apply a partial onboarding preference and return the resulting state. The
+ * merge itself happens in SQL — see `updateUserOnboarding` for why a
+ * read-modify-write here would destroy keys written by a newer deployment and
+ * lose concurrent appends.
+ */
+export async function patchOnboardingState(
+  userId: string,
+  patch: OnboardingPatch,
+): Promise<OnboardingState> {
+  const updated = await updateUserOnboarding(db, userId, patch);
+  return OnboardingStateSchema.parse(updated ?? {});
 }

--- a/apps/api/src/features/auth/user-onboarding.test.ts
+++ b/apps/api/src/features/auth/user-onboarding.test.ts
@@ -1,0 +1,393 @@
+import { eq } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+
+import { MAX_COACH_MARKS_SEEN } from '@tradr/shared';
+import type { StoredOnboardingState } from '@tradr/shared';
+
+import app from '@/app';
+import { db } from '@/db';
+import { users } from '@/db/schema';
+
+// A sibling of auth.test.ts and user-timezone.test.ts: onboarding is its own
+// preference surface, and auth.test.ts's closing test pins the frozen auth
+// response shapes byte-for-byte and is better left focused.
+
+let testCounter = 0;
+const testRunId = Date.now();
+function uniqueEmail() {
+  return `onb-test${testRunId}-${++testCounter}@example.com`;
+}
+
+// Own /8 sub-range (auth.test.ts owns 10.0, password-reset 10.20, verification
+// 10.30, timezone 10.31) so the register limiter never sees a shared client.
+let ipCounter = 0;
+function uniqueIp() {
+  return `10.32.${Math.floor(ipCounter / 250)}.${(ipCounter++ % 250) + 1}`;
+}
+
+function getCookieValue(res: Response, name: string): string | undefined {
+  for (const header of res.headers.getSetCookie()) {
+    const match = header.match(new RegExp(`${name}=([^;]*)`));
+    if (match) return match[1];
+  }
+  return undefined;
+}
+
+async function registerAndGetCookie(): Promise<{ cookie: string; email: string }> {
+  const email = uniqueEmail();
+  const res = await app.request('/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-Forwarded-For': uniqueIp() },
+    body: JSON.stringify({ email, password: 'password123' }),
+  });
+  expect(res.status).toBe(201);
+  const cookie = getCookieValue(res, 'session');
+  expect(cookie).toBeDefined();
+  return { cookie: cookie!, email };
+}
+
+function authedRequest(method: string, path: string, cookie: string, body?: unknown) {
+  const headers: Record<string, string> = {
+    Cookie: `session=${cookie}`,
+    'X-Forwarded-For': uniqueIp(),
+  };
+  if (body !== undefined) headers['Content-Type'] = 'application/json';
+  return app.request(path, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+/** The column verbatim, unparsed — the only way to see keys the schema strips. */
+function storedOnboarding(email: string) {
+  return db
+    .select({ onboarding: users.onboarding })
+    .from(users)
+    .where(eq(users.email, email))
+    .then((rows) => rows[0]?.onboarding as Record<string, unknown> | undefined);
+}
+
+function setStoredOnboarding(email: string, value: Record<string, unknown>) {
+  return db
+    .update(users)
+    .set({ onboarding: value as StoredOnboardingState })
+    .where(eq(users.email, email));
+}
+
+async function getOnboarding(cookie: string) {
+  const res = await authedRequest('GET', '/api/users/me/onboarding', cookie);
+  expect(res.status).toBe(200);
+  return (await res.json()) as {
+    status: string;
+    coachMarksSeen: string[];
+    calculatorFirstUsedAt?: string;
+  };
+}
+
+async function patchOnboarding(cookie: string, body: unknown) {
+  return authedRequest('PATCH', '/api/users/me/onboarding', cookie, body);
+}
+
+describe('GET /api/users/me/onboarding', () => {
+  it('resolves an empty column to the schema defaults', async () => {
+    // The column's DEFAULT is '{}', so this is what every registered user and
+    // every pre-migration row reads as. The defaults come from the shared
+    // schema, not from fallbacks in the handler.
+    const { cookie, email } = await registerAndGetCookie();
+    expect(await storedOnboarding(email)).toEqual({});
+
+    expect(await getOnboarding(cookie)).toEqual({ status: 'pending', coachMarksSeen: [] });
+  });
+
+  it('omits calculatorFirstUsedAt until it is recorded', async () => {
+    // Absent is meaningful — the calculator has not been used — so it must not
+    // be defaulted to a timestamp or nulled.
+    const { cookie } = await registerAndGetCookie();
+    expect('calculatorFirstUsedAt' in (await getOnboarding(cookie))).toBe(false);
+  });
+
+  it('is side-effect-free', async () => {
+    // The SameSite=Lax cookie posture makes any side-effecting GET a CSRF
+    // vector, so the read must not "helpfully" materialise the defaults it
+    // resolves. Asserted on the raw column, which stays '{}'.
+    const { cookie, email } = await registerAndGetCookie();
+    await getOnboarding(cookie);
+    expect(await storedOnboarding(email)).toEqual({});
+  });
+});
+
+describe('PATCH /api/users/me/onboarding merges rather than replaces', () => {
+  it('sets a status without clearing the coach marks', async () => {
+    const { cookie } = await registerAndGetCookie();
+
+    await patchOnboarding(cookie, { coachMarkSeen: 'csv-import' });
+    const res = await patchOnboarding(cookie, { status: 'skipped' });
+    expect(res.status).toBe(200);
+
+    // The body naming only `status` must leave coachMarksSeen exactly as found.
+    expect(await res.json()).toEqual({ status: 'skipped', coachMarksSeen: ['csv-import'] });
+    expect(await getOnboarding(cookie)).toEqual({
+      status: 'skipped',
+      coachMarksSeen: ['csv-import'],
+    });
+  });
+
+  it('appends a coach mark without disturbing the status', async () => {
+    const { cookie } = await registerAndGetCookie();
+
+    await patchOnboarding(cookie, { status: 'active' });
+    const res = await patchOnboarding(cookie, { coachMarkSeen: 'scale-in' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: 'active', coachMarksSeen: ['scale-in'] });
+  });
+
+  it('appends the same coach mark twice without duplicating it', async () => {
+    const { cookie } = await registerAndGetCookie();
+
+    await patchOnboarding(cookie, { coachMarkSeen: 'widget-management' });
+    const second = await patchOnboarding(cookie, { coachMarkSeen: 'widget-management' });
+    // Idempotent, not an error: a re-mounted component re-dismissing a mark is
+    // ordinary, and the client should not have to check first.
+    expect(second.status).toBe(200);
+    expect(await second.json()).toEqual({
+      status: 'pending',
+      coachMarksSeen: ['widget-management'],
+    });
+  });
+
+  it('accumulates distinct coach marks', async () => {
+    const { cookie } = await registerAndGetCookie();
+
+    for (const key of ['partial-close', 'scale-in', 'csv-import']) {
+      expect((await patchOnboarding(cookie, { coachMarkSeen: key })).status).toBe(200);
+    }
+    expect((await getOnboarding(cookie)).coachMarksSeen).toEqual([
+      'partial-close',
+      'scale-in',
+      'csv-import',
+    ]);
+  });
+
+  it('records calculatorFirstUsedAt without disturbing the other fields', async () => {
+    const { cookie } = await registerAndGetCookie();
+    await patchOnboarding(cookie, { status: 'active' });
+    await patchOnboarding(cookie, { coachMarkSeen: 'options-tools' });
+
+    const at = '2026-08-06T12:00:00.000Z';
+    const res = await patchOnboarding(cookie, { calculatorFirstUsedAt: at });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      status: 'active',
+      coachMarksSeen: ['options-tools'],
+      calculatorFirstUsedAt: at,
+    });
+  });
+
+  it('applies status, timestamp and coach mark in one body', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const at = '2026-08-06T09:30:00.000Z';
+
+    const res = await patchOnboarding(cookie, {
+      status: 'done',
+      calculatorFirstUsedAt: at,
+      coachMarkSeen: 'partial-close',
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      status: 'done',
+      calculatorFirstUsedAt: at,
+      coachMarksSeen: ['partial-close'],
+    });
+  });
+
+  it('makes a skipped checklist recoverable', async () => {
+    // R4.5: dismissal must be re-openable without support intervention, which
+    // is just another PATCH.
+    const { cookie } = await registerAndGetCookie();
+    await patchOnboarding(cookie, { status: 'skipped' });
+    expect((await getOnboarding(cookie)).status).toBe('skipped');
+
+    await patchOnboarding(cookie, { status: 'active' });
+    expect((await getOnboarding(cookie)).status).toBe('active');
+  });
+});
+
+describe('PATCH preserves state this deployment does not know about', () => {
+  it('leaves a key written by a newer deployment intact', async () => {
+    // THE ROLLING-DEPLOY HAZARD. OnboardingStateSchema STRIPS unknown keys on
+    // read, so a handler that read, parsed, merged and wrote the whole object
+    // back would silently delete whatever a newer container had written. The
+    // merge happens in SQL and names only the keys in the body, so it cannot.
+    const { cookie, email } = await registerAndGetCookie();
+    await setStoredOnboarding(email, {
+      status: 'active',
+      coachMarksSeen: ['csv-import'],
+      tourVariant: 'v2-from-a-newer-deployment',
+    });
+
+    expect((await patchOnboarding(cookie, { status: 'done' })).status).toBe(200);
+
+    const raw = await storedOnboarding(email);
+    expect(raw?.tourVariant).toBe('v2-from-a-newer-deployment');
+    expect(raw?.status).toBe('done');
+    expect(raw?.coachMarksSeen).toEqual(['csv-import']);
+
+    // The response is still this deployment's known shape — the unknown key is
+    // preserved in storage, not leaked onto the wire.
+    expect(await getOnboarding(cookie)).toEqual({ status: 'done', coachMarksSeen: ['csv-import'] });
+  });
+
+  it('leaves an unknown key intact while appending a coach mark', async () => {
+    const { cookie, email } = await registerAndGetCookie();
+    await setStoredOnboarding(email, { coachMarksSeen: ['a'], futureKey: { nested: true } });
+
+    expect((await patchOnboarding(cookie, { coachMarkSeen: 'b' })).status).toBe(200);
+
+    const raw = await storedOnboarding(email);
+    expect(raw?.futureKey).toEqual({ nested: true });
+    expect(raw?.coachMarksSeen).toEqual(['a', 'b']);
+  });
+});
+
+describe('PATCH is safe under interleaved writes', () => {
+  it('keeps both coach marks when two tabs append at once', async () => {
+    // The lost-update case a read-modify-write cannot survive: both requests
+    // read the same array and the second write drops the first's key. The merge
+    // is one UPDATE, so PostgreSQL's row lock serialises them and the second
+    // re-evaluates against the first's committed value.
+    const { cookie } = await registerAndGetCookie();
+
+    const [first, second] = await Promise.all([
+      patchOnboarding(cookie, { coachMarkSeen: 'tab-one' }),
+      patchOnboarding(cookie, { coachMarkSeen: 'tab-two' }),
+    ]);
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+
+    expect((await getOnboarding(cookie)).coachMarksSeen.sort()).toEqual(['tab-one', 'tab-two']);
+  });
+
+  it('keeps a concurrent status change and coach-mark append together', async () => {
+    // Different keys, so neither request has to know about the other's field.
+    const { cookie } = await registerAndGetCookie();
+
+    await Promise.all([
+      patchOnboarding(cookie, { status: 'done' }),
+      patchOnboarding(cookie, { coachMarkSeen: 'scale-in' }),
+    ]);
+
+    expect(await getOnboarding(cookie)).toEqual({
+      status: 'done',
+      coachMarksSeen: ['scale-in'],
+    });
+  });
+
+  it('caps the coach-mark set rather than growing it without limit', async () => {
+    // Nothing ever removes a key, so an uncapped append is unbounded growth of
+    // one row's jsonb by an authenticated client. Past the cap the append is a
+    // no-op — a coach mark is a UI nicety, and the cap is an order of magnitude
+    // above the five surfaces R7.1 names.
+    const { cookie, email } = await registerAndGetCookie();
+    const full = Array.from({ length: MAX_COACH_MARKS_SEEN }, (_, i) => `mark-${i}`);
+    await setStoredOnboarding(email, { coachMarksSeen: full });
+
+    const res = await patchOnboarding(cookie, { coachMarkSeen: 'one-too-many' });
+    expect(res.status).toBe(200);
+    expect((await res.json()).coachMarksSeen).toEqual(full);
+
+    // The rest of the body still applies — the cap silences the append only.
+    const withStatus = await patchOnboarding(cookie, {
+      status: 'done',
+      coachMarkSeen: 'one-too-many',
+    });
+    expect((await withStatus.json()).status).toBe('done');
+  });
+});
+
+describe('PATCH validation', () => {
+  it('rejects an invalid status with 400 and changes nothing', async () => {
+    const { cookie } = await registerAndGetCookie();
+    await patchOnboarding(cookie, { status: 'active' });
+
+    const res = await patchOnboarding(cookie, { status: 'finished' });
+    expect(res.status).toBe(400);
+    expect((await getOnboarding(cookie)).status).toBe('active');
+  });
+
+  it('rejects an unknown field', async () => {
+    // Strict on the wire, unlike the state schema, whose author may be a newer
+    // deployment. Here the author is a client and an unexpected key is a bug.
+    const { cookie } = await registerAndGetCookie();
+    const res = await patchOnboarding(cookie, { accountCreated: true });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an empty body', async () => {
+    const { cookie } = await registerAndGetCookie();
+    expect((await patchOnboarding(cookie, {})).status).toBe(400);
+  });
+
+  it('rejects a non-ISO calculatorFirstUsedAt and an over-length coach mark', async () => {
+    const { cookie } = await registerAndGetCookie();
+
+    const badDate = await patchOnboarding(cookie, { calculatorFirstUsedAt: '2026-08-06' });
+    expect(badDate.status).toBe(400);
+
+    const longKey = await patchOnboarding(cookie, { coachMarkSeen: 'x'.repeat(65) });
+    expect(longKey.status).toBe(400);
+
+    const emptyKey = await patchOnboarding(cookie, { coachMarkSeen: '' });
+    expect(emptyKey.status).toBe(400);
+  });
+
+  it('rejects a coachMarksSeen array — the whole set is never sent', async () => {
+    // The plural field is deliberately not accepted: a client that could send
+    // the array could shrink the set by omission and clobber another tab's mark.
+    const { cookie } = await registerAndGetCookie();
+    const res = await patchOnboarding(cookie, { coachMarksSeen: ['a', 'b'] });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('onboarding preference is scoped to the calling user', () => {
+  it('requires authentication on both verbs', async () => {
+    const get = await app.request('/api/users/me/onboarding', {
+      headers: { 'X-Forwarded-For': uniqueIp() },
+    });
+    expect(get.status).toBe(401);
+
+    const patch = await app.request('/api/users/me/onboarding', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', 'X-Forwarded-For': uniqueIp() },
+      body: JSON.stringify({ status: 'done' }),
+    });
+    expect(patch.status).toBe(401);
+  });
+
+  it('ignores a userId in the body and never reads another user', async () => {
+    const a = await registerAndGetCookie();
+    const b = await registerAndGetCookie();
+    await patchOnboarding(b.cookie, { status: 'active', coachMarkSeen: 'b-only' });
+
+    const bRow = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.email, b.email))
+      .then((rows) => rows[0]);
+
+    // A names B and asks for B's preference to change. The subject comes from
+    // the session only, so the extra key is a 400 and nothing is written at all.
+    const res = await patchOnboarding(a.cookie, { userId: bRow.id, status: 'done' });
+    expect(res.status).toBe(400);
+    expect(await storedOnboarding(a.email)).toEqual({});
+
+    // A's own write lands on A's row and leaves B's alone.
+    expect((await patchOnboarding(a.cookie, { status: 'done' })).status).toBe(200);
+    expect(await getOnboarding(a.cookie)).toEqual({ status: 'done', coachMarksSeen: [] });
+    expect(await getOnboarding(b.cookie)).toEqual({
+      status: 'active',
+      coachMarksSeen: ['b-only'],
+    });
+  });
+});

--- a/apps/docs/src/content/docs/self-hosting/reference/db-schema.mdx
+++ b/apps/docs/src/content/docs/self-hosting/reference/db-schema.mdx
@@ -6,9 +6,9 @@ description: Every table Tradr creates, its columns, and how they reference each
 {/* GENERATED FILE — do not edit.
     Source: apps/api/src/db/migrations/meta/ (latest snapshot) · Generator: apps/docs/scripts/gen-db-schema.mjs */}
 
-Tradr's schema is **32 tables**, created by **27 migrations** that run
+Tradr's schema is **32 tables**, created by **28 migrations** that run
 automatically when the api boots. This page is generated from the Drizzle snapshot
-for the latest migration (`0026_user_reporting_timezone`), so it describes the schema the migrations
+for the latest migration (`0027_user_onboarding_preference`), so it describes the schema the migrations
 actually produce.
 
 You do not need any of this to run Tradr. It is here for writing queries against
@@ -40,6 +40,7 @@ a query you write against these tables may need updating on any release.
 | `advisor_trade_data_consent` | `boolean` | not null, default `false` |
 | `writable_account_id` | `uuid` | — |
 | `changelog_viewed_at` | `timestamp with time zone` | — |
+| `onboarding` | `jsonb` | not null, default `'{}'::jsonb` |
 | `created_at` | `timestamp with time zone` | not null, default `now()` |
 | `updated_at` | `timestamp with time zone` | not null, default `now()` |
 

--- a/apps/docs/src/openapi/tradr-api.json
+++ b/apps/docs/src/openapi/tradr-api.json
@@ -4303,6 +4303,111 @@
         ]
       }
     },
+    "/api/users/me/onboarding": {
+      "get": {
+        "description": "Authed. Whether the user has started, skipped or finished the guided walkthrough, when they first used the calculator, and which contextual coach marks they have already dismissed. Preference only — this does not report checklist progress, which is derived from the user's accounts and positions and so cannot disagree with their real data. Never null: a user who has expressed no preference reads as `pending` with an empty coach-mark list.\n",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "calculatorFirstUsedAt": {
+                      "description": "Absent until the calculator has been used.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "coachMarksSeen": {
+                      "description": "Surface keys already dismissed, as a set.",
+                      "example": [],
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "status": {
+                      "description": "`pending` not started, `active` running, `skipped` dismissed (recoverable — set it back to start again), `done` completed.\n",
+                      "enum": [
+                        "pending",
+                        "active",
+                        "skipped",
+                        "done"
+                      ],
+                      "example": "pending",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The resolved onboarding preference."
+          },
+          "401": {
+            "description": "Authentication required."
+          }
+        },
+        "summary": "Get the onboarding preference.",
+        "tags": [
+          "Auth"
+        ]
+      },
+      "patch": {
+        "description": "Authed. Partial: send only what changes. The server merges the named fields into the stored preference, so omitting a field leaves it as it was — a body carrying only `status` does not clear the coach marks. `coachMarkSeen` appends one key to the seen set and is idempotent; sending the same key again is not an error and does not duplicate it. At least one field is required.\n",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "minProperties": 1,
+                "properties": {
+                  "calculatorFirstUsedAt": {
+                    "description": "When the calculator was first used.",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "coachMarkSeen": {
+                    "description": "One surface key to add to the seen set — singular, because the whole set is never sent. Ignored once the set holds 64 keys.\n",
+                    "example": "partial-close",
+                    "maxLength": 64,
+                    "type": "string"
+                  },
+                  "status": {
+                    "enum": [
+                      "pending",
+                      "active",
+                      "skipped",
+                      "done"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The merged onboarding preference",
+            "in the same shape as the GET.": null
+          },
+          "400": {
+            "description": "Unknown field",
+            "empty body": null,
+            "or an invalid status or timestamp.": null
+          },
+          "401": {
+            "description": "Authentication required."
+          }
+        },
+        "summary": "Update part of the onboarding preference.",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
     "/api/users/me/tax-jurisdiction": {
       "get": {
         "description": "Authed. Selects which loss rules the tax summary applies. `null` means the user has not chosen one.\n",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -262,6 +262,19 @@ export type {
 } from './schemas/changelog';
 export { ReportingTimezoneField, UserTimezoneSchema } from './schemas/user';
 export type { UserTimezoneInput } from './schemas/user';
+export {
+  OnboardingStatusSchema,
+  OnboardingStateSchema,
+  OnboardingPatchSchema,
+  COACH_MARK_KEY_MAX_LENGTH,
+  MAX_COACH_MARKS_SEEN,
+} from './schemas/onboarding';
+export type {
+  OnboardingStatus,
+  OnboardingState,
+  StoredOnboardingState,
+  OnboardingPatch,
+} from './schemas/onboarding';
 export type { CanonicalPart, CanonicalMessage, ProviderModel } from './lib/advisor/types';
 export { uuidv5, uuidv5Batch, WIDGET_DEFAULT_NAMESPACE } from './utils/uuidv5';
 export { DEFAULT_WIDGETS, BODY_LIMIT_BYTES } from './constants/dashboard-defaults';

--- a/packages/shared/src/schemas/onboarding.test.ts
+++ b/packages/shared/src/schemas/onboarding.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  COACH_MARK_KEY_MAX_LENGTH,
+  OnboardingPatchSchema,
+  OnboardingStateSchema,
+  OnboardingStatusSchema,
+} from './onboarding';
+
+describe('OnboardingStateSchema', () => {
+  // The load-bearing case: users.onboarding is NOT NULL DEFAULT '{}', so every
+  // row that predates the column reads back as {} with no backfill. If this
+  // ever stops parsing, existing users break on login.
+  it('parses {} to sensible defaults', () => {
+    const result = OnboardingStateSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ status: 'pending', coachMarksSeen: [] });
+      expect(result.data.calculatorFirstUsedAt).toBeUndefined();
+    }
+  });
+
+  it.each(OnboardingStatusSchema.options)('round-trips status %s', (status) => {
+    const result = OnboardingStateSchema.safeParse({ status });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.status).toBe(status);
+  });
+
+  it.each(['complete', 'dismissed', 'PENDING', '', null, 0])(
+    'rejects the invalid status %j',
+    (status) => {
+      const result = OnboardingStateSchema.safeParse({ status });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.some((i) => i.path[0] === 'status')).toBe(true);
+      }
+    },
+  );
+
+  it('defaults coachMarksSeen to an empty array', () => {
+    const result = OnboardingStateSchema.safeParse({ status: 'done' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.coachMarksSeen).toEqual([]);
+  });
+
+  it('accepts surface keys in coachMarksSeen', () => {
+    const seen = ['partial-close', 'scale-in', 'csv-import', 'options-tools', 'dashboard-widgets'];
+    const result = OnboardingStateSchema.safeParse({ coachMarksSeen: seen });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.coachMarksSeen).toEqual(seen);
+  });
+
+  it.each([['not-an-array'], [[1, 2]], [[null]]])(
+    'rejects a non-string-array coachMarksSeen %j',
+    (coachMarksSeen) => {
+      expect(OnboardingStateSchema.safeParse({ coachMarksSeen }).success).toBe(false);
+    },
+  );
+
+  // The single named R4.2 exception, and a timestamp rather than a flag.
+  it.each(['2026-08-06T04:12:00.000Z', '2026-01-01T00:00:00Z'])(
+    'accepts the ISO timestamp %s for calculatorFirstUsedAt',
+    (calculatorFirstUsedAt) => {
+      const result = OnboardingStateSchema.safeParse({ calculatorFirstUsedAt });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.calculatorFirstUsedAt).toBe(calculatorFirstUsedAt);
+    },
+  );
+
+  it.each(['yesterday', '2026-08-06', '', true, 1785986843966])(
+    'rejects junk %j for calculatorFirstUsedAt',
+    (calculatorFirstUsedAt) => {
+      const result = OnboardingStateSchema.safeParse({ calculatorFirstUsedAt });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.some((i) => i.path[0] === 'calculatorFirstUsedAt')).toBe(true);
+      }
+    },
+  );
+
+  it('omits calculatorFirstUsedAt entirely when absent rather than nulling it', () => {
+    const result = OnboardingStateSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) expect('calculatorFirstUsedAt' in result.data).toBe(false);
+  });
+
+  // Deliberately NOT .strict(): this schema parses rows read back out of the
+  // database, so a key written by a newer deployment must not make an older one
+  // throw on its own users table. Stripping is Zod's default and matches the
+  // majority of this package's schemas; .strict() is reserved for wire bodies
+  // (expense.ts, accounting.ts, dashboard.ts) where a client is the author.
+  it('strips unknown keys rather than rejecting them', () => {
+    const result = OnboardingStateSchema.safeParse({
+      status: 'active',
+      futureVersionKey: 'written by a newer deployment',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ status: 'active', coachMarksSeen: [] });
+      expect('futureVersionKey' in result.data).toBe(false);
+    }
+  });
+
+  // R4.2 / design.md: per-item completion is derived from real data, never
+  // stored. A stray flag must not survive into the parsed state.
+  it('strips a per-item completion flag if one is ever written', () => {
+    const result = OnboardingStateSchema.safeParse({ accountCreated: true, positionLogged: true });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ status: 'pending', coachMarksSeen: [] });
+    }
+  });
+
+  it('rejects a non-object', () => {
+    expect(OnboardingStateSchema.safeParse(null).success).toBe(false);
+    expect(OnboardingStateSchema.safeParse('{}').success).toBe(false);
+  });
+});
+
+describe('OnboardingPatchSchema', () => {
+  it('accepts each field on its own', () => {
+    expect(OnboardingPatchSchema.safeParse({ status: 'skipped' }).success).toBe(true);
+    expect(
+      OnboardingPatchSchema.safeParse({ calculatorFirstUsedAt: '2026-08-06T12:00:00.000Z' })
+        .success,
+    ).toBe(true);
+    expect(OnboardingPatchSchema.safeParse({ coachMarkSeen: 'csv-import' }).success).toBe(true);
+  });
+
+  // The mirror image of the state schema above, and deliberately so: this
+  // body's author is a client, where an unexpected key is a mistake worth
+  // saying out loud rather than dropping.
+  it('rejects an unknown key instead of stripping it', () => {
+    expect(OnboardingPatchSchema.safeParse({ status: 'done', tourVariant: 'v2' }).success).toBe(
+      false,
+    );
+  });
+
+  // The stored field is plural and is never sent whole: a client that could
+  // send the array could shrink the set by omission and clobber another tab's
+  // mark. Only the singular append operation is on the wire.
+  it('rejects the plural coachMarksSeen array', () => {
+    expect(OnboardingPatchSchema.safeParse({ coachMarksSeen: ['a'] }).success).toBe(false);
+  });
+
+  it('rejects an empty body — it would have no effect', () => {
+    expect(OnboardingPatchSchema.safeParse({}).success).toBe(false);
+  });
+
+  it('rejects an invalid status and a non-ISO timestamp', () => {
+    expect(OnboardingPatchSchema.safeParse({ status: 'finished' }).success).toBe(false);
+    expect(OnboardingPatchSchema.safeParse({ calculatorFirstUsedAt: '2026-08-06' }).success).toBe(
+      false,
+    );
+  });
+
+  // Bounded because nothing ever removes a coach-mark key: an unbounded key
+  // would let one client grow one row's jsonb without limit.
+  it('bounds the coach-mark key', () => {
+    expect(OnboardingPatchSchema.safeParse({ coachMarkSeen: '' }).success).toBe(false);
+    expect(
+      OnboardingPatchSchema.safeParse({ coachMarkSeen: 'x'.repeat(COACH_MARK_KEY_MAX_LENGTH) })
+        .success,
+    ).toBe(true);
+    expect(
+      OnboardingPatchSchema.safeParse({ coachMarkSeen: 'x'.repeat(COACH_MARK_KEY_MAX_LENGTH + 1) })
+        .success,
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/schemas/onboarding.ts
+++ b/packages/shared/src/schemas/onboarding.ts
@@ -1,0 +1,101 @@
+import { z } from 'zod';
+
+// Onboarding PREFERENCE state (user-onboarding R4.5, R4.6, R4.7, R7.2), stored
+// as the `users.onboarding` jsonb column.
+//
+// PREFERENCE ONLY. Per-item checklist completion is NEVER stored here — it is
+// derived at read time from the user's real data (account count, position
+// count, closed-position count) so it cannot disagree with reality, drift, or
+// need repair (R4.2). If you are tempted to add `accountCreated` or
+// `positionLogged` to this object, that is the bug this comment exists to stop.
+//
+// `calculatorFirstUsedAt` is the single named exception, and it is not a
+// completion flag: the calculator writes nothing else to the database, so
+// checklist item 2 has no other data trace. It records a fact — when the
+// calculator was first used — and the derivation reads it like any other
+// primitive.
+//
+// This is one jsonb column rather than three scalar columns because
+// `coachMarksSeen` is a growing SET of surface keys; as columns it would
+// eventually need its own table for what is a UI preference. Follows the
+// `dashboard_layouts.widgets` precedent.
+
+export const OnboardingStatusSchema = z.enum(['pending', 'active', 'skipped', 'done']);
+
+export type OnboardingStatus = z.infer<typeof OnboardingStatusSchema>;
+
+// EVERY field is optional-with-a-default, which is what makes the column's
+// `DEFAULT '{}'` work with no backfill: an existing row stores `{}`, parses
+// here, and comes out as a fully populated, usable state. The defaulting lives
+// in the schema on purpose — the API, the hook and the derivation all read a
+// resolved OnboardingState and none of them has to special-case an empty
+// object, a missing key, or a pre-migration row.
+//
+// 'pending' is the correct default for a row that predates the column: it has
+// neither opted out nor finished, so it is exactly where a brand-new user is.
+//
+// Unknown keys are STRIPPED (Zod's default) rather than rejected, unlike the
+// wire-body schemas in expense.ts / accounting.ts / dashboard.ts that call
+// .strict(). Those guard payloads arriving from a client. This one also parses
+// rows that were WRITTEN by another deployment: a key added by a newer version
+// of Tradr must not make an older one throw on read of its own users table.
+// The PATCH body schema is the place to be strict about what a client may send.
+export const OnboardingStateSchema = z.object({
+  status: OnboardingStatusSchema.default('pending'),
+  // Z-form ISO timestamp, matching every other `.datetime()` field in this
+  // package (positions' filledAt, changelog's publishedAt).
+  calculatorFirstUsedAt: z.string().datetime().optional(),
+  // Surface keys, treated as a set. Order is not meaningful and duplicates are
+  // prevented by the server-side merge, not by the type.
+  coachMarksSeen: z.array(z.string()).default([]),
+});
+
+// The RESOLVED state: what every reader gets after parsing. Nothing is
+// optional-with-a-default here — the defaults already ran.
+export type OnboardingState = z.infer<typeof OnboardingStateSchema>;
+
+// The STORED state: what is actually in the jsonb column, where every key may
+// be absent and `{}` is the commonest value on earth for this table. This, not
+// OnboardingState, is the honest `$type` for the Drizzle column — `{}` is not a
+// valid OnboardingState, and typing the column as one would tell every reader
+// that `row.onboarding.status` is a string when for existing rows it is
+// undefined. (Contrast dashboard_layouts.widgets, where the `'[]'` default IS a
+// valid WidgetPlacement[], so its `$type` can be the resolved type directly.)
+export type StoredOnboardingState = z.input<typeof OnboardingStateSchema>;
+
+// A coach-mark key names a UI surface (R7.1), so it is short and slug-shaped.
+// Bounded because the stored set only ever grows: nothing removes a key, so an
+// unbounded key would let a client grow one row's jsonb without limit.
+export const COACH_MARK_KEY_MAX_LENGTH = 64;
+
+// And the set itself is bounded for the same reason — R7.1 names five surfaces,
+// so this is an order of magnitude of headroom. Enforced by the server-side
+// merge, not here: the client never sends the whole array (see below).
+export const MAX_COACH_MARKS_SEEN = 64;
+
+// The PATCH body. STRICT, unlike OnboardingStateSchema above: this one's author
+// is a client, so an unexpected key really is a mistake and saying so beats
+// silently dropping it. (The state schema strips because it also parses rows
+// written by another deployment — see the comment on it.)
+//
+// `coachMarkSeen` is SINGULAR and deliberately not the stored field's name. The
+// stored `coachMarksSeen` is a set that only grows, so the operation a client
+// needs is "append this one key, idempotently" — not "here is the whole array",
+// which would make two tabs able to clobber each other's marks and would let a
+// client shrink the set by omission. Naming the operation rather than the field
+// makes it impossible to send the array by accident.
+//
+// Every field is optional, and at least one is required: a body naming nothing
+// has no effect, and answering 200 to it would hide a client bug.
+export const OnboardingPatchSchema = z
+  .object({
+    status: OnboardingStatusSchema.optional(),
+    calculatorFirstUsedAt: z.string().datetime().optional(),
+    coachMarkSeen: z.string().min(1).max(COACH_MARK_KEY_MAX_LENGTH).optional(),
+  })
+  .strict()
+  .refine((patch) => Object.keys(patch).length > 0, {
+    message: 'Provide at least one of status, calculatorFirstUsedAt or coachMarkSeen',
+  });
+
+export type OnboardingPatch = z.infer<typeof OnboardingPatchSchema>;


### PR DESCRIPTION
Groundwork for the new-user experience: somewhere to remember what a user has chosen about being guided, without that store ever becoming a second version of the truth.

## What changed

- `users.onboarding` — a new jsonb column holding **preference only**: whether the user wants guidance, when they first used the calculator, and which one-shot hints they have dismissed.
- `GET` / `PATCH /api/users/me/onboarding`, joining the existing per-user preference endpoints. PATCH merges, so setting one field never clears another, and dismissing the same hint twice is a no-op.

## Why preference only

Whether a user has created an account, logged a position, or closed one is **derived from their data**, never stored here. Stored progress can drift out of step with reality — a position created by CSV import, or an account deleted, would leave a stale tick. Deriving it means there is nothing to reconcile and nothing to repair.

The one exception is the first-calculator-use timestamp: the calculator computes and returns without writing anything, so that moment leaves no other trace. It records a fact about the user rather than a step in a list.

## Rolling-deploy safety

The merge happens in SQL, touching only the keys being changed. A key written by a newer deployment is never read into the application, so an older container cannot strip it while both are live. Verified by seeding an unknown key, patching through the handler, and confirming it survives — a read-modify-write implementation destroys it.

## Checks

Typecheck across all packages; the migrations, api and shared suites; the self-host parity suite; eslint; and the generated reference artifacts regenerate to a clean tree.
