### PR TITLE
feat(onboarding): replace the empty first-login dashboard

### DIFF
--- a/apps/api/src/db/migrations/0028_onboarding_backfill_existing_users.sql
+++ b/apps/api/src/db/migrations/0028_onboarding_backfill_existing_users.sql
@@ -1,0 +1,72 @@
+-- Users who predate onboarding start out already ONBOARDED (user-onboarding R3.6).
+--
+-- 0027 added `users.onboarding` as NOT NULL DEFAULT '{}' with no backfill, on
+-- the reasoning that '{}' parses to status 'pending' and 'pending' is "exactly
+-- where a brand-new user is". That is true of a brand-new user and false of
+-- everyone else: the fast default put EVERY pre-existing row at 'pending' too,
+-- including people who have been trading in Tradr for years.
+--
+-- It matters because 'pending' is what the zero-state gate keys on. R3.6 says
+-- the zero-state SHALL NOT reappear for a returning user who deletes their last
+-- account — "a returning user with history is not an onboarding user" — and the
+-- gate implements that by retiring on status 'done'. But 'done' is only ever
+-- reached by completing all four checklist items, and item 2 needs
+-- `calculatorFirstUsedAt`, which nothing wrote before this feature existed. So
+-- without this backfill a user with years of history who deletes their last
+-- account is shown "Welcome to Tradr". This is the one-time correction.
+--
+-- WHY A MIGRATION AND NOT A READ-TIME DERIVATION. The alternative — resolving
+-- 'pending' to 'done' on every GET /users/me/onboarding when the user has
+-- history — would put an EXISTS over accounts and positions on a preference
+-- read that is deliberately the CHEAP one (it is what gates the two expensive
+-- checklist reads), and it would keep paying for a fact that can only be true
+-- once. "Predates the feature" is a property of a moment that has already
+-- passed, so it is stored once, at that moment, and never asked again.
+--
+-- WHO COUNTS AS PRE-EXISTING. Two conditions, and each does a distinct job:
+--
+--   1. `onboarding = '{}'` — the column has never been written. Every row that
+--      predates the feature is '{}', and any row that is NOT '{}' has expressed
+--      a preference this migration must not overwrite. It is also what makes
+--      the statement IDEMPOTENT: a backfilled row is no longer '{}', so a
+--      re-run is a no-op. (Deliberately not `onboarding -> 'status' IS NULL`,
+--      which would also catch a row whose only key is `calculatorFirstUsedAt`
+--      or `coachMarksSeen` — a preference expressed through the PATCH endpoint
+--      0027 already shipped, and therefore not a pre-existing row at all.)
+--
+--   2. History — at least one account or position. A timestamp comparison
+--      cannot do this job: every row that exists when this runs was created
+--      before it, so `created_at < now()` marks the whole table, including
+--      someone who registered a minute before the deploy and is genuinely new.
+--      History is the signal R3.6 itself names, and it separates the two
+--      cleanly — a minute-old registration has none.
+--
+--      A user with neither is not being wronged. They have no accounts and no
+--      positions, so the zero-state is the accurate screen for them whether
+--      they registered a minute ago or two years ago: there is no history for
+--      it to contradict. That is also the honest limit of this migration —
+--      someone who had already deleted every account AND every position before
+--      the deploy leaves no trace to find, and is indistinguishable from a new
+--      registration. Going forward they are covered, because they are marked
+--      'done' here while the history still exists and deleting it later cannot
+--      un-mark them.
+--
+--      Both arms are index-backed (accounts_user_id_idx, positions_user_id_idx)
+--      and short-circuit on the first row. The positions arm is redundant today
+--      — positions.account_id is ON DELETE RESTRICT and the service refuses to
+--      delete an account that still has positions, so positions imply accounts
+--      — but "has ever created a position" is half of what R3.6 means by
+--      history, and stating it here means a future relaxation of that FK cannot
+--      quietly narrow this rule.
+--
+-- ADDITIVE AND ROLLING-DEPLOY SAFE: no DDL, and 'done' is a value the currently
+-- deployed code already understands (OnboardingStatusSchema shipped with 0027),
+-- so an instance running the old build reads a backfilled row without error.
+UPDATE "users" u
+SET "onboarding" = jsonb_set(u."onboarding", '{status}', '"done"'::jsonb, true),
+    "updated_at" = now()
+WHERE u."onboarding" = '{}'::jsonb
+  AND (
+    EXISTS (SELECT 1 FROM "accounts" a WHERE a."user_id" = u."id")
+    OR EXISTS (SELECT 1 FROM "positions" p WHERE p."user_id" = u."id")
+  );

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1786041305065,
       "tag": "0027_user_onboarding_preference",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1786054566343,
+      "tag": "0028_onboarding_backfill_existing_users",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/features/auth/user-onboarding-backfill.test.ts
+++ b/apps/api/src/features/auth/user-onboarding-backfill.test.ts
@@ -1,0 +1,189 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { eq, sql } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+
+import { OnboardingStateSchema } from '@tradr/shared';
+import type { StoredOnboardingState } from '@tradr/shared';
+
+import { db } from '@/db';
+import { accounts, positions, users } from '@/db/schema';
+
+// Migration 0028 — "users who predate onboarding start out already onboarded"
+// (user-onboarding R3.6).
+//
+// The statement under test is the migration FILE itself, read from disk and
+// executed, not a hand-copied paraphrase of it. A paraphrase would pass while
+// the shipped SQL said something else, which is the only failure mode that
+// matters for a one-shot backfill nobody can re-run by hand.
+//
+// It is safe to execute here because the statement is idempotent by
+// construction (it only touches rows whose `onboarding` is still `'{}'`), and
+// this project's test setup wraps every test in a transaction that rolls back,
+// so the fixture rows and the re-run both disappear afterwards.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATION_PATH = path.resolve(
+  __dirname,
+  '../../db/migrations/0028_onboarding_backfill_existing_users.sql',
+);
+
+/** Runs the migration and reports how many rows it actually wrote. */
+async function runBackfill(): Promise<number> {
+  const ddl = await readFile(MIGRATION_PATH, 'utf8');
+  const result = await db.execute(sql.raw(ddl));
+  return (result as unknown as { count: number }).count;
+}
+
+let seq = 0;
+const runId = Date.now();
+
+/** A row as it exists before the backfill: `onboarding` still the 0027 default. */
+async function makeUser(): Promise<{ id: string; email: string }> {
+  const email = `onb-backfill-${runId}-${++seq}@example.com`;
+  const [row] = await db
+    .insert(users)
+    .values({ email, passwordHash: 'x'.repeat(60) })
+    .returning({ id: users.id, email: users.email });
+  return row;
+}
+
+async function makeAccount(userId: string): Promise<string> {
+  const [row] = await db
+    .insert(accounts)
+    .values({ userId, name: `acct-${++seq}`, currency: 'USD' })
+    .returning({ id: accounts.id });
+  return row.id;
+}
+
+async function makePosition(userId: string, accountId: string): Promise<void> {
+  // performance-charts §8.2 audit: the default status 'draft' is CHECK-safe
+  // (positions_closed_at_when_closed_chk only constrains 'closed'), and the
+  // backfill's EXISTS reads no column but user_id.
+  // eslint-disable-next-line no-restricted-syntax
+  await db
+    .insert(positions)
+    .values({ userId, accountId, symbol: 'AAPL', side: 'long', assetType: 'stock' });
+}
+
+function storedOnboarding(id: string) {
+  return db
+    .select({ onboarding: users.onboarding })
+    .from(users)
+    .where(eq(users.id, id))
+    .then((rows) => rows[0]?.onboarding as Record<string, unknown> | undefined);
+}
+
+function setStoredOnboarding(id: string, value: Record<string, unknown>) {
+  return db
+    .update(users)
+    .set({ onboarding: value as StoredOnboardingState })
+    .where(eq(users.id, id));
+}
+
+describe('migration 0028 — onboarding backfill for pre-existing users', () => {
+  it('marks a user with history as done, so the zero-state cannot come back (R3.6)', async () => {
+    // The user R3.6 is about: years of history, and `{}` in the column because
+    // the 0027 fast default put every existing row at 'pending'. Left alone,
+    // deleting their last account shows them "Welcome to Tradr".
+    const user = await makeUser();
+    const accountId = await makeAccount(user.id);
+    await makePosition(user.id, accountId);
+    expect(await storedOnboarding(user.id)).toEqual({});
+
+    await runBackfill();
+
+    expect(await storedOnboarding(user.id)).toEqual({ status: 'done' });
+    // And it resolves through the shared schema like any other stored state —
+    // `jsonb_set` writing one key must not disturb the rest of the defaulting.
+    expect(OnboardingStateSchema.parse(await storedOnboarding(user.id))).toEqual({
+      status: 'done',
+      coachMarksSeen: [],
+    });
+  });
+
+  it('marks a user whose only history is an account', async () => {
+    // Deleting the last account is R3.6's own scenario, and the account is the
+    // history that proves they are not new. Positions are not required.
+    const user = await makeUser();
+    await makeAccount(user.id);
+
+    await runBackfill();
+
+    expect(await storedOnboarding(user.id)).toEqual({ status: 'done' });
+  });
+
+  it('marks a user whose only history is a position', async () => {
+    // The second arm of the OR. Today it cannot fire on its own —
+    // positions.account_id is ON DELETE RESTRICT and the accounts service
+    // refuses to delete an account that still has positions, so a position
+    // implies an account — and this fixture reaches the shape only by booking
+    // the position against another user's account. That is the point: the arm
+    // is here so a future relaxation of that FK cannot quietly narrow the rule,
+    // and an untested arm would not survive the next refactor.
+    const other = await makeUser();
+    const otherAccount = await makeAccount(other.id);
+    const user = await makeUser();
+    await makePosition(user.id, otherAccount);
+
+    await runBackfill();
+
+    expect(await storedOnboarding(user.id)).toEqual({ status: 'done' });
+  });
+
+  it('leaves a user with no history alone — a minute-old registration is genuinely new', async () => {
+    // The trap in dating "pre-existing" by `created_at`: every row that exists
+    // when the migration runs was created before it, so a timestamp comparison
+    // marks the whole table, this user included. They have no accounts and no
+    // positions, so the zero-state is the accurate screen for them and 'pending'
+    // is the correct status.
+    const user = await makeUser();
+
+    await runBackfill();
+
+    expect(await storedOnboarding(user.id)).toEqual({});
+    expect(OnboardingStateSchema.parse(await storedOnboarding(user.id)).status).toBe('pending');
+  });
+
+  it('never overwrites a preference the user has already expressed', async () => {
+    // A dismissal (R4.5) is recoverable and a `skipped` user still reaches the
+    // zero-state and its reopen row. Backfilling over it would retire the
+    // checklist behind their back and delete the only way back.
+    const skipped = await makeUser();
+    await makeAccount(skipped.id);
+    await setStoredOnboarding(skipped.id, { status: 'skipped' });
+
+    // And a row whose only key is one the PATCH endpoint wrote: not '{}', so
+    // not a pre-existing row, even though it has no `status` yet.
+    const marked = await makeUser();
+    await makeAccount(marked.id);
+    await setStoredOnboarding(marked.id, { coachMarksSeen: ['csv-import'] });
+
+    await runBackfill();
+
+    expect(await storedOnboarding(skipped.id)).toEqual({ status: 'skipped' });
+    expect(await storedOnboarding(marked.id)).toEqual({ coachMarksSeen: ['csv-import'] });
+  });
+
+  it('is idempotent — a second run changes nothing', async () => {
+    // Migrations are journalled and run once, but a backfill that is only
+    // correct on its first application is a trap for anyone replaying it
+    // against a restored dump. The `onboarding = '{}'` guard is what makes the
+    // re-run a no-op: a backfilled row is no longer '{}'.
+    const withHistory = await makeUser();
+    await makeAccount(withHistory.id);
+    const withoutHistory = await makeUser();
+
+    const firstCount = await runBackfill();
+    expect(firstCount).toBeGreaterThan(0);
+    const first = await storedOnboarding(withHistory.id);
+
+    // Zero rows written, not merely the same values afterwards: an UPDATE that
+    // rewrote the row with an identical value would satisfy the weaker claim.
+    expect(await runBackfill()).toBe(0);
+    expect(await storedOnboarding(withHistory.id)).toEqual(first);
+    expect(await storedOnboarding(withoutHistory.id)).toEqual({});
+  });
+});

--- a/apps/docs/scripts/gen-db-schema.mjs
+++ b/apps/docs/scripts/gen-db-schema.mjs
@@ -12,7 +12,7 @@
 // sort, so it follows the migration order Drizzle itself uses.
 //
 // Usage: node scripts/gen-db-schema.mjs
-import { readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -62,10 +62,19 @@ const GROUPS = [
 function latestSnapshot() {
   const journal = JSON.parse(readFileSync(join(META, '_journal.json'), 'utf8'));
   const entries = [...journal.entries].sort((a, b) => a.when - b.when);
-  const last = entries[entries.length - 1];
-  if (!last) throw new Error('gen-db-schema: the migration journal is empty');
-  const idx = String(last.idx).padStart(4, '0');
-  return { file: join(META, `${idx}_snapshot.json`), tag: last.tag, count: entries.length };
+  if (entries.length === 0) throw new Error('gen-db-schema: the migration journal is empty');
+  // Walk BACK to the newest entry that actually has a snapshot. Not every
+  // migration does: a data-only one (0021's dashboard row-unit rescale, 0028's
+  // onboarding backfill) is hand-authored, changes no DDL, and Drizzle Kit — the
+  // only thing that writes snapshots — was never involved. Such a migration
+  // leaves the schema exactly as the previous snapshot describes it, so that
+  // snapshot is the correct source; taking the last journal entry unconditionally
+  // just crashed on a missing file the moment a data migration shipped last.
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const file = join(META, `${String(entries[i].idx).padStart(4, '0')}_snapshot.json`);
+    if (existsSync(file)) return { file, tag: entries[i].tag, count: entries.length };
+  }
+  throw new Error('gen-db-schema: no migration in the journal has a snapshot');
 }
 
 /**
@@ -131,7 +140,7 @@ out.push(`    Source: apps/api/src/db/migrations/meta/ (latest snapshot) · Gene
 out.push('');
 out.push(`Tradr's schema is **${tables.length} tables**, created by **${count} migrations** that run`);
 out.push('automatically when the api boots. This page is generated from the Drizzle snapshot');
-out.push(`for the latest migration (\`${tag}\`), so it describes the schema the migrations`);
+out.push(`for the latest schema-changing migration (\`${tag}\`), so it describes the schema the migrations`);
 out.push('actually produce.');
 out.push('');
 out.push('You do not need any of this to run Tradr. It is here for writing queries against');

--- a/apps/docs/src/content/docs/self-hosting/reference/db-schema.mdx
+++ b/apps/docs/src/content/docs/self-hosting/reference/db-schema.mdx
@@ -6,9 +6,9 @@ description: Every table Tradr creates, its columns, and how they reference each
 {/* GENERATED FILE — do not edit.
     Source: apps/api/src/db/migrations/meta/ (latest snapshot) · Generator: apps/docs/scripts/gen-db-schema.mjs */}
 
-Tradr's schema is **32 tables**, created by **28 migrations** that run
+Tradr's schema is **32 tables**, created by **29 migrations** that run
 automatically when the api boots. This page is generated from the Drizzle snapshot
-for the latest migration (`0027_user_onboarding_preference`), so it describes the schema the migrations
+for the latest schema-changing migration (`0027_user_onboarding_preference`), so it describes the schema the migrations
 actually produce.
 
 You do not need any of this to run Tradr. It is here for writing queries against

--- a/apps/web/src/features/accounts/hooks/useAccounts.ts
+++ b/apps/web/src/features/accounts/hooks/useAccounts.ts
@@ -26,10 +26,16 @@ export function getAccountErrorCode(err: unknown): string | undefined {
   return (err as { error?: { code?: string } }).error?.code;
 }
 
-export function useAccounts() {
+/**
+ * `options.enabled` lets a caller that may not need the list at all skip the
+ * request entirely; omitted, it fetches as before. A disabled query reports
+ * `data: undefined`, `isLoading: false` and `isError: false`.
+ */
+export function useAccounts(options?: { enabled?: boolean }) {
   return useQuery<Account[]>({
     queryKey: ['accounts', 'list'],
     queryFn: () => api.get<Account[]>('/accounts'),
+    enabled: options?.enabled,
   });
 }
 

--- a/apps/web/src/features/onboarding/components/ActivationChecklist.test.tsx
+++ b/apps/web/src/features/onboarding/components/ActivationChecklist.test.tsx
@@ -1,0 +1,390 @@
+// @vitest-environment jsdom
+//
+// The hook is faked wholesale. This file is about what the component does with
+// the three checklist values, and the hook's own behaviour (three composed
+// reads, the derivation, the PATCH round trip) already has 22 tests of its own
+// in hooks/useOnboarding.test.ts. Faking it here keeps the two suites from
+// re-testing each other.
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { OnboardingState, OnboardingStatus } from '@tradr/shared';
+
+import { useOnboarding, type UseOnboardingResult } from '../hooks/useOnboarding';
+import { deriveChecklist, type ChecklistItemId } from '../lib/derive-checklist';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../hooks/useOnboarding', () => ({ useOnboarding: vi.fn() }));
+
+import { ActivationChecklist } from './ActivationChecklist';
+
+const mockUseOnboarding = vi.mocked(useOnboarding);
+
+function preference(status: OnboardingStatus): OnboardingState {
+  return { status, coachMarksSeen: [] };
+}
+
+/** The REAL derivation — the component must never disagree with it. */
+function checklistOf(over: Partial<Parameters<typeof deriveChecklist>[0]> = {}) {
+  return deriveChecklist({
+    accountCount: 0,
+    positionsEverCreatedCount: 0,
+    closedPositionCount: 0,
+    ...over,
+  });
+}
+
+const ALL_DONE = {
+  accountCount: 1,
+  positionsEverCreatedCount: 1,
+  closedPositionCount: 1,
+  calculatorFirstUsedAt: '2026-08-06T00:00:00.000Z',
+};
+
+function useHook(over: Partial<UseOnboardingResult> = {}): UseOnboardingResult {
+  const value: UseOnboardingResult = {
+    checklist: undefined,
+    preference: undefined,
+    isLoading: false,
+    isError: false,
+    isSaving: false,
+    setStatus: vi.fn(),
+    dismiss: vi.fn(),
+    markCoachMarkSeen: vi.fn(),
+    ...over,
+  };
+  mockUseOnboarding.mockReturnValue(value);
+  return value;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('ActivationChecklist — the four items (R4.1)', () => {
+  it('renders exactly four items, in the derivation order', () => {
+    useHook({ checklist: checklistOf(), preference: preference('pending') });
+    render(<ActivationChecklist />);
+
+    const items = [...document.querySelectorAll('[data-checklist-item]')];
+    expect(items.map((el) => el.getAttribute('data-checklist-item'))).toEqual([
+      'account',
+      'calculator',
+      'position',
+      'close',
+    ]);
+    expect(items.map((el) => el.textContent)).toEqual([
+      'Create a brokerage account — not completed',
+      'Size a trade in the calculator — not completed',
+      'Log a position — not completed',
+      'Close it and see the stats — not completed',
+    ]);
+  });
+
+  it('reflects per-item completion derived upstream, not recomputed here', () => {
+    // Deliberately out of order: an account-less user who imported closed
+    // positions by CSV is a legitimate state (R4.3), so the component must
+    // render whatever the derivation says rather than assume a sequence.
+    useHook({
+      checklist: checklistOf({ positionsEverCreatedCount: 3, closedPositionCount: 3 }),
+      preference: preference('active'),
+    });
+    render(<ActivationChecklist />);
+
+    const done = [...document.querySelectorAll('[data-checklist-item]')].map((el) =>
+      el.textContent?.includes('— completed'),
+    );
+    expect(done).toEqual([false, false, true, true]);
+  });
+
+  it('stays visible with item 1 incomplete when only demo data is present (R4.8)', () => {
+    // Demo seeding gives positions but no account the user created, so the
+    // hook's account count is still 0 and item 1 is still open.
+    useHook({
+      checklist: checklistOf({ positionsEverCreatedCount: 5 }),
+      preference: preference('pending'),
+    });
+    render(<ActivationChecklist />);
+
+    expect(screen.getByTestId('activation-checklist')).toBeTruthy();
+    expect(document.querySelector('[data-checklist-item="account"]')?.textContent).toContain(
+      '— not completed',
+    );
+  });
+
+  it('reports progress as a count, so completion never rests on colour alone', () => {
+    useHook({
+      checklist: checklistOf({ accountCount: 1, positionsEverCreatedCount: 1 }),
+      preference: preference('active'),
+    });
+    render(<ActivationChecklist />);
+
+    expect(screen.getByTestId('activation-checklist-progress').textContent).toBe('2 of 4 complete');
+  });
+});
+
+describe('ActivationChecklist — undefined vs null are different answers', () => {
+  it('renders a skeleton while the checklist is not known yet, never four unticked boxes', () => {
+    // The status is KNOWN to be one that still shows a checklist; only the two
+    // gated reads behind it are outstanding. That is the one case a skeleton is
+    // honest, because it is going to resolve into a card.
+    useHook({ checklist: undefined, preference: preference('pending'), isLoading: true });
+    render(<ActivationChecklist />);
+
+    expect(screen.getByTestId('activation-checklist-loading')).toBeTruthy();
+    expect(screen.queryByTestId('activation-checklist')).toBeNull();
+    expect(document.querySelectorAll('[data-checklist-item]').length).toBe(0);
+    // Not the dismissed footprint either — nothing has been dismissed.
+    expect(screen.queryByTestId('activation-checklist-reopen')).toBeNull();
+  });
+
+  it('renders a skeleton for an `active` user whose gated reads are in flight', () => {
+    useHook({ checklist: undefined, preference: preference('active'), isLoading: true });
+    render(<ActivationChecklist />);
+
+    expect(screen.getByTestId('activation-checklist-loading')).toBeTruthy();
+  });
+
+  it('occupies no space at all while the status itself is unknown', () => {
+    // The preference read has not landed, so `undefined` here does NOT mean "a
+    // checklist is loading" — it means we do not yet know whether this user
+    // gets one. Most do not. A skeleton would paint a four-row card on every
+    // established user's dashboard and then collapse it: a layout jump on the
+    // primary screen, which the design system forbids of a loading state.
+    useHook({ checklist: undefined, preference: undefined, isLoading: true });
+    const { container } = render(<ActivationChecklist />);
+
+    expect(screen.queryByTestId('activation-checklist-loading')).toBeNull();
+    expect(screen.queryByTestId('activation-checklist')).toBeNull();
+    expect(screen.queryByTestId('activation-checklist-reopen')).toBeNull();
+    // Not merely invisible — no node, so no box, so nothing to reflow when the
+    // status lands and the real answer takes its place.
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing — not a skeleton — for a gated-off `done` user', () => {
+    useHook({ checklist: null, preference: preference('done') });
+    const { container } = render(<ActivationChecklist />);
+
+    // A skeleton here would spin forever: the reads it waits on are never sent.
+    expect(screen.queryByTestId('activation-checklist-loading')).toBeNull();
+    expect(container.textContent).toBe('');
+  });
+
+  it('renders the reopen affordance — not a skeleton — for a `skipped` user', () => {
+    useHook({ checklist: null, preference: preference('skipped') });
+    render(<ActivationChecklist />);
+
+    expect(screen.getByTestId('activation-checklist-reopen')).toBeTruthy();
+    expect(screen.queryByTestId('activation-checklist-loading')).toBeNull();
+    expect(screen.queryByTestId('activation-checklist')).toBeNull();
+  });
+
+  it('renders nothing on a terminal read failure', () => {
+    // `checklist` is undefined on error too, but an unticked box we cannot
+    // substantiate is worse than no box — and a skeleton would never resolve.
+    // The preference is present so this exercises the error branch itself, not
+    // the status-unknown gate that sits behind it.
+    useHook({ checklist: undefined, preference: preference('active'), isError: true });
+    const { container } = render(<ActivationChecklist />);
+
+    expect(container.textContent).toBe('');
+    expect(screen.queryByTestId('activation-checklist-loading')).toBeNull();
+  });
+});
+
+describe('ActivationChecklist — dismissal round-trips and is recoverable (R4.5)', () => {
+  it('calls dismiss from the dismiss control', async () => {
+    const hook = useHook({ checklist: checklistOf(), preference: preference('pending') });
+    render(<ActivationChecklist />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss checklist' }));
+
+    expect(hook.dismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('round-trips: dismissed -> reopen affordance -> active', async () => {
+    const first = useHook({ checklist: checklistOf(), preference: preference('pending') });
+    const { rerender } = render(<ActivationChecklist />);
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss checklist' }));
+    expect(first.dismiss).toHaveBeenCalledTimes(1);
+
+    // What the hook reports once `status: 'skipped'` has landed: the gated
+    // reads are off, so the checklist is `null`.
+    const dismissed = useHook({ checklist: null, preference: preference('skipped') });
+    rerender(<ActivationChecklist />);
+
+    const reopen = screen.getByRole('button', { name: /reopen setup checklist/i });
+    await userEvent.click(reopen);
+    expect(dismissed.setStatus).toHaveBeenCalledWith('active');
+
+    // And the checklist comes back with its items intact — nothing was lost,
+    // because no progress was ever stored.
+    useHook({ checklist: checklistOf({ accountCount: 1 }), preference: preference('active') });
+    rerender(<ActivationChecklist />);
+    expect(document.querySelectorAll('[data-checklist-item]').length).toBe(4);
+    expect(screen.queryByTestId('activation-checklist-reopen')).toBeNull();
+  });
+
+  it('disables both write controls while a preference write is in flight', () => {
+    useHook({ checklist: checklistOf(), preference: preference('pending'), isSaving: true });
+    const { rerender } = render(<ActivationChecklist />);
+    expect(screen.getByRole('button', { name: 'Dismiss checklist' }).hasAttribute('disabled')).toBe(
+      true,
+    );
+
+    useHook({ checklist: null, preference: preference('skipped'), isSaving: true });
+    rerender(<ActivationChecklist />);
+    expect(
+      screen.getByRole('button', { name: /reopen setup checklist/i }).hasAttribute('disabled'),
+    ).toBe(true);
+  });
+});
+
+describe('ActivationChecklist — retirement (R4.7)', () => {
+  it('stops rendering and persists `done` when all four are complete', () => {
+    const hook = useHook({ checklist: checklistOf(ALL_DONE), preference: preference('active') });
+    const { container } = render(<ActivationChecklist />);
+
+    expect(container.textContent).toBe('');
+    expect(hook.setStatus).toHaveBeenCalledTimes(1);
+    expect(hook.setStatus).toHaveBeenCalledWith('done');
+  });
+
+  it('writes `done` only once across re-renders while the status catches up', () => {
+    const hook = useHook({
+      checklist: checklistOf(ALL_DONE),
+      preference: preference('active'),
+      isSaving: true,
+    });
+    const { rerender } = render(<ActivationChecklist />);
+    rerender(<ActivationChecklist />);
+    rerender(<ActivationChecklist />);
+
+    expect(hook.setStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not write `done` while any item is outstanding', () => {
+    const hook = useHook({
+      checklist: checklistOf({ accountCount: 1, positionsEverCreatedCount: 1 }),
+      preference: preference('active'),
+    });
+    render(<ActivationChecklist />);
+
+    expect(hook.setStatus).not.toHaveBeenCalled();
+  });
+
+  it('leaves no reopen affordance behind — retirement is permanent', () => {
+    useHook({ checklist: null, preference: preference('done') });
+    render(<ActivationChecklist />);
+
+    expect(screen.queryByTestId('activation-checklist-reopen')).toBeNull();
+  });
+});
+
+describe('ActivationChecklist — per-item action', () => {
+  it('fires onStartStep with that item id', async () => {
+    const onStartStep = vi.fn<(id: ChecklistItemId) => void>();
+    useHook({ checklist: checklistOf(), preference: preference('pending') });
+    render(<ActivationChecklist onStartStep={onStartStep} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Start: Log a position' }));
+
+    expect(onStartStep).toHaveBeenCalledTimes(1);
+    expect(onStartStep).toHaveBeenCalledWith('position');
+  });
+
+  it('offers an action for every outstanding item and none for a completed one', () => {
+    useHook({ checklist: checklistOf({ accountCount: 1 }), preference: preference('pending') });
+    render(<ActivationChecklist onStartStep={vi.fn()} />);
+
+    const actions = [...document.querySelectorAll('[data-checklist-action]')].map((el) =>
+      el.getAttribute('data-checklist-action'),
+    );
+    expect(actions).toEqual(['calculator', 'position', 'close']);
+  });
+
+  it('renders no dead buttons when no handler is supplied', () => {
+    useHook({ checklist: checklistOf(), preference: preference('pending') });
+    render(<ActivationChecklist />);
+
+    expect(document.querySelectorAll('[data-checklist-action]').length).toBe(0);
+    expect(document.querySelectorAll('[data-checklist-item]').length).toBe(4);
+  });
+});
+
+describe('ActivationChecklist — keyboard and design-system gates', () => {
+  it('is fully operable from the keyboard', async () => {
+    const onStartStep = vi.fn<(id: ChecklistItemId) => void>();
+    const hook = useHook({ checklist: checklistOf(), preference: preference('pending') });
+    render(<ActivationChecklist onStartStep={onStartStep} />);
+
+    // Tab order: dismiss (in the header) first, then each item's action.
+    await userEvent.tab();
+    expect(document.activeElement?.getAttribute('aria-label')).toBe('Dismiss checklist');
+    await userEvent.tab();
+    expect(document.activeElement?.getAttribute('data-checklist-action')).toBe('account');
+
+    await userEvent.keyboard('{Enter}');
+    expect(onStartStep).toHaveBeenCalledWith('account');
+
+    await userEvent.keyboard(' ');
+    expect(onStartStep).toHaveBeenCalledTimes(2);
+
+    // And the dismiss control activates from the keyboard too.
+    await userEvent.tab({ shift: true });
+    await userEvent.keyboard('{Enter}');
+    expect(hook.dismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('puts cursor-pointer on every button', () => {
+    useHook({ checklist: checklistOf(), preference: preference('pending') });
+    const { rerender } = render(<ActivationChecklist onStartStep={vi.fn()} />);
+    for (const button of document.querySelectorAll('button')) {
+      expect(button.className).toContain('cursor-pointer');
+    }
+
+    useHook({ checklist: null, preference: preference('skipped') });
+    rerender(<ActivationChecklist />);
+    for (const button of document.querySelectorAll('button')) {
+      expect(button.className).toContain('cursor-pointer');
+    }
+  });
+
+  it('never colours completion with the gain/loss financial tokens', () => {
+    useHook({
+      checklist: checklistOf({ accountCount: 1, positionsEverCreatedCount: 1 }),
+      preference: preference('active'),
+    });
+    render(<ActivationChecklist />);
+
+    const markup = screen.getByTestId('activation-checklist').outerHTML;
+    // Money direction only — a green tick borrowing `gain` would read as P&L.
+    expect(markup).not.toMatch(/\b(text|bg|fill|stroke|border)-(gain|loss|flat)\b/);
+    expect(markup).toContain('text-success');
+    // No hardcoded colours: every colour is a semantic role.
+    expect(markup).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+    expect(markup).not.toMatch(/\b(text|bg)-(green|red|emerald|rose)-\d{2,3}\b/);
+  });
+
+  it('carries no primary (amber) action — the zero-state owns the one per view', () => {
+    useHook({ checklist: checklistOf(), preference: preference('pending') });
+    render(<ActivationChecklist onStartStep={vi.fn()} />);
+
+    for (const button of document.querySelectorAll('button')) {
+      expect(button.getAttribute('data-variant')).toBe('ghost');
+    }
+  });
+
+  it('holds its animation still under prefers-reduced-motion', () => {
+    useHook({ checklist: undefined, preference: preference('pending'), isLoading: true });
+    render(<ActivationChecklist />);
+
+    for (const el of document.querySelectorAll('[data-slot="skeleton"]')) {
+      expect(el.className).toContain('motion-reduce:animate-none');
+    }
+  });
+});

--- a/apps/web/src/features/onboarding/components/ActivationChecklist.tsx
+++ b/apps/web/src/features/onboarding/components/ActivationChecklist.tsx
@@ -1,0 +1,234 @@
+// ActivationChecklist — the four-item "what set up means" list (R4).
+//
+// It renders derived state and writes nothing except the onboarding STATUS.
+// Every completion decision comes from `useOnboarding().checklist`, which is
+// `deriveChecklist`'s output: this file must never restate a rule like
+// `accountCount > 0` or `items.every(done)`, because that would fork the rule
+// set out of `lib/derive-checklist.ts` (the "one function with one input shape"
+// NFR). `allComplete` is read, not recomputed.
+//
+// R4.8 follows for free: item 1 stays incomplete while only demo data is
+// present because the hook excludes demo accounts from the count it derives
+// from. Nothing here knows demo data exists, and nothing here should.
+//
+// THE THREE CHECKLIST VALUES ARE THREE DIFFERENT ANSWERS, and this component is
+// the reason the hook bothers to distinguish them:
+//
+//   `undefined` — not known yet. A read is in flight (or failed). Render a
+//                 skeleton, never four unticked boxes: a half-loaded derivation
+//                 is a WRONG answer, not an early one, and would flash "you
+//                 have done nothing" at a fully set-up user on every load.
+//                 But ONLY once `preference` has landed — see below.
+//   `null`      — this user has no checklist, because onboarding is `done` or
+//                 `skipped`, so the reads it would need were never issued. A
+//                 skeleton here would spin forever waiting for a request that
+//                 is never going to happen.
+//   a Checklist — the answer. Render it.
+//
+// `undefined` COVERS TWO SITUATIONS AND ONLY ONE OF THEM EARNS A SKELETON. The
+// hook composes a cheap preference read and two expensive gated reads, and the
+// cheap one lands first. Until it does, `preference` is `undefined` and we do
+// not yet know whether this user is `pending`/`active` (a checklist is coming)
+// or `done`/`skipped` (one never will be). Painting the four-row skeleton in
+// that window means every established user gets a card on the dashboard that
+// then collapses to a single ghost row or to nothing — a layout jump on the
+// primary screen for the majority of users, which the design system forbids of
+// a loading state. So `preference` is the gate: render nothing, occupying no
+// space, while the status is unknown, and start the skeleton only once the
+// status says a checklist is on its way. Once `preference` HAS landed the two
+// values cannot be confused — a `done`/`skipped` user's checklist is `null`, so
+// `undefined` past this point can only mean the gated reads are still in
+// flight.
+//
+// R4.5 — WHERE RECOVERY LIVES. Dismissal is only `status: 'skipped'` (no
+// progress is stored anywhere, so there is nothing to lose), which means it is
+// recoverable in principle. This component is what makes it recoverable in
+// PRACTICE: for a `skipped` user it renders a single quiet "Reopen setup
+// checklist" row instead of nothing at all. `setStatus('active')` flips the
+// hook's gate on the same render, the two gated reads fire, and the checklist
+// comes back with real counts. A dismissed checklist that left NO trace
+// anywhere would satisfy "dismissible" and fail "re-openable without support
+// intervention". Note the asymmetry with `done`: retirement (R4.7) is
+// permanent and leaves nothing behind, dismissal leaves this one row.
+//
+// R4.7 — RETIREMENT. When all four are complete the checklist stops rendering
+// AND writes `status: 'done'` once, so it does not reappear on later logins.
+// The write is not merely an optimisation: it also switches off the two
+// expensive gated reads for a user who can never see a checklist again.
+//
+// COLOUR: completion uses the `success` STATUS role, never `gain`. A green tick
+// borrowing the gain token would read as a P&L direction on a screen full of
+// money — the exact collision the design system reserves gain/loss to prevent.
+// The tick is doubled by an icon shape and by screen-reader text, so completion
+// never rests on colour alone.
+
+import { Circle, CircleCheck, RotateCcw, X } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+
+import { useOnboarding } from '../hooks/useOnboarding';
+import type { ChecklistItemId } from '../lib/derive-checklist';
+
+interface ActivationChecklistProps {
+  /**
+   * Start the walkthrough step set for one item. The ids are the same strings
+   * as the step-set module names, so the wiring needs no lookup table.
+   *
+   * Optional, and the per-item buttons render ONLY when it is supplied: a
+   * "Start" button with nothing behind it is a dead control, and the checklist
+   * is useful without one (the items name their own actions, all of which are
+   * reachable from the normal UI — R4.3). The zero-state can therefore mount
+   * this before the walkthrough exists.
+   */
+  onStartStep?: (id: ChecklistItemId) => void;
+}
+
+export function ActivationChecklist({ onStartStep }: ActivationChecklistProps) {
+  const { checklist, preference, isError, isSaving, setStatus, dismiss } = useOnboarding();
+
+  const allComplete = checklist?.allComplete === true;
+  const status = preference?.status;
+
+  // Fire the R4.7 retirement write exactly once per mount. The ref is what
+  // stops a second PATCH going out on the renders between the mutation being
+  // sent and the new status landing in the cache — during that window
+  // `allComplete` is still true and `status` is still the old one.
+  const retired = useRef(false);
+  useEffect(() => {
+    if (!allComplete || retired.current || status === 'done') return;
+    retired.current = true;
+    setStatus('done');
+  }, [allComplete, status, setStatus]);
+
+  // "There is no checklist for this user." Only a dismissal leaves a trace.
+  if (checklist === null) {
+    if (status !== 'skipped') return null;
+    return (
+      <div data-testid="activation-checklist-reopen">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="cursor-pointer text-muted-foreground"
+          disabled={isSaving}
+          onClick={() => setStatus('active')}
+        >
+          <RotateCcw aria-hidden="true" />
+          Reopen setup checklist
+        </Button>
+      </div>
+    );
+  }
+
+  // "Not known yet." A terminal failure is not a loading state — an unticked
+  // box we cannot substantiate is worse than no box, so render nothing at all.
+  if (checklist === undefined) {
+    if (isError) return null;
+    // Status unknown: the cheap preference read has not landed, so we cannot
+    // tell a user who is about to see a checklist from one who never will.
+    // Occupy no space rather than reserve room for a card most users lose.
+    if (preference === undefined) return null;
+    return (
+      <Card
+        data-testid="activation-checklist-loading"
+        role="status"
+        aria-label="Loading your setup checklist"
+        className="gap-4 py-4"
+      >
+        <CardHeader className="px-4">
+          <Skeleton className="h-5 w-32 motion-reduce:animate-none" />
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3 px-4">
+          {[0, 1, 2, 3].map((row) => (
+            <Skeleton key={row} className="h-6 w-full motion-reduce:animate-none" />
+          ))}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // R4.7: retired. The effect above persists it; this stops showing it now.
+  if (allComplete) return null;
+
+  const doneCount = checklist.items.filter((item) => item.done).length;
+
+  return (
+    <Card data-testid="activation-checklist" className="gap-4 py-4">
+      <CardHeader className="px-4">
+        <CardTitle className="text-base">Get set up</CardTitle>
+        {/* The non-colour carrier for overall progress, and the answer to "how
+            far along am I?" that R4's user story asks for. */}
+        <CardDescription data-testid="activation-checklist-progress">
+          {doneCount} of {checklist.items.length} complete
+        </CardDescription>
+        <CardAction>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="cursor-pointer"
+            aria-label="Dismiss checklist"
+            disabled={isSaving}
+            onClick={dismiss}
+          >
+            <X aria-hidden="true" />
+          </Button>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="px-4">
+        {/* Ordered because R4.1 fixes the order, not because the items gate on
+            each other — any one can be completed first (R4.3). */}
+        <ol className="flex flex-col">
+          {checklist.items.map((item) => (
+            <li
+              key={item.id}
+              // The join to the walkthrough: this attribute is the anchor the
+              // tour targets and the handle the per-item action is found by.
+              data-checklist-item={item.id}
+              className="flex min-h-9 items-center gap-3 py-1"
+            >
+              {item.done ? (
+                <CircleCheck className="size-4 shrink-0 text-success" aria-hidden="true" />
+              ) : (
+                <Circle className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+              )}
+              <span
+                className={cn(
+                  'min-w-0 flex-1 text-sm',
+                  item.done && 'text-muted-foreground line-through',
+                )}
+              >
+                {item.label}
+                <span className="sr-only">{item.done ? ' — completed' : ' — not completed'}</span>
+              </span>
+              {/* No primary (amber) action anywhere on this card. The checklist
+                  is embedded in the zero-state, which carries the one primary
+                  action that view is allowed. */}
+              {!item.done && onStartStep && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="shrink-0 cursor-pointer"
+                  data-checklist-action={item.id}
+                  aria-label={`Start: ${item.label}`}
+                  onClick={() => onStartStep(item.id)}
+                >
+                  Start
+                </Button>
+              )}
+            </li>
+          ))}
+        </ol>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/features/onboarding/components/ZeroState.test.tsx
+++ b/apps/web/src/features/onboarding/components/ZeroState.test.tsx
@@ -1,0 +1,357 @@
+// @vitest-environment jsdom
+//
+// `useOnboarding` is faked wholesale — the hook has 22 tests of its own and
+// ActivationChecklist has 24, so this file is only about what the ZERO-STATE
+// does: the three forward actions, R3.3's copy, and the R3.2 guarantee that
+// neither fork leaves the user with less than they started with.
+//
+// ActivationChecklist is deliberately NOT mocked. R3.2 is a claim about the
+// composed screen ("declining guidance leaves the checklist and a docs link in
+// place"), and a stubbed checklist would let that claim pass while the real one
+// rendered nothing. The single `useOnboarding` mock reaches both components,
+// since both import it from the same path.
+//
+// AccountDialog IS mocked, to a marker that respects `open`. It pulls in
+// brokerages, tier state and the API client, none of which this screen's
+// behaviour depends on — what matters here is only that the primary action
+// opens it. (AccountList.test.tsx stubs it the same way.)
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { OnboardingState, OnboardingStatus } from '@tradr/shared';
+
+import { DOCS_BASE_URL, docsUrl } from '@/lib/docs';
+
+import { useOnboarding, type UseOnboardingResult } from '../hooks/useOnboarding';
+import { deriveChecklist } from '../lib/derive-checklist';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../hooks/useOnboarding', () => ({ useOnboarding: vi.fn() }));
+
+vi.mock('@/features/accounts/components/AccountDialog', () => ({
+  AccountDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="account-dialog" /> : null,
+}));
+
+import { ZeroState } from './ZeroState';
+
+const mockUseOnboarding = vi.mocked(useOnboarding);
+
+function preference(status: OnboardingStatus): OnboardingState {
+  return { status, coachMarksSeen: [] };
+}
+
+/** A fresh user: no accounts, no positions, the calculator untouched. */
+function freshChecklist() {
+  return deriveChecklist({
+    accountCount: 0,
+    positionsEverCreatedCount: 0,
+    closedPositionCount: 0,
+  });
+}
+
+function useHook(over: Partial<UseOnboardingResult> = {}): UseOnboardingResult {
+  const value: UseOnboardingResult = {
+    checklist: freshChecklist(),
+    preference: preference('pending'),
+    isLoading: false,
+    isError: false,
+    isSaving: false,
+    setStatus: vi.fn(),
+    dismiss: vi.fn(),
+    markCoachMarkSeen: vi.fn(),
+    ...over,
+  };
+  mockUseOnboarding.mockReturnValue(value);
+  return value;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('ZeroState — the three forward actions (R3.2, R9.1)', () => {
+  it('renders all three, and the sample-data option alongside the real one', () => {
+    useHook();
+    render(<ZeroState />);
+
+    expect(screen.getByRole('button', { name: 'Create my first account' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Walk me through it' })).toBeTruthy();
+    // R9.1: alongside, never instead of — the real account action is still the
+    // one that comes first and the one that carries the weight.
+    expect(screen.getByRole('button', { name: 'Add sample data' })).toBeTruthy();
+  });
+
+  it('opens the account dialog from the primary action', async () => {
+    useHook();
+    render(<ZeroState />);
+
+    expect(screen.queryByTestId('account-dialog')).toBeNull();
+    await userEvent.click(screen.getByRole('button', { name: 'Create my first account' }));
+
+    expect(screen.getByTestId('account-dialog')).toBeTruthy();
+  });
+
+  it('records the guided opt-in as `active` (R5.2)', async () => {
+    const hook = useHook();
+    render(<ZeroState />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Walk me through it' }));
+
+    expect(hook.setStatus).toHaveBeenCalledTimes(1);
+    expect(hook.setStatus).toHaveBeenCalledWith('active');
+  });
+
+  it('does not re-record the opt-in while the write is in flight', () => {
+    useHook({ isSaving: true });
+    render(<ZeroState />);
+
+    expect(
+      screen.getByRole('button', { name: 'Walk me through it' }).hasAttribute('disabled'),
+    ).toBe(true);
+  });
+
+  it('offers sample data as a disabled control with the reason stated, never a silent no-op', () => {
+    useHook();
+    render(<ZeroState />);
+
+    const sample = screen.getByTestId('zero-state-sample-data');
+    expect(sample.hasAttribute('disabled')).toBe(true);
+    // The explanation is real markup the button points at, not a comment.
+    const noteId = sample.getAttribute('aria-describedby');
+    expect(noteId).toBeTruthy();
+    expect(document.getElementById(noteId!)?.textContent).toBe('Sample data is not available yet.');
+  });
+
+  it('says so plainly when guidance is not wired yet, rather than appearing to do nothing', async () => {
+    useHook();
+    render(<ZeroState />);
+
+    expect(screen.queryByTestId('zero-state-guidance-note')).toBeNull();
+    await userEvent.click(screen.getByRole('button', { name: 'Walk me through it' }));
+
+    // TASK 24: replace this with an assertion that the walkthrough started.
+    expect(screen.getByTestId('zero-state-guidance-note').textContent).toContain('not built yet');
+  });
+});
+
+describe('ZeroState — what the screen says (R3.3)', () => {
+  it('names the brokerage account as the prerequisite for everything else', () => {
+    useHook();
+    render(<ZeroState />);
+
+    const text = screen.getByTestId('onboarding-zero-state').textContent ?? '';
+    expect(text).toContain('Start with a brokerage account');
+    expect(text).toContain('booked against one');
+  });
+
+  it('states that Tradr accounts mirror real ones but are not connected to them', () => {
+    useHook();
+    render(<ZeroState />);
+
+    const statement = screen.getByTestId('zero-state-not-connected').textContent ?? '';
+    expect(statement).toContain('mirrors a real brokerage account');
+    expect(statement).toContain('not connected to your broker');
+  });
+
+  it('states that Tradr never places or executes trades', () => {
+    useHook();
+    render(<ZeroState />);
+
+    expect(screen.getByTestId('zero-state-not-connected').textContent).toContain(
+      'never places or executes trades',
+    );
+  });
+});
+
+describe('ZeroState — neither fork is a dead end (R3.2)', () => {
+  it('leaves the checklist and the docs link in place after declining guidance', async () => {
+    useHook();
+    render(<ZeroState />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Walk me through it' }));
+
+    // Both survive the choice, and so does the action that actually unblocks
+    // the product — nothing on this screen is spent by taking a fork.
+    expect(screen.getByTestId('activation-checklist')).toBeTruthy();
+    expect(document.querySelectorAll('[data-checklist-item]').length).toBe(4);
+    expect(screen.getByTestId('zero-state-docs-link')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Create my first account' })).toBeTruthy();
+  });
+
+  it('leaves the checklist and the docs link in place on the unguided path', async () => {
+    useHook();
+    render(<ZeroState />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Create my first account' }));
+
+    expect(screen.getByTestId('activation-checklist')).toBeTruthy();
+    expect(screen.getByTestId('zero-state-docs-link')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Walk me through it' })).toBeTruthy();
+  });
+
+  it('keeps the docs link when the checklist itself has been dismissed', () => {
+    // A dismissed checklist collapses to its own reopen row; the docs link is a
+    // sibling of the checklist, not a child, so it cannot go with it.
+    useHook({ checklist: null, preference: preference('skipped') });
+    render(<ZeroState />);
+
+    expect(screen.getByTestId('zero-state-docs-link')).toBeTruthy();
+    expect(screen.getByTestId('activation-checklist-reopen')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Create my first account' })).toBeTruthy();
+  });
+
+  it('links to the docs through docsUrl(), with the host written down nowhere here', () => {
+    useHook();
+    render(<ZeroState />);
+
+    const link = screen.getByTestId('zero-state-docs-link');
+    expect(link.getAttribute('href')).toBe(docsUrl('gettingStarted'));
+    expect(link.getAttribute('href')?.startsWith(DOCS_BASE_URL)).toBe(true);
+    // Mid-task reader: a new tab rather than losing the page they were on.
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toBe('noreferrer');
+  });
+});
+
+describe('ZeroState — design-system gates', () => {
+  it('carries exactly one primary (amber) action, and it is the account', () => {
+    useHook();
+    render(<ZeroState />);
+
+    const primaries = [...document.querySelectorAll('button[data-variant="default"]')];
+    expect(primaries.length).toBe(1);
+    expect(primaries[0]?.getAttribute('data-testid')).toBe('zero-state-create-account');
+
+    // Everything else, including the checklist's own controls, stays quiet.
+    for (const button of document.querySelectorAll('button')) {
+      if (button === primaries[0]) continue;
+      expect(['outline', 'ghost']).toContain(button.getAttribute('data-variant'));
+    }
+  });
+
+  it('does not spend a second amber on the docs link', () => {
+    // ImportPage and the sidebar colour their docs links `text-primary`; those
+    // surfaces have no amber button competing with them and this one does.
+    useHook();
+    render(<ZeroState />);
+
+    expect(screen.getByTestId('zero-state-docs-link').className).not.toContain('text-primary');
+  });
+
+  it('puts cursor-pointer on every button and on the link', () => {
+    useHook();
+    render(<ZeroState />);
+
+    for (const button of document.querySelectorAll('button')) {
+      expect(button.className).toContain('cursor-pointer');
+    }
+    expect(screen.getByTestId('zero-state-docs-link').className).toContain('cursor-pointer');
+  });
+
+  it('uses semantic roles only — no financial-semantic tokens, no hardcoded colours', () => {
+    useHook();
+    render(<ZeroState />);
+
+    const markup = screen.getByTestId('onboarding-zero-state').outerHTML;
+    // gain/loss/flat mean money direction. Nothing on a welcome screen does.
+    expect(markup).not.toMatch(/\b(text|bg|fill|stroke|border)-(gain|loss|flat)\b/);
+    expect(markup).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+    expect(markup).not.toMatch(/\b(text|bg)-(green|red|amber|emerald|rose|yellow)-\d{2,3}\b/);
+  });
+
+  it('holds its transitions still under prefers-reduced-motion', () => {
+    useHook();
+    render(<ZeroState />);
+
+    // The hover/focus transition on the three action buttons is the only motion
+    // this screen has, and it is the only thing that has to stand still.
+    for (const testid of [
+      'zero-state-create-account',
+      'zero-state-walkthrough',
+      'zero-state-sample-data',
+    ]) {
+      expect(screen.getByTestId(testid).className).toContain('motion-reduce:transition-none');
+    }
+  });
+
+  it('is fully operable from the keyboard', async () => {
+    const hook = useHook();
+    render(<ZeroState />);
+
+    await userEvent.tab();
+    expect(document.activeElement?.getAttribute('data-testid')).toBe('zero-state-create-account');
+
+    await userEvent.tab();
+    expect(document.activeElement?.getAttribute('data-testid')).toBe('zero-state-walkthrough');
+
+    // The disabled sample-data control is skipped rather than trapping a tab.
+    await userEvent.tab();
+    expect(document.activeElement?.getAttribute('aria-label')).toBe('Dismiss checklist');
+
+    await userEvent.tab();
+    expect(document.activeElement?.getAttribute('data-testid')).toBe('zero-state-docs-link');
+
+    // Both fork actions activate from the keyboard, with both keys.
+    await userEvent.tab({ shift: true });
+    await userEvent.tab({ shift: true });
+    await userEvent.keyboard('{Enter}');
+    expect(hook.setStatus).toHaveBeenCalledWith('active');
+
+    await userEvent.tab({ shift: true });
+    await userEvent.keyboard(' ');
+    expect(screen.getByTestId('account-dialog')).toBeTruthy();
+  });
+});
+
+describe('ZeroState — mobile widths (R3.7)', () => {
+  it('renders every part of the screen at a 320px viewport', () => {
+    window.innerWidth = 320;
+    useHook();
+    render(<ZeroState />);
+
+    // jsdom does not lay out, so this pins the CONTENT contract: nothing is
+    // hidden or dropped at the narrowest width the app supports.
+    expect(screen.getByTestId('onboarding-zero-state')).toBeTruthy();
+    expect(screen.getByTestId('zero-state-not-connected')).toBeTruthy();
+    expect(screen.getByTestId('zero-state-create-account')).toBeTruthy();
+    expect(screen.getByTestId('zero-state-walkthrough')).toBeTruthy();
+    expect(screen.getByTestId('zero-state-sample-data')).toBeTruthy();
+    expect(screen.getByTestId('activation-checklist')).toBeTruthy();
+    expect(screen.getByTestId('zero-state-docs-link')).toBeTruthy();
+  });
+
+  it('stacks the actions full-width below `sm` and only then puts them in a row', () => {
+    useHook();
+    render(<ZeroState />);
+
+    const row = screen.getByTestId('zero-state-create-account').parentElement;
+    expect(row?.className).toContain('flex-col');
+    expect(row?.className).toContain('sm:flex-row');
+
+    for (const testid of [
+      'zero-state-create-account',
+      'zero-state-walkthrough',
+      'zero-state-sample-data',
+    ]) {
+      const className = screen.getByTestId(testid).className;
+      expect(className).toContain('w-full');
+      expect(className).toContain('sm:w-auto');
+    }
+  });
+
+  it('sets no fixed or minimum width anywhere, so nothing can overflow a narrow viewport', () => {
+    useHook();
+    render(<ZeroState />);
+
+    const root = screen.getByTestId('onboarding-zero-state');
+    expect(root.className).toContain('w-full');
+    // A max is fine — it only bites on wide screens. A fixed or minimum width
+    // is what forces a horizontal scrollbar on a phone.
+    expect(root.outerHTML).not.toMatch(/\bmin-w-\[/);
+    expect(root.outerHTML).not.toMatch(/\bw-\[\d/);
+  });
+});

--- a/apps/web/src/features/onboarding/components/ZeroState.tsx
+++ b/apps/web/src/features/onboarding/components/ZeroState.tsx
@@ -1,0 +1,203 @@
+// ZeroState — the screen a newly-registered user lands on instead of six empty
+// widgets (R3).
+//
+// WHAT IT REPLACES. `/dashboard` renders six widgets, and for a user with no
+// accounts every one of them is empty and phrases its emptiness differently:
+// "Close a position to see stats." / "No open positions. Create one to get
+// started." / "No accounts yet." Each is individually correct and the screen as
+// a whole reads as broken, because nothing on it says which of the six holes to
+// fill first. This component answers that question once, at the top, in the
+// user's words: you need a brokerage account, and here is how to get one.
+//
+// WHY NOT `EmptyState`. The shared `EmptyState` is a centred `max-w-md` card
+// with one string description and one action slot, and the zero-state needs two
+// paragraphs (the prerequisite AND R3.3's not-connected statement), three
+// actions of three different weights, and an embedded checklist. Pushing all of
+// that through `action` would use the component as a container rather than as
+// the empty-state idiom, and widening the shared component for its one
+// non-empty-state caller is worse. So the same Card primitives `EmptyState`
+// itself is built from are used directly, with the same real-heading shape —
+// no parallel primitive is introduced and no shared component is bent.
+//
+// R3.3 IS THE LOAD-BEARING COPY, not decoration. New users arrive expecting
+// either a broker connection or an execution platform, and the account form
+// asks for a starting balance and a currency without ever saying what the thing
+// it is creating IS. The card states both halves plainly: a Tradr account
+// MIRRORS a real brokerage account, and it is NOT connected to one — Tradr
+// never places or executes trades. Say it here, once, before the user types a
+// balance into a form and wonders whose money it is.
+//
+// EXACTLY ONE PRIMARY (AMBER) ACTION, AND IT IS "CREATE MY FIRST ACCOUNT".
+// The design system reserves amber for the single action a view is about, and
+// on this view that is the brokerage account: it is the prerequisite R3.3 names,
+// the only control here that changes the user's data, and the one that makes
+// this whole screen go away (R3.4). The walkthrough is a way of doing that same
+// thing with help, not a different outcome, so it takes `outline`; sample data
+// is an aside. `ActivationChecklist` deliberately carries no primary action of
+// its own for exactly this reason — the one amber this composed view is allowed
+// lives here.
+//
+// The docs link is a MUTED underlined link, not the app's usual `text-primary`
+// one (ImportPage, Sidebar). Those surfaces have no amber button competing with
+// them; this one does, and an amber link two inches under an amber button is a
+// second primary action in everything but markup.
+//
+// NEITHER FORK IS A DEAD END (R3.2) — and it is structural, not a branch. The
+// checklist and the docs link are unconditional siblings: no choice on this
+// screen hides them, so there is no state in which declining guidance leaves the
+// user with less than they started with. That is cheaper to keep true than a
+// rule about which branch re-renders what.
+
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader } from '@/components/ui/card';
+import { AccountDialog } from '@/features/accounts/components/AccountDialog';
+import { docsUrl } from '@/lib/docs';
+
+import { useOnboarding } from '../hooks/useOnboarding';
+
+import { ActivationChecklist } from './ActivationChecklist';
+
+export function ZeroState() {
+  const { setStatus, isSaving } = useOnboarding();
+  const [accountDialogOpen, setAccountDialogOpen] = useState(false);
+  const [guidanceUnavailable, setGuidanceUnavailable] = useState(false);
+
+  // ===========================================================================
+  // TASK 24 SEAM — wiring the guided walkthrough.
+  //
+  // The walkthrough engine (`useWalkthrough`, `lib/tour-engine.ts`, the step
+  // sets) is Phase E and does not exist yet. What DOES exist is the opt-in
+  // record: `status: 'active'` is the persisted "this user asked to be guided"
+  // that R5.2 requires before any tour may run, so the fork is not decorative
+  // today — it writes the thing the tour will later read.
+  //
+  // Task 24 changes exactly this function and the note it sets:
+  //   1. call `useWalkthrough()` at the top of the component,
+  //   2. add `start()` after `setStatus('active')` here,
+  //   3. delete `setGuidanceUnavailable(true)` and the block that renders
+  //      `guidanceUnavailable` below — with a tour running the note is a lie,
+  //      and the test that pins it ("says so plainly when guidance is not
+  //      wired") should be replaced by one asserting `start` was called.
+  //   4. pass `onStartStep` through to `<ActivationChecklist>` (the prop is
+  //      already optional there and its per-item buttons appear when supplied).
+  // ZeroState takes no props: task 24's file list is this file and
+  // ActivationChecklist, so threading a handler down from the dashboard route
+  // would drag task 19's file into a change that has no business touching it.
+  //
+  // Until then the fork is honest rather than silent. A button that records a
+  // preference and then appears to do nothing is the same defect as the six
+  // empty widgets this screen exists to fix, so the note says what happened and
+  // points at the checklist, which lists the same four steps in the same order.
+  // ===========================================================================
+  const startWalkthrough = () => {
+    setStatus('active');
+    setGuidanceUnavailable(true);
+  };
+
+  return (
+    <div
+      data-testid="onboarding-zero-state"
+      // Single column at every width, capped so the prose keeps a readable
+      // measure on a desktop dashboard (R3.7). Nothing here has a minimum width,
+      // so there is nothing to overflow a 320px viewport.
+      className="mx-auto flex w-full max-w-2xl flex-col gap-4 p-4 sm:p-6"
+    >
+      <Card>
+        <CardHeader className="px-4 sm:px-6">
+          <h2 className="text-xl leading-none font-semibold">Welcome to Tradr</h2>
+          <CardDescription>
+            Start with a brokerage account. Every position, fill and ledger entry is booked against
+            one, so there is nothing to show on this dashboard until you create it.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4 px-4 sm:px-6">
+          {/* R3.3. Both halves, plainly, before the user meets a form asking for
+              a starting balance. */}
+          <p data-testid="zero-state-not-connected" className="text-sm text-muted-foreground">
+            A Tradr account mirrors a real brokerage account: the same currency, the same starting
+            balance, the same trades. It is not connected to your broker. Tradr never places or
+            executes trades — you record trades you have already made.
+          </p>
+
+          {/* Stacked and full-width on a phone, side by side from `sm` up. The
+              row wraps rather than shrinking, so no label is ever truncated. */}
+          <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+            <Button
+              data-testid="zero-state-create-account"
+              className="w-full cursor-pointer motion-reduce:transition-none sm:w-auto"
+              onClick={() => setAccountDialogOpen(true)}
+            >
+              Create my first account
+            </Button>
+            <Button
+              variant="outline"
+              data-testid="zero-state-walkthrough"
+              className="w-full cursor-pointer motion-reduce:transition-none sm:w-auto"
+              disabled={isSaving}
+              onClick={startWalkthrough}
+            >
+              Walk me through it
+            </Button>
+            {/* R9.1 — sample data is offered ALONGSIDE creating a real account,
+                never instead of it, which is why it sits next to the primary
+                action and does not replace it.
+                TASK 31 SEAM: the seeder (`useDemoAccount`, POST
+                /api/accounts/demo) is Phase G and does not exist. Rather than
+                ship a control that silently does nothing, the option is present
+                and DISABLED with the reason stated next to it. Task 31 drops
+                `disabled`, adds `onClick={seed}`, and removes the note below;
+                the tests pinning both are the ones to update. */}
+            <Button
+              variant="outline"
+              data-testid="zero-state-sample-data"
+              className="w-full cursor-pointer motion-reduce:transition-none sm:w-auto"
+              disabled
+              aria-describedby="zero-state-sample-data-note"
+            >
+              Add sample data
+            </Button>
+          </div>
+
+          {guidanceUnavailable && (
+            <p
+              role="status"
+              data-testid="zero-state-guidance-note"
+              className="text-sm text-muted-foreground"
+            >
+              The guided walkthrough is not built yet. The setup checklist below lists the same four
+              steps — start with the brokerage account.
+            </p>
+          )}
+
+          <p id="zero-state-sample-data-note" className="text-xs text-muted-foreground">
+            Sample data is not available yet.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Unconditional, both of them: this is what stops either fork being a
+          dead end (R3.2). The checklist reads its own state and handles its own
+          loading, dismissed and retired cases. */}
+      <ActivationChecklist />
+
+      <p className="text-sm text-muted-foreground">
+        {/* The docs live on their own host, so this is an <a>, not a router
+            Link, and it opens in a new tab — a reader following it is mid-task.
+            The host comes from docsUrl() and is never written down here. */}
+        <a
+          data-testid="zero-state-docs-link"
+          href={docsUrl('gettingStarted')}
+          target="_blank"
+          rel="noreferrer"
+          className="cursor-pointer underline underline-offset-2 hover:text-foreground"
+        >
+          Read the getting-started guide
+        </a>
+      </p>
+
+      <AccountDialog open={accountDialogOpen} onOpenChange={setAccountDialogOpen} account={null} />
+    </div>
+  );
+}

--- a/apps/web/src/features/onboarding/hooks/useOnboarding.test.ts
+++ b/apps/web/src/features/onboarding/hooks/useOnboarding.test.ts
@@ -1,0 +1,477 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Account, OnboardingPatch, OnboardingState, PositionListItem } from '@tradr/shared';
+
+import { api } from '@/lib/api';
+
+import { ONBOARDING_QUERY_KEY, useOnboarding } from './useOnboarding';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+// --- fixtures ---------------------------------------------------------------
+
+// Only the fields the derivation reads matter; the rest of each row is noise
+// here and constructing it in full would hide what the test is actually about.
+const anAccount = { id: 'acct-1', name: 'Main' } as Account;
+
+function aPosition(id: string, status: 'draft' | 'open' | 'closed'): PositionListItem {
+  return { id, status } as PositionListItem;
+}
+
+const FRESH: OnboardingState = { status: 'pending', coachMarksSeen: [] };
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: qc }, children);
+  };
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false, gcTime: 0 },
+    },
+  });
+}
+
+/**
+ * Answers the three reads useOnboarding composes, and applies PATCH bodies the
+ * way the API does — partial merge, idempotent coach-mark append, response is
+ * the merged state. Stateful on purpose: the hook seeds the cache from the
+ * response AND invalidates, so a frozen GET stub would answer the follow-up
+ * read with the pre-write state and make a working round-trip look broken.
+ */
+function mockServer(server: {
+  accounts?: Account[];
+  positions?: PositionListItem[] | Promise<PositionListItem[]>;
+  preference?: OnboardingState;
+}) {
+  const accounts = server.accounts ?? [];
+  const positions = server.positions ?? [];
+  const stored: OnboardingState = {
+    ...(server.preference ?? FRESH),
+    coachMarksSeen: [...(server.preference ?? FRESH).coachMarksSeen],
+  };
+  const snapshot = () => ({ ...stored, coachMarksSeen: [...stored.coachMarksSeen] });
+
+  const get = vi.spyOn(api, 'get').mockImplementation((path: string) => {
+    if (path === '/accounts') return Promise.resolve(accounts) as never;
+    if (path === '/positions') return Promise.resolve(positions) as never;
+    if (path === '/users/me/onboarding') return Promise.resolve(snapshot()) as never;
+    return Promise.reject(new Error(`unexpected GET ${path}`)) as never;
+  });
+
+  const patch = vi.spyOn(api, 'patch').mockImplementation((path: string, body?: unknown) => {
+    if (path !== '/users/me/onboarding') {
+      return Promise.reject(new Error(`unexpected PATCH ${path}`)) as never;
+    }
+    const sent = body as OnboardingPatch;
+    if (sent.status) stored.status = sent.status;
+    if (sent.calculatorFirstUsedAt) stored.calculatorFirstUsedAt = sent.calculatorFirstUsedAt;
+    if (sent.coachMarkSeen && !stored.coachMarksSeen.includes(sent.coachMarkSeen)) {
+      stored.coachMarksSeen.push(sent.coachMarkSeen);
+    }
+    return Promise.resolve(snapshot()) as never;
+  });
+
+  return { get, patch, snapshot };
+}
+
+/** The done-vector, in R4.1 presentation order: account, calculator, position, close. */
+function doneVector(items: { id: string; done: boolean }[]) {
+  return items.map((item) => [item.id, item.done] as const);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// --- derivation -------------------------------------------------------------
+
+describe('useOnboarding — derived checklist', () => {
+  it('a fresh user gets four incomplete items, allComplete false, and status pending', async () => {
+    mockServer({ accounts: [], positions: [], preference: FRESH });
+    const { result } = renderHook(() => useOnboarding(), {
+      wrapper: makeWrapper(makeQueryClient()),
+    });
+
+    await waitFor(() => expect(result.current.checklist).toBeDefined());
+
+    expect(doneVector(result.current.checklist!.items)).toEqual([
+      ['account', false],
+      ['calculator', false],
+      ['position', false],
+      ['close', false],
+    ]);
+    expect(result.current.checklist!.allComplete).toBe(false);
+    expect(result.current.preference).toEqual(FRESH);
+  });
+
+  it('reads the position list UNFILTERED — no status query parameter is ever sent', async () => {
+    const { get } = mockServer({ accounts: [anAccount], positions: [aPosition('p1', 'closed')] });
+    const { result } = renderHook(() => useOnboarding(), {
+      wrapper: makeWrapper(makeQueryClient()),
+    });
+
+    await waitFor(() => expect(result.current.checklist).toBeDefined());
+
+    // The count feeding item 3 is "positions EVER created". A status-filtered
+    // read here is the bug this assertion exists to catch.
+    const positionReads = get.mock.calls
+      .map(([path]) => path)
+      .filter((p) => p.startsWith('/positions'));
+    expect(positionReads).toEqual(['/positions']);
+  });
+
+  it('a partially-complete user ticks exactly the items their data supports', async () => {
+    mockServer({
+      accounts: [anAccount],
+      positions: [aPosition('p1', 'open')],
+      preference: { ...FRESH, calculatorFirstUsedAt: '2026-08-01T10:00:00.000Z' },
+    });
+    const { result } = renderHook(() => useOnboarding(), {
+      wrapper: makeWrapper(makeQueryClient()),
+    });
+
+    await waitFor(() => expect(result.current.checklist).toBeDefined());
+
+    expect(doneVector(result.current.checklist!.items)).toEqual([
+      ['account', true],
+      ['calculator', true],
+      ['position', true],
+      ['close', false],
+    ]);
+    expect(result.current.checklist!.allComplete).toBe(false);
+  });
+
+  it('a user whose positions are ALL closed still ticks "log a position" and reaches allComplete', async () => {
+    // The regression this test exists for: passing an open-only count would
+    // leave item 3 unticked for this user forever, so allComplete could never
+    // become true and the checklist would never retire (R4.7).
+    mockServer({
+      accounts: [anAccount],
+      positions: [aPosition('p1', 'closed'), aPosition('p2', 'closed')],
+      preference: { ...FRESH, calculatorFirstUsedAt: '2026-08-01T10:00:00.000Z' },
+    });
+    const { result } = renderHook(() => useOnboarding(), {
+      wrapper: makeWrapper(makeQueryClient()),
+    });
+
+    await waitFor(() => expect(result.current.checklist).toBeDefined());
+
+    expect(doneVector(result.current.checklist!.items)).toEqual([
+      ['account', true],
+      ['calculator', true],
+      ['position', true],
+      ['close', true],
+    ]);
+    expect(result.current.checklist!.allComplete).toBe(true);
+  });
+
+  it('counts drafts and open positions towards "ever created" but only closed ones towards item 4', async () => {
+    mockServer({
+      accounts: [anAccount],
+      positions: [aPosition('p1', 'draft'), aPosition('p2', 'open')],
+    });
+    const { result } = renderHook(() => useOnboarding(), {
+      wrapper: makeWrapper(makeQueryClient()),
+    });
+
+    await waitFor(() => expect(result.current.checklist).toBeDefined());
+
+    expect(doneVector(result.current.checklist!.items)).toEqual([
+      ['account', true],
+      ['calculator', false],
+      ['position', true],
+      ['close', false],
+    ]);
+  });
+});
+
+// --- the in-flight window ---------------------------------------------------
+
+describe('useOnboarding — while the reads are in flight', () => {
+  it('reports no checklist at all until every read has landed, then the real one', async () => {
+    let releasePositions: (positions: PositionListItem[]) => void = () => {};
+    const pendingPositions = new Promise<PositionListItem[]>((resolve) => {
+      releasePositions = resolve;
+    });
+    mockServer({
+      accounts: [anAccount],
+      positions: pendingPositions,
+      preference: { ...FRESH, calculatorFirstUsedAt: '2026-08-01T10:00:00.000Z' },
+    });
+
+    const { result } = renderHook(() => useOnboarding(), {
+      wrapper: makeWrapper(makeQueryClient()),
+    });
+
+    // Accounts and the preference have landed; positions has not. A checklist
+    // derived now would show a set-up user four unticked boxes.
+    await waitFor(() => expect(result.current.preference).toBeDefined());
+    expect(result.current.checklist).toBeUndefined();
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      releasePositions([aPosition('p1', 'closed')]);
+      await pendingPositions;
+    });
+
+    await waitFor(() => expect(result.current.checklist).toBeDefined());
+    expect(result.current.checklist!.allComplete).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('reports no checklist when a read fails terminally, and flags the error', async () => {
+    vi.spyOn(api, 'get').mockImplementation((path: string) => {
+      if (path === '/positions') return Promise.reject(new Error('positions down')) as never;
+      if (path === '/accounts') return Promise.resolve([anAccount]) as never;
+      return Promise.resolve(FRESH) as never;
+    });
+    const { result } = renderHook(() => useOnboarding(), {
+      wrapper: makeWrapper(makeQueryClient()),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.checklist).toBeUndefined();
+  });
+});
+
+// --- the status gate on the expensive reads ---------------------------------
+
+/** Every path the hook actually asked the API for, in order. */
+function readsOf(get: { mock: { calls: unknown[][] } }) {
+  return get.mock.calls.map((call) => call[0] as string);
+}
+
+/** The two reads that cost real money: `/positions` has no LIMIT. */
+function expensiveReadsOf(get: { mock: { calls: unknown[][] } }) {
+  return readsOf(get).filter((p) => p.startsWith('/positions') || p.startsWith('/accounts'));
+}
+
+describe('useOnboarding — the expensive reads are gated on the stored status', () => {
+  // A retired (R4.7) or dismissed (R4.5) user will not be shown a checklist, so
+  // fetching every account and every enriched position row to compute one is
+  // pure cost — and it is paid on every dashboard mount, forever, growing with
+  // the user's history.
+  it.each(['done', 'skipped'] as const)(
+    'a `%s` user issues NEITHER expensive read and gets a null checklist',
+    async (status) => {
+      const { get } = mockServer({
+        accounts: [anAccount],
+        positions: [aPosition('p1', 'closed')],
+        preference: { ...FRESH, status },
+      });
+
+      const { result } = renderHook(() => useOnboarding(), {
+        wrapper: makeWrapper(makeQueryClient()),
+      });
+
+      await waitFor(() => expect(result.current.preference?.status).toBe(status));
+      // Fetches are kicked off from an effect, so give one a chance to happen
+      // before asserting that it never did.
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(expensiveReadsOf(get)).toEqual([]);
+      // The cheap preference read is what tells us the rest is unnecessary, so
+      // it must still go out.
+      expect(readsOf(get)).toContain('/users/me/onboarding');
+
+      // `null`, not `undefined`: a consumer that cannot tell "no checklist for
+      // this user" from "not known yet" would sit on a skeleton forever waiting
+      // for reads that are never coming.
+      expect(result.current.checklist).toBeNull();
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isError).toBe(false);
+    },
+  );
+
+  it.each(['pending', 'active'] as const)(
+    'a `%s` user — who can still be shown a checklist — DOES issue both',
+    async (status) => {
+      const { get } = mockServer({
+        accounts: [anAccount],
+        positions: [aPosition('p1', 'closed')],
+        preference: { ...FRESH, status, calculatorFirstUsedAt: '2026-08-01T10:00:00.000Z' },
+      });
+
+      const { result } = renderHook(() => useOnboarding(), {
+        wrapper: makeWrapper(makeQueryClient()),
+      });
+
+      // Not `toBeDefined()` — `null` would satisfy that, and `null` is exactly
+      // the failure this test is here to catch.
+      await waitFor(() => expect(result.current.checklist?.items).toHaveLength(4));
+
+      expect(readsOf(get)).toContain('/accounts');
+      expect(readsOf(get)).toContain('/positions');
+      expect(result.current.checklist!.allComplete).toBe(true);
+    },
+  );
+
+  it('a dismissed user who RE-OPENS the checklist still gets a correct one', async () => {
+    // The reason gating on `skipped` is safe (R4.5): completion is derived and
+    // never stored (R4.2/R4.4), so going quiet loses nothing. Re-opening flips
+    // the status the gate reads, both reads fire, and the same counts produce
+    // the same answer they would have all along.
+    const { get } = mockServer({
+      accounts: [anAccount],
+      positions: [aPosition('p1', 'closed'), aPosition('p2', 'open')],
+      preference: {
+        ...FRESH,
+        status: 'skipped',
+        calculatorFirstUsedAt: '2026-08-01T10:00:00.000Z',
+      },
+    });
+
+    const { result } = renderHook(() => useOnboarding(), {
+      wrapper: makeWrapper(makeQueryClient()),
+    });
+
+    await waitFor(() => expect(result.current.checklist).toBeNull());
+    expect(expensiveReadsOf(get)).toEqual([]);
+
+    await act(async () => {
+      result.current.setStatus('active');
+    });
+
+    await waitFor(() => expect(result.current.checklist?.items).toHaveLength(4));
+    expect(doneVector(result.current.checklist!.items)).toEqual([
+      ['account', true],
+      ['calculator', true],
+      ['position', true],
+      ['close', true],
+    ]);
+    expect(readsOf(get)).toContain('/positions');
+  });
+});
+
+// --- preference writes ------------------------------------------------------
+
+describe('useOnboarding — preference mutations', () => {
+  it('dismiss() round-trips to the API and the returned state seeds the cache', async () => {
+    const { patch } = mockServer({ accounts: [anAccount], positions: [], preference: FRESH });
+
+    const qc = makeQueryClient();
+    const { result } = renderHook(() => useOnboarding(), { wrapper: makeWrapper(qc) });
+    await waitFor(() => expect(result.current.checklist).toBeDefined());
+
+    await act(async () => {
+      result.current.dismiss();
+    });
+
+    expect(patch).toHaveBeenCalledWith('/users/me/onboarding', { status: 'skipped' });
+    const dismissed: OnboardingState = { status: 'skipped', coachMarksSeen: [] };
+    await waitFor(() => expect(result.current.preference).toEqual(dismissed));
+    expect(qc.getQueryData(ONBOARDING_QUERY_KEY)).toEqual(dismissed);
+  });
+
+  it('a dismissed checklist is recoverable — setStatus("active") reopens it', async () => {
+    const { patch } = mockServer({
+      accounts: [anAccount],
+      positions: [],
+      preference: { ...FRESH, status: 'skipped' },
+    });
+
+    const { result } = renderHook(() => useOnboarding(), {
+      wrapper: makeWrapper(makeQueryClient()),
+    });
+    await waitFor(() => expect(result.current.preference?.status).toBe('skipped'));
+
+    await act(async () => {
+      result.current.setStatus('active');
+    });
+
+    expect(patch).toHaveBeenCalledWith('/users/me/onboarding', { status: 'active' });
+    await waitFor(() => expect(result.current.preference?.status).toBe('active'));
+  });
+
+  it('markCoachMarkSeen() appends ONE key under the singular field name', async () => {
+    const { patch } = mockServer({ accounts: [anAccount], positions: [], preference: FRESH });
+
+    const { result } = renderHook(() => useOnboarding(), {
+      wrapper: makeWrapper(makeQueryClient()),
+    });
+    await waitFor(() => expect(result.current.checklist).toBeDefined());
+
+    await act(async () => {
+      result.current.markCoachMarkSeen('import');
+    });
+
+    // Singular `coachMarkSeen` — the plural array is a 400, and sending the
+    // whole set would let one tab shrink another's by omission.
+    expect(patch).toHaveBeenCalledWith('/users/me/onboarding', { coachMarkSeen: 'import' });
+    await waitFor(() => expect(result.current.preference?.coachMarksSeen).toEqual(['import']));
+
+    // Idempotent server-side, so the hook fires again without checking
+    // membership first and the set does not grow duplicates.
+    await act(async () => {
+      result.current.markCoachMarkSeen('import');
+    });
+    await waitFor(() => expect(result.current.preference?.coachMarksSeen).toEqual(['import']));
+  });
+
+  it('a status write does not carry the rest of the state — the merge is server-side', async () => {
+    const { patch } = mockServer({
+      accounts: [anAccount],
+      positions: [],
+      preference: { status: 'active', coachMarksSeen: ['import'] },
+    });
+
+    const { result } = renderHook(() => useOnboarding(), {
+      wrapper: makeWrapper(makeQueryClient()),
+    });
+    await waitFor(() => expect(result.current.preference).toBeDefined());
+
+    await act(async () => {
+      result.current.setStatus('done');
+    });
+
+    expect(patch).toHaveBeenCalledWith('/users/me/onboarding', { status: 'done' });
+    const [, body] = patch.mock.calls[0] as [string, Record<string, unknown>];
+    expect(Object.keys(body)).toEqual(['status']);
+    // The coach marks it never sent are still there afterwards.
+    await waitFor(() => expect(result.current.preference?.coachMarksSeen).toEqual(['import']));
+  });
+});
+
+// --- no client-side persistence of progress ---------------------------------
+
+describe('useOnboarding — no client-side progress', () => {
+  it('writes nothing to localStorage, through reads or writes', async () => {
+    const setItem = vi.spyOn(Storage.prototype, 'setItem');
+    mockServer({
+      accounts: [anAccount],
+      positions: [aPosition('p1', 'closed')],
+      preference: { ...FRESH, calculatorFirstUsedAt: '2026-08-01T10:00:00.000Z' },
+    });
+
+    const { result } = renderHook(() => useOnboarding(), {
+      wrapper: makeWrapper(makeQueryClient()),
+    });
+    await waitFor(() => expect(result.current.checklist?.allComplete).toBe(true));
+
+    await act(async () => {
+      result.current.markCoachMarkSeen('import');
+    });
+    await act(async () => {
+      result.current.dismiss();
+    });
+
+    // Resumability across sessions and devices comes from re-deriving the
+    // checklist from the user's real data (R4.4). Any cached copy here would be
+    // a second source of truth that can only ever disagree with it.
+    expect(setItem).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/onboarding/hooks/useOnboarding.ts
+++ b/apps/web/src/features/onboarding/hooks/useOnboarding.ts
@@ -1,0 +1,245 @@
+// useOnboarding — the one access point for onboarding state (R4).
+//
+// It composes THREE reads: the accounts list, the positions list, and the
+// stored onboarding preference. Per-item checklist completion is DERIVED from
+// the first two (R4.2) and is never stored anywhere, which is exactly what
+// makes the checklist resume across sessions and devices with no extra state
+// (R4.4). Nothing in this file — or downstream of it — may write progress to
+// localStorage, Zustand or any other client store: the counts are the same
+// counts on every device, so a cached copy could only ever disagree with them.
+// Server data lives in TanStack Query and nowhere else (structure.md, State
+// Management Rules).
+//
+// THE PREFERENCE READ IS SPLIT OUT as `useOnboardingQuery()` deliberately. A
+// consumer that needs only the status or the coach-mark seen set (the coach
+// marks, mounted on ordinary working surfaces) should use that directly rather
+// than this hook, which pulls the whole positions list down to count it.
+//
+// NOTHING IS REPORTED UNTIL ALL ENABLED READS HAVE LANDED. `checklist` is
+// `undefined` while any of them is in flight, rather than a checklist derived
+// from whichever counts have arrived so far. A partially-loaded derivation is
+// not a slightly-early answer, it is a WRONG one: every count starts absent, so
+// a fully set-up user would see four unticked boxes on every load and a
+// checklist that has already retired (R4.7) would flash back into existence
+// before vanishing again. `undefined` says "not known yet", which is the truth,
+// and lets the consumer render a skeleton or nothing at all. The same gate
+// covers terminal failure: on error the checklist stays `undefined` and
+// `isError` is set, because an unticked box we cannot substantiate is worse
+// than no box.
+//
+// THE TWO EXPENSIVE READS ARE GATED ON THE STORED STATUS. `GET /positions` has
+// no LIMIT and returns every enriched row; running it on every dashboard mount
+// for a user who will never see a checklist again is a cost with no possible
+// payoff, and it grows with the account. So accounts and positions only fetch
+// while the status is `pending` or `active` — the two states in which a
+// checklist can still be shown. `done` is R4.7's retirement, which by
+// definition never reappears. `skipped` is an R4.5 dismissal, which IS
+// recoverable, and gating on it costs nothing precisely BECAUSE completion is
+// derived and never stored (R4.2/R4.4): `setStatus('active')` seeds the new
+// status into the cache, `checklistNeeded` flips on the same render, both reads
+// fire, and the checklist comes back with real counts. There is no client-side
+// progress that going quiet could have lost.
+//
+// The test is an ALLOWLIST, not `!== 'done' && !== 'skipped'`. The status is
+// `undefined` until the preference read lands, and a denylist would read as
+// "needed" during that window — firing both expensive reads on every mount for
+// exactly the users this gate exists to spare. Waiting one round trip is the
+// price, and it is why the preference read is the cheap one.
+//
+// FOR A GATED-OFF USER `checklist` IS `null`, NOT `undefined`. The two are
+// different answers and a consumer must be able to tell them apart: `undefined`
+// means "not known yet, ask again", `null` means "there is no checklist for
+// this user". Collapsing both to `undefined` would leave a `done` user's
+// consumer sitting on a skeleton forever, waiting for reads that are never
+// going to happen.
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+import { toast } from 'sonner';
+
+import type { OnboardingPatch, OnboardingState, OnboardingStatus } from '@tradr/shared';
+
+import { useAccounts } from '@/features/accounts/hooks/useAccounts';
+import { usePositions } from '@/features/positions/hooks/usePositions';
+import { api } from '@/lib/api';
+
+import { deriveChecklist, type Checklist } from '../lib/derive-checklist';
+
+/** [feature, scope, id] — the same shape as the other /users/me/* preferences. */
+export const ONBOARDING_QUERY_KEY = ['users', 'me', 'onboarding'] as const;
+
+function getErrorMessage(err: unknown, fallback: string): string {
+  if (typeof err === 'object' && err !== null && 'error' in err) {
+    const e = err as { error?: { message?: string } };
+    if (e.error?.message) return e.error.message;
+  }
+  return fallback;
+}
+
+/**
+ * The stored onboarding PREFERENCE — status, the coach marks already seen, and
+ * the first-calculator-use timestamp. Never checklist progress.
+ *
+ * Always resolves: a row that predates the column stores `{}` and the server
+ * parses it to `{ status: 'pending', coachMarksSeen: [] }`, with
+ * `calculatorFirstUsedAt` ABSENT rather than null. Test it with `undefined`, not
+ * `!== null`.
+ */
+export function useOnboardingQuery() {
+  return useQuery<OnboardingState>({
+    queryKey: ONBOARDING_QUERY_KEY,
+    queryFn: () => api.get<OnboardingState>('/users/me/onboarding'),
+  });
+}
+
+/**
+ * The single write path: PATCH /api/users/me/onboarding with a PARTIAL body.
+ *
+ * The merge happens server-side in SQL, so a body naming only `status` does not
+ * clear the coach marks and a key written by a newer deployment is not
+ * destroyed. Never send the whole state object back — that is the shape that
+ * loses data. `coachMarkSeen` is singular and names the operation (append one,
+ * idempotently); the plural array is a 400.
+ *
+ * The 200 body is the merged state in the GET's shape, so it seeds the cache
+ * directly — the UI settles without a round trip. The invalidate that follows
+ * is not redundant: the response is only a snapshot of this request, and a
+ * concurrent write from another tab can land immediately after it.
+ */
+export function useOnboardingPatch() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (patch: OnboardingPatch) =>
+      api.patch<OnboardingState>('/users/me/onboarding', patch),
+    onSuccess: (state) => {
+      queryClient.setQueryData(ONBOARDING_QUERY_KEY, state);
+      queryClient.invalidateQueries({ queryKey: ONBOARDING_QUERY_KEY });
+    },
+    onError: (err: unknown) => {
+      // No success toast: the visible change — the checklist closing, the coach
+      // mark going away — is the confirmation. A failure has no such tell.
+      toast.error(getErrorMessage(err, 'Failed to save your onboarding preference'));
+    },
+  });
+}
+
+export interface UseOnboardingResult {
+  /**
+   * The derived checklist. Three distinct values, and a consumer must branch on
+   * all three: a `Checklist` is the answer; `undefined` is "not known yet"
+   * (a read is in flight, or one failed terminally — pair it with `isError`);
+   * `null` is "this user has no checklist", because onboarding is `done` or
+   * `skipped` and the reads it would need were never issued. Only `undefined`
+   * ever resolves into a checklist on its own — treating `null` as a loading
+   * state is a skeleton that never goes away.
+   */
+  checklist: Checklist | null | undefined;
+  /** The stored preference, or `undefined` until its read lands. */
+  preference: OnboardingState | undefined;
+  /** A read the checklist still needs is in flight. Never true once `checklist` is `null`. */
+  isLoading: boolean;
+  /** One of the enabled reads failed terminally. */
+  isError: boolean;
+  /** A preference write is in flight. */
+  isSaving: boolean;
+  setStatus: (status: OnboardingStatus) => void;
+  /**
+   * Dismiss the checklist (R4.5). Dismissal is only a status, which is what
+   * makes it recoverable without support: `setStatus('active')` reopens it.
+   */
+  dismiss: () => void;
+  /** Append one coach-mark key (R7.2). Idempotent server-side, so callers need no membership check. */
+  markCoachMarkSeen: (key: string) => void;
+}
+
+export function useOnboarding(): UseOnboardingResult {
+  const preferenceQuery = useOnboardingQuery();
+  const preferenceStatus = preferenceQuery.data?.status;
+  // The allowlist described at the top of the file: only these two statuses can
+  // still put a checklist on screen, so only they are worth paying for. Stays
+  // false while the preference read is in flight, which is what keeps a `done`
+  // user from issuing the reads speculatively on every single mount.
+  const checklistNeeded = preferenceStatus === 'pending' || preferenceStatus === 'active';
+
+  const accountsQuery = useAccounts({ enabled: checklistNeeded });
+  // NO STATUS FILTER, AND THIS IS THE POINT. `positionsEverCreatedCount` means
+  // every position the user has ever created, whatever state it is in now —
+  // item 3 asks whether they have ever logged one, and that cannot become
+  // untrue later. An open-only list would un-tick item 3 the moment the user
+  // closed their last position, and a user who had closed everything could
+  // never reach `allComplete`, so the checklist would never retire (R4.7).
+  // The closed count below is filtered from this same unfiltered list rather
+  // than fetched as a second, status-filtered query: one request, and no second
+  // count sitting around that could be passed to the wrong field. The gate on
+  // the second argument decides WHETHER this request goes out, never WHAT it
+  // asks for — the filters stay `undefined`.
+  const positionsQuery = usePositions(undefined, { enabled: checklistNeeded });
+  const patch = useOnboardingPatch();
+
+  const accounts = accountsQuery.data;
+  const positions = positionsQuery.data;
+  const preference = preferenceQuery.data;
+
+  const checklist = useMemo(() => {
+    // Order matters. "Not known yet" has to be answered before "not needed":
+    // until the preference lands we cannot tell a fresh user from a retired
+    // one, and returning `null` there would claim the user has no checklist on
+    // every first render.
+    if (!preference) return undefined;
+    if (!checklistNeeded) return null;
+    if (!accounts || !positions) return undefined;
+    return deriveChecklist({
+      // WHEN THE DEMO-DATA FLAG LANDS (`accounts.is_demo`, added by the demo
+      // seeding work later in this spec), THIS COUNT MUST EXCLUDE FLAGGED
+      // ACCOUNTS. Seeding sample data is not creating an account, so item 1
+      // stays incomplete while only demo data is present (R4.8) — and
+      // deriveChecklist deliberately never learns demo data exists, so this
+      // caller is the only place that can get it right.
+      accountCount: accounts.length,
+      positionsEverCreatedCount: positions.length,
+      closedPositionCount: positions.filter((p) => p.status === 'closed').length,
+      // Absent until the calculator is first used; the single named exception
+      // to "completion is derived", because the calculator writes nothing else.
+      calculatorFirstUsedAt: preference.calculatorFirstUsedAt,
+    });
+  }, [accounts, positions, preference, checklistNeeded]);
+
+  const { mutate } = patch;
+  const setStatus = useCallback(
+    (status: OnboardingStatus) => {
+      mutate({ status });
+    },
+    [mutate],
+  );
+  const dismiss = useCallback(() => {
+    setStatus('skipped');
+  }, [setStatus]);
+  const markCoachMarkSeen = useCallback(
+    (key: string) => {
+      mutate({ coachMarkSeen: key });
+    },
+    [mutate],
+  );
+
+  // A disabled query is neither loading nor failed, so the gated-off reads drop
+  // out of both of these on their own.
+  const isError = accountsQuery.isError || positionsQuery.isError || preferenceQuery.isError;
+
+  return {
+    checklist,
+    preference,
+    // Stated against the ANSWER rather than by OR-ing the three queries, so the
+    // pair is always coherent: `checklist === undefined` with `isError` false
+    // means loading, full stop. OR-ing would report a false gap on the render
+    // where the gate opens — the two reads are enabled but their fetches have
+    // not been kicked off yet, so every `isLoading` is momentarily false while
+    // the checklist is still `undefined`.
+    isLoading:
+      preferenceQuery.isLoading || (checklistNeeded && !isError && checklist === undefined),
+    isError,
+    isSaving: patch.isPending,
+    setStatus,
+    dismiss,
+    markCoachMarkSeen,
+  };
+}

--- a/apps/web/src/features/onboarding/lib/derive-checklist.test.ts
+++ b/apps/web/src/features/onboarding/lib/derive-checklist.test.ts
@@ -1,0 +1,322 @@
+// @vitest-environment node
+//
+// node, NOT jsdom: deriveChecklist takes primitives and returns data, so the
+// highest-value unit test in this spec must not need a browser to run. If a
+// change to the module makes this file need jsdom, the module has stopped being
+// pure and that is the bug.
+
+import { describe, expect, it } from 'vitest';
+
+import { type ChecklistInput, type ChecklistItemId, deriveChecklist } from './derive-checklist';
+
+const USED_AT = '2026-08-06T12:00:00.000Z';
+
+/** Build an input from the four completion signals, in R4.1 order. */
+function inputFor(signals: [boolean, boolean, boolean, boolean]): ChecklistInput {
+  const [account, calculator, position, close] = signals;
+  return {
+    accountCount: account ? 1 : 0,
+    calculatorFirstUsedAt: calculator ? USED_AT : undefined,
+    positionsEverCreatedCount: position ? 1 : 0,
+    closedPositionCount: close ? 1 : 0,
+  };
+}
+
+function doneFlags(input: ChecklistInput): boolean[] {
+  return deriveChecklist(input).items.map((item) => item.done);
+}
+
+describe('deriveChecklist — shape', () => {
+  it('returns exactly the four R4.1 items, in order, with stable ids and labels', () => {
+    const { items } = deriveChecklist(inputFor([false, false, false, false]));
+
+    expect(items).toHaveLength(4);
+    expect(items.map((item) => item.id)).toEqual(['account', 'calculator', 'position', 'close']);
+    expect(items.map((item) => item.label)).toEqual([
+      'Create a brokerage account',
+      'Size a trade in the calculator',
+      'Log a position',
+      'Close it and see the stats',
+    ]);
+  });
+
+  it('keeps the ids stable regardless of completion state — task 24 joins on them', () => {
+    const ids: ChecklistItemId[] = ['account', 'calculator', 'position', 'close'];
+
+    expect(deriveChecklist(inputFor([true, true, true, true])).items.map((i) => i.id)).toEqual(ids);
+    expect(deriveChecklist(inputFor([false, true, false, true])).items.map((i) => i.id)).toEqual(
+      ids,
+    );
+  });
+});
+
+describe('deriveChecklist — truth table', () => {
+  // All 16 combinations of the four signals. Each item answers only its own
+  // question, so every combination is a legitimate state — including the
+  // out-of-order ones (R4.3). The `allComplete` column is the R4.7 retirement
+  // flag.
+  const table: {
+    name: string;
+    signals: [boolean, boolean, boolean, boolean];
+    allComplete: boolean;
+  }[] = [
+    {
+      name: 'fresh user — nothing done',
+      signals: [false, false, false, false],
+      allComplete: false,
+    },
+
+    // Each item alone.
+    { name: 'account only', signals: [true, false, false, false], allComplete: false },
+    { name: 'calculator only', signals: [false, true, false, false], allComplete: false },
+    { name: 'position only', signals: [false, false, true, false], allComplete: false },
+    { name: 'closed position only', signals: [false, false, false, true], allComplete: false },
+
+    // Pairs, including out-of-order ones.
+    {
+      name: 'account + calculator (in order)',
+      signals: [true, true, false, false],
+      allComplete: false,
+    },
+    {
+      name: 'account + position, calculator skipped',
+      signals: [true, false, true, false],
+      allComplete: false,
+    },
+    {
+      name: 'account + closed position, middle skipped',
+      signals: [true, false, false, true],
+      allComplete: false,
+    },
+    {
+      name: 'calculator + position, no account',
+      signals: [false, true, true, false],
+      allComplete: false,
+    },
+    {
+      name: 'calculator + closed position, no account',
+      signals: [false, true, false, true],
+      allComplete: false,
+    },
+    {
+      name: 'position + closed position, no account (CSV import)',
+      signals: [false, false, true, true],
+      allComplete: false,
+    },
+
+    // Triples.
+    { name: 'all but the close', signals: [true, true, true, false], allComplete: false },
+    { name: 'all but the position', signals: [true, true, false, true], allComplete: false },
+    { name: 'all but the calculator', signals: [true, false, true, true], allComplete: false },
+    { name: 'all but the account', signals: [false, true, true, true], allComplete: false },
+
+    // The retirement case.
+    { name: 'all four complete', signals: [true, true, true, true], allComplete: true },
+  ];
+
+  it.each(table)('$name', ({ signals, allComplete }) => {
+    const result = deriveChecklist(inputFor(signals));
+
+    expect(result.items.map((item) => item.done)).toEqual(signals);
+    expect(result.allComplete).toBe(allComplete);
+  });
+
+  it('covers every combination of the four signals', () => {
+    expect(table).toHaveLength(16);
+    expect(new Set(table.map((row) => row.signals.join(','))).size).toBe(16);
+  });
+
+  it('is only allComplete when all four are — one gap is enough to keep it alive (R4.7)', () => {
+    const complete = table.filter((row) => row.allComplete);
+
+    expect(complete).toHaveLength(1);
+    expect(complete[0].signals).toEqual([true, true, true, true]);
+  });
+});
+
+describe('deriveChecklist — count derivation (R4.2, R4.3)', () => {
+  it('treats zero as incomplete and any positive count as complete', () => {
+    expect(
+      doneFlags({ accountCount: 0, positionsEverCreatedCount: 0, closedPositionCount: 0 }),
+    ).toEqual([false, false, false, false]);
+    expect(
+      doneFlags({ accountCount: 1, positionsEverCreatedCount: 1, closedPositionCount: 1 }),
+    ).toEqual([true, false, true, true]);
+    expect(
+      doneFlags({ accountCount: 3, positionsEverCreatedCount: 42, closedPositionCount: 17 }),
+    ).toEqual([true, false, true, true]);
+  });
+
+  it('derives from the counts alone — provenance is not an input (R4.3)', () => {
+    // Two users with identical counts: one typed every position in by hand, the
+    // other imported a CSV. There is no field here that could tell them apart,
+    // which is exactly the property R4.3 asks for.
+    const counts = { accountCount: 1, positionsEverCreatedCount: 12, closedPositionCount: 12 };
+
+    expect(deriveChecklist(counts)).toEqual(deriveChecklist({ ...counts }));
+    expect(doneFlags(counts)).toEqual([true, false, true, true]);
+  });
+
+  it('does not gate an item on the ones before it — out-of-order states are valid', () => {
+    // Closed positions but no account row: the items are independent, so item 4
+    // ticks and item 1 does not. Representable, not an error.
+    expect(
+      doneFlags({ accountCount: 0, positionsEverCreatedCount: 5, closedPositionCount: 5 }),
+    ).toEqual([false, false, true, true]);
+  });
+
+  it('keeps item 3 ticked once every position has been closed', () => {
+    // positionsEverCreatedCount counts positions ever created, NOT open ones.
+    // A user who has closed all 4 of their positions has still logged a
+    // position, so item 3 stays ticked and the checklist can retire (R4.7). If
+    // a caller ever passed an open-only count here, this user would show 0 and
+    // item 3 would un-tick itself — the reason the field is named as it is.
+    const allClosed = {
+      accountCount: 1,
+      positionsEverCreatedCount: 4,
+      closedPositionCount: 4,
+      calculatorFirstUsedAt: USED_AT,
+    };
+
+    expect(doneFlags(allClosed)).toEqual([true, true, true, true]);
+    expect(deriveChecklist(allClosed).allComplete).toBe(true);
+  });
+
+  it('leaves item 1 incomplete while only demo data is present (R4.8)', () => {
+    // Demo seeding is not creating an account, so the account count the caller
+    // passes excludes it and item 1 stays open. Nothing in here needs to know
+    // about demo data — it only ever sees the number it is given.
+    expect(
+      doneFlags({ accountCount: 0, positionsEverCreatedCount: 8, closedPositionCount: 4 })[0],
+    ).toBe(false);
+  });
+});
+
+describe('deriveChecklist — calculator timestamp (the single R4.2 exception)', () => {
+  const counts = { accountCount: 0, positionsEverCreatedCount: 0, closedPositionCount: 0 };
+
+  it('is incomplete when the key is absent — the API omits it rather than nulling it', () => {
+    expect(deriveChecklist(counts).items[1].done).toBe(false);
+  });
+
+  it('is incomplete for null and for an empty string', () => {
+    expect(deriveChecklist({ ...counts, calculatorFirstUsedAt: null }).items[1].done).toBe(false);
+    expect(deriveChecklist({ ...counts, calculatorFirstUsedAt: '' }).items[1].done).toBe(false);
+  });
+
+  it('is complete for any recorded timestamp', () => {
+    expect(deriveChecklist({ ...counts, calculatorFirstUsedAt: USED_AT }).items[1].done).toBe(true);
+    expect(
+      deriveChecklist({ ...counts, calculatorFirstUsedAt: '2020-01-01T00:00:00.000Z' }).items[1]
+        .done,
+    ).toBe(true);
+  });
+
+  it('is complete for a malformed value too — forgiving on purpose', () => {
+    // The stored value comes from a jsonb column, so junk is reachable. Item 2
+    // asks only WHETHER the calculator was used, never WHEN, so any non-empty
+    // string ticks it. Parsing strictly would strand the checklist on a bad
+    // stored value the user has no way to clear. Pinned so the posture is a
+    // decision, not an accident someone "fixes" later.
+    for (const junk of ['not-a-date', '{}', '0', 'null', '   ']) {
+      expect(deriveChecklist({ ...counts, calculatorFirstUsedAt: junk }).items[1].done).toBe(true);
+    }
+  });
+
+  it('reads the timestamp only — no count moves item 2', () => {
+    expect(
+      deriveChecklist({ accountCount: 9, positionsEverCreatedCount: 9, closedPositionCount: 9 })
+        .items[1].done,
+    ).toBe(false);
+  });
+
+  it('is the only item the timestamp moves', () => {
+    const withTimestamp = deriveChecklist({ ...counts, calculatorFirstUsedAt: USED_AT });
+
+    expect(withTimestamp.items.map((item) => item.done)).toEqual([false, true, false, false]);
+    expect(withTimestamp.allComplete).toBe(false);
+  });
+});
+
+describe('deriveChecklist — nonsense counts stay harmless', () => {
+  // The function is total: it validates nothing and throws nothing, because a
+  // checklist is a nudge and bad input should degrade to an un-ticked item
+  // rather than an error the user cannot get past. These tests pin that
+  // behaviour so a later refactor cannot quietly turn it into a throw or a
+  // silently-ticked item.
+
+  it('treats a negative count as not positive', () => {
+    expect(
+      doneFlags({ accountCount: -1, positionsEverCreatedCount: -5, closedPositionCount: -1 }),
+    ).toEqual([false, false, false, false]);
+  });
+
+  it('treats NaN as not positive', () => {
+    expect(
+      doneFlags({
+        accountCount: Number.NaN,
+        positionsEverCreatedCount: Number.NaN,
+        closedPositionCount: Number.NaN,
+      }),
+    ).toEqual([false, false, false, false]);
+  });
+
+  it('accepts more closed positions than were ever created without complaint', () => {
+    // Impossible in real data, but the two counts are read independently and
+    // never compared, so this is representable rather than an error.
+    expect(
+      doneFlags({ accountCount: 1, positionsEverCreatedCount: 1, closedPositionCount: 9 }),
+    ).toEqual([true, false, true, true]);
+  });
+
+  it('never throws on any of them', () => {
+    expect(() =>
+      deriveChecklist({
+        accountCount: Number.NaN,
+        positionsEverCreatedCount: -1,
+        closedPositionCount: Number.POSITIVE_INFINITY,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe('deriveChecklist — purity', () => {
+  it('runs with no DOM at all', () => {
+    // Pins the docblock at the top of this file. If someone drops the node
+    // environment override, or the module starts reaching for a browser API,
+    // this fails rather than silently passing under jsdom.
+    expect(typeof globalThis.document).toBe('undefined');
+    expect(typeof globalThis.window).toBe('undefined');
+  });
+
+  it('does not mutate its input', () => {
+    const input: ChecklistInput = {
+      accountCount: 1,
+      positionsEverCreatedCount: 1,
+      closedPositionCount: 0,
+      calculatorFirstUsedAt: USED_AT,
+    };
+
+    deriveChecklist(input);
+
+    expect(input).toEqual({
+      accountCount: 1,
+      positionsEverCreatedCount: 1,
+      closedPositionCount: 0,
+      calculatorFirstUsedAt: USED_AT,
+    });
+  });
+
+  it('returns an equal result for equal input, and a fresh array each call', () => {
+    const input: ChecklistInput = {
+      accountCount: 1,
+      positionsEverCreatedCount: 0,
+      closedPositionCount: 0,
+    };
+    const first = deriveChecklist(input);
+    const second = deriveChecklist(input);
+
+    expect(first).toEqual(second);
+    expect(first.items).not.toBe(second.items);
+  });
+});

--- a/apps/web/src/features/onboarding/lib/derive-checklist.ts
+++ b/apps/web/src/features/onboarding/lib/derive-checklist.ts
@@ -1,0 +1,123 @@
+/**
+ * The activation checklist's completion rules — the ONLY place they are stated.
+ *
+ * R4.2: an item's completed state is DERIVED from the user's actual data, never
+ * read from a stored per-step flag. That is why this takes plain primitives and
+ * not a query result, a hook, or a server response: there is nothing to keep in
+ * sync, nothing to reconcile, and nothing that can drift out of agreement with
+ * reality. Resumability across sessions and devices (R4.4) falls out of the same
+ * property for free — the counts are the same counts on every device.
+ *
+ * R4.3: completion is reachable by ANY route. The counts alone decide, so a
+ * position created by CSV import, an account created outside the walkthrough, or
+ * a trade closed months before onboarding shipped all tick their item. Nothing
+ * here may ever filter by HOW the data arrived.
+ *
+ * Keep this module pure: no React, no TanStack Query, no fetch, no DOM. Its test
+ * runs under the node environment precisely to prove that.
+ */
+
+/**
+ * Stable per-item identity. Task 24 wires a per-item action to the matching
+ * walkthrough step set (`lib/steps/{account,calculator,position,close}.ts`), so
+ * these ids are the join between the two and must not be renamed casually.
+ */
+export type ChecklistItemId = 'account' | 'calculator' | 'position' | 'close';
+
+export interface ChecklistItem {
+  id: ChecklistItemId;
+  /** Sentence-case label, in the words the UI itself uses (R4.1). */
+  label: string;
+  done: boolean;
+}
+
+export interface ChecklistInput {
+  /**
+   * How many brokerage accounts the user has. Demo data is not an account the
+   * user created, so the caller excludes it (R4.8).
+   */
+  accountCount: number;
+  /**
+   * How many positions the user has EVER created — open and closed alike, in
+   * every account. It must NOT be filtered by status. Item 3 asks whether the
+   * user has ever logged a position, and that fact cannot become untrue later:
+   * an open-only count would un-tick item 3 the moment the user closed their
+   * last position, and a user who had closed everything could never reach
+   * `allComplete`, so the checklist would never retire (R4.7). The name says
+   * "ever created" so a caller holding a status-filtered count — the web app's
+   * `usePositions({ status })` returns one — cannot pass it here by accident.
+   */
+  positionsEverCreatedCount: number;
+  /**
+   * How many of the user's positions are currently closed. This one IS a
+   * status-filtered count; that is exactly what item 4 asks. It stands on its
+   * own — no relationship to `positionsEverCreatedCount` is assumed or checked.
+   */
+  closedPositionCount: number;
+  /**
+   * The single named R4.2 exception. The calculator is stateless — it computes
+   * and returns, writing no row — so item 2 has no other data trace. This is a
+   * timestamp recording a fact, not a completion flag; absent (or null) means
+   * the calculator has not been used. The API OMITS the key rather than sending
+   * null, hence the optional as well as the null.
+   *
+   * Any non-empty string counts as used, malformed ones included. That is a
+   * deliberate choice, not an oversight: the value is stored in a jsonb column,
+   * so junk is genuinely reachable, and parsing it strictly would strand the
+   * user's checklist on a bad stored value with no way for them to clear it.
+   * Item 2 only asks WHETHER the calculator was used, never WHEN, so the
+   * forgiving read cannot get the question it actually answers wrong.
+   */
+  calculatorFirstUsedAt?: string | null;
+}
+
+export interface Checklist {
+  /** Exactly four items, in the R4.1 order. */
+  items: ChecklistItem[];
+  /** R4.7 — when this is true the checklist retires. The UI decides how. */
+  allComplete: boolean;
+}
+
+/**
+ * Derive the four-item activation checklist from the user's data.
+ *
+ * The items are INDEPENDENT, not sequential. The requirements never say the
+ * order must be obeyed, and R4.3 explicitly allows any route in, so an
+ * out-of-order state — positions imported by CSV before the user ever opened
+ * the calculator, say — is a legitimate state that must be representable rather
+ * than treated as invalid. No item gates on the one before it; each answers
+ * only its own question. The order in the array is presentation order (R4.1),
+ * not a dependency chain.
+ *
+ * Total and forgiving: it validates nothing and throws nothing. A count is read
+ * as `> 0` and nothing else, so a negative or NaN count is simply not positive
+ * and leaves its item untouched, and the two position counts are never compared
+ * with each other. A checklist is a nudge — bad input should degrade to an
+ * un-ticked item, never to an error the user cannot get past.
+ */
+export function deriveChecklist(input: ChecklistInput): Checklist {
+  const items: ChecklistItem[] = [
+    {
+      id: 'account',
+      label: 'Create a brokerage account',
+      done: input.accountCount > 0,
+    },
+    {
+      id: 'calculator',
+      label: 'Size a trade in the calculator',
+      done: Boolean(input.calculatorFirstUsedAt),
+    },
+    {
+      id: 'position',
+      label: 'Log a position',
+      done: input.positionsEverCreatedCount > 0,
+    },
+    {
+      id: 'close',
+      label: 'Close it and see the stats',
+      done: input.closedPositionCount > 0,
+    },
+  ];
+
+  return { items, allComplete: items.every((item) => item.done) };
+}

--- a/apps/web/src/features/positions/hooks/usePositions.ts
+++ b/apps/web/src/features/positions/hooks/usePositions.ts
@@ -43,7 +43,16 @@ export function handleCreatePositionError(
   showToast(msg || 'Failed to create position');
 }
 
-export function usePositions(filters?: { status?: string; accountId?: string }) {
+/**
+ * `GET /positions` has no LIMIT and returns every enriched row, so it is the
+ * most expensive list the app fetches. `options.enabled` lets a caller that may
+ * not need it at all skip the request entirely; omitted, it fetches as before.
+ * A disabled query reports `data: undefined`, `isLoading: false`, `isError: false`.
+ */
+export function usePositions(
+  filters?: { status?: string; accountId?: string },
+  options?: { enabled?: boolean },
+) {
   const params = new URLSearchParams();
   if (filters?.status) params.set('status', filters.status);
   if (filters?.accountId) params.set('accountId', filters.accountId);
@@ -52,6 +61,7 @@ export function usePositions(filters?: { status?: string; accountId?: string }) 
   return useQuery<PositionListItem[]>({
     queryKey: ['positions', 'list', filters],
     queryFn: () => api.get<PositionListItem[]>(`/positions${query ? `?${query}` : ''}`),
+    enabled: options?.enabled,
   });
 }
 

--- a/apps/web/src/routes/_auth.dashboard.test.tsx
+++ b/apps/web/src/routes/_auth.dashboard.test.tsx
@@ -38,9 +38,60 @@ vi.mock('@tradr/shared', async () => {
   };
 });
 
+// ---- Zero-state mocks (Req 3) ----------------------------------------------
+//
+// The route now composes two more reads before it decides what to show. Both
+// are faked here, but NOT identically:
+//
+// `useAccounts` is discriminated on its ARGUMENT. Only the route passes an
+// options object (`{ enabled }`); the widget call sites inside the grid —
+// AccountBalancesWidget, CrossCurrencyTotal — pass none. So the mock hands the
+// route a controllable knob while handing the widgets exactly what they saw in
+// this file before the zero-state existed: a failed read, hence their skeleton.
+// That is what makes "the existing branches behave as before" (Req 3.5) a
+// literal claim about these tests rather than an approximate one.
+//
+// `useOnboarding` is faked wholesale rather than only `useOnboardingQuery`,
+// because ZeroState and the ActivationChecklist inside it both read the real
+// hook. Neither is stubbed: whether a `skipped` user still reaches the reopen
+// control is a claim about the COMPOSED screen, and a stubbed checklist would
+// let that claim pass while the real one rendered nothing.
+type AccountsResult = { data: unknown[] | undefined; isLoading: boolean; isError: boolean };
+let accountsMock: AccountsResult = { data: [], isLoading: false, isError: false };
+vi.mock('@/features/accounts/hooks/useAccounts', () => ({
+  useAccounts: (options?: { enabled?: boolean }): AccountsResult => {
+    if (options === undefined) return { data: undefined, isLoading: false, isError: true };
+    // The real hook reports `data: undefined` for a disabled query.
+    if (options.enabled === false) return { data: undefined, isLoading: false, isError: false };
+    return accountsMock;
+  },
+}));
+
+let onboardingQueryMock: {
+  data: OnboardingState | undefined;
+  isLoading: boolean;
+  isError: boolean;
+};
+let onboardingMock: UseOnboardingResult;
+vi.mock('@/features/onboarding/hooks/useOnboarding', () => ({
+  useOnboardingQuery: () => onboardingQueryMock,
+  useOnboarding: () => onboardingMock,
+}));
+
+// Same stub AccountList.test.tsx and ZeroState.test.tsx use: it pulls in
+// brokerages, tier state and the API client, none of which this route's
+// branching depends on.
+vi.mock('@/features/accounts/components/AccountDialog', () => ({
+  AccountDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="account-dialog" /> : null,
+}));
+
 import { toast } from 'sonner';
 import { uuidv5Batch, DEFAULT_WIDGETS } from '@tradr/shared';
+import type { OnboardingState, OnboardingStatus } from '@tradr/shared';
 import { TooltipProvider } from '@/components/ui/tooltip';
+import type { UseOnboardingResult } from '@/features/onboarding/hooks/useOnboarding';
+import { deriveChecklist } from '@/features/onboarding/lib/derive-checklist';
 import { Route } from './_auth.dashboard';
 
 const DashboardPage = Route.options.component as () => React.ReactElement;
@@ -58,13 +109,17 @@ function makeQueryClient() {
 
 function renderRoute() {
   const qc = makeQueryClient();
-  return render(
+  // A fresh element each time, on the SAME client: `rerenderRoute` has to model
+  // a data change arriving at a mounted tree, so nothing may remount.
+  const tree = () => (
     <QueryClientProvider client={qc}>
       <TooltipProvider>
         <DashboardPage />
       </TooltipProvider>
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
+  const result = render(tree());
+  return { ...result, rerenderRoute: () => result.rerender(tree()) };
 }
 
 const sixDefaultWidgets: WidgetPlacement[] = DEFAULT_WIDGETS.map((d, i) => ({
@@ -91,11 +146,62 @@ function baseLayout(overrides: Partial<Record<string, unknown>> = {}) {
   };
 }
 
+/**
+ * Point the two onboarding reads at one status. `undefined` means the cheap
+ * preference read has not landed yet.
+ *
+ * The derived `checklist` MIRRORS the real hook's three values rather than
+ * always handing back a checklist, because the route now mounts
+ * `ActivationChecklist` on the populated and empty-layout branches and the
+ * component branches on all three: `undefined` while the status is unknown,
+ * `null` for a `done` or `skipped` user (the reads it would need were never
+ * issued), a `Checklist` otherwise. A mock that returned four unticked boxes for
+ * a retired user would let a regression pass here that the product would show.
+ */
+function setOnboarding(
+  status: OnboardingStatus | undefined,
+  over: Partial<UseOnboardingResult> = {},
+) {
+  const preference: OnboardingState | undefined =
+    status === undefined ? undefined : { status, coachMarksSeen: [] };
+  onboardingQueryMock = {
+    data: preference,
+    isLoading: preference === undefined,
+    isError: false,
+  };
+  const checklistNeeded = status === 'pending' || status === 'active';
+  onboardingMock = {
+    checklist:
+      preference === undefined
+        ? undefined
+        : checklistNeeded
+          ? deriveChecklist({
+              accountCount: 0,
+              positionsEverCreatedCount: 0,
+              closedPositionCount: 0,
+            })
+          : null,
+    preference,
+    isLoading: false,
+    isError: false,
+    isSaving: false,
+    setStatus: vi.fn(),
+    dismiss: vi.fn(),
+    markCoachMarkSeen: vi.fn(),
+    ...over,
+  };
+}
+
 let fetchSpy: MockInstance | null = null;
 
 beforeEach(() => {
   vi.mocked(toast.error).mockClear();
   vi.mocked(uuidv5Batch).mockClear();
+  // Cases 1-7 predate the zero-state and must keep behaving exactly as they
+  // did, so the default user is one whose onboarding has RETIRED — the gate
+  // short-circuits before it ever looks at the account count.
+  setOnboarding('done');
+  accountsMock = { data: [], isLoading: false, isError: false };
   fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(null, { status: 200 }));
 });
 
@@ -259,5 +365,384 @@ describe('_auth.dashboard route', () => {
       return init?.keepalive === true;
     });
     expect(keepaliveCalls.length).toBe(0);
+  });
+});
+
+// ---- Zero state (Req 3) ----------------------------------------------------
+
+describe('_auth.dashboard route — the zero-state gate', () => {
+  const populated = {
+    widgets: sixDefaultWidgets,
+    theme: 'light',
+    updatedAt: '2026-05-01T00:00:00.000Z',
+  };
+  const emptyLayout = { widgets: [], theme: 'light', updatedAt: '2026-05-01T00:00:00.000Z' };
+  const oneAccount = [{ id: 'acct-1' }];
+
+  it('Req 3.1: a fresh user gets the zero-state instead of six empty widgets', () => {
+    // The layout is fully populated, so without the gate this user would be
+    // looking at the grid — which is exactly the screen Req 3 exists to replace.
+    layoutMockValue = baseLayout({ data: populated });
+    setOnboarding('pending');
+    accountsMock = { data: [], isLoading: false, isError: false };
+    const { container } = renderRoute();
+    expect(screen.getByTestId('onboarding-zero-state')).toBeTruthy();
+    expect(container.querySelector('[data-widget-id]')).toBeNull();
+    expect(container.querySelector('[data-slot="dashboard-skeleton"]')).toBeNull();
+  });
+
+  it('Req 3.5: the zero-state takes precedence over the empty-layout state', () => {
+    layoutMockValue = baseLayout({ data: emptyLayout });
+    setOnboarding('pending');
+    accountsMock = { data: [], isLoading: false, isError: false };
+    renderRoute();
+    expect(screen.getByTestId('onboarding-zero-state')).toBeTruthy();
+    expect(screen.queryByText('Your dashboard is empty')).toBeNull();
+  });
+
+  it('Req 3.4: creating the first account swaps to the grid with no reload', async () => {
+    // `useCreateAccount` invalidates ['accounts'] and the route observes
+    // ['accounts', 'list'], so a real create produces exactly this data change.
+    // What is pinned here is the route's reaction to it: the SAME mounted tree
+    // re-renders into the grid — nothing is remounted and no reload happens.
+    layoutMockValue = baseLayout({ data: populated });
+    setOnboarding('pending');
+    accountsMock = { data: [], isLoading: false, isError: false };
+    const { container, rerenderRoute } = renderRoute();
+    expect(screen.getByTestId('onboarding-zero-state')).toBeTruthy();
+
+    accountsMock = { data: oneAccount, isLoading: false, isError: false };
+    rerenderRoute();
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-widget-id]').length).toBeGreaterThanOrEqual(6);
+    });
+    expect(screen.queryByTestId('onboarding-zero-state')).toBeNull();
+  });
+
+  it('a user who already has an account never sees the zero-state', () => {
+    layoutMockValue = baseLayout({ data: emptyLayout });
+    setOnboarding('pending');
+    accountsMock = { data: oneAccount, isLoading: false, isError: false };
+    renderRoute();
+    expect(screen.queryByTestId('onboarding-zero-state')).toBeNull();
+    expect(screen.getByText('Your dashboard is empty')).toBeTruthy();
+  });
+
+  it('Req 3.6: a retired user with zero accounts gets the empty layout, not the zero-state', () => {
+    // The returning user who deleted every account. `done` is the whole reason
+    // the stored status exists — the account count alone cannot tell them apart
+    // from someone who registered a minute ago.
+    layoutMockValue = baseLayout({ data: emptyLayout });
+    setOnboarding('done');
+    accountsMock = { data: [], isLoading: false, isError: false };
+    renderRoute();
+    expect(screen.queryByTestId('onboarding-zero-state')).toBeNull();
+    expect(screen.getByText('Your dashboard is empty')).toBeTruthy();
+  });
+
+  it('Req 3.6/4.5: a SKIPPED user with zero accounts still gets the zero-state, and with it the reopen control', () => {
+    // The trap this gate is most likely to fall into. Retiring on
+    // `done || skipped` would look harmless — but ActivationChecklist's
+    // "Reopen setup checklist" row is the only way back from a dismissal
+    // anywhere in the product, and the zero-state is the only screen that
+    // mounts the checklist. Gate on `skipped` too and dismissal stops being
+    // recoverable, with nothing in the checklist's own tests to notice.
+    layoutMockValue = baseLayout({ data: emptyLayout });
+    setOnboarding('skipped', { checklist: null });
+    accountsMock = { data: [], isLoading: false, isError: false };
+    renderRoute();
+    expect(screen.getByTestId('onboarding-zero-state')).toBeTruthy();
+    expect(screen.getByTestId('activation-checklist-reopen')).toBeTruthy();
+  });
+
+  it('no flash: holds the skeleton rather than showing the grid while the status is unknown', () => {
+    // An established user must not see the zero-state for a beat, and a brand
+    // new one must not see the grid. Neither can be decided until the status
+    // has landed, so the route stays on the skeleton it is already showing.
+    layoutMockValue = baseLayout({ data: populated });
+    setOnboarding(undefined);
+    accountsMock = { data: oneAccount, isLoading: false, isError: false };
+    const { container } = renderRoute();
+    expect(container.querySelector('[data-slot="dashboard-skeleton"]')).not.toBeNull();
+    expect(container.querySelector('[data-widget-id]')).toBeNull();
+    expect(screen.queryByTestId('onboarding-zero-state')).toBeNull();
+  });
+
+  it('no flash: holds the skeleton rather than showing the zero-state while the accounts read is in flight', () => {
+    layoutMockValue = baseLayout({ data: populated });
+    setOnboarding('pending');
+    accountsMock = { data: undefined, isLoading: true, isError: false };
+    const { container } = renderRoute();
+    expect(container.querySelector('[data-slot="dashboard-skeleton"]')).not.toBeNull();
+    expect(screen.queryByTestId('onboarding-zero-state')).toBeNull();
+  });
+
+  it('a failed onboarding read falls through to the dashboard instead of parking on the skeleton', () => {
+    layoutMockValue = baseLayout({ data: emptyLayout });
+    setOnboarding(undefined);
+    onboardingQueryMock = { data: undefined, isLoading: false, isError: true };
+    accountsMock = { data: [], isLoading: false, isError: false };
+    const { container } = renderRoute();
+    expect(container.querySelector('[data-slot="dashboard-skeleton"]')).toBeNull();
+    expect(screen.getByText('Your dashboard is empty')).toBeTruthy();
+  });
+
+  it('a failed accounts read falls through to the dashboard too', () => {
+    layoutMockValue = baseLayout({ data: emptyLayout });
+    setOnboarding('pending');
+    accountsMock = { data: undefined, isLoading: false, isError: true };
+    const { container } = renderRoute();
+    expect(container.querySelector('[data-slot="dashboard-skeleton"]')).toBeNull();
+    expect(screen.getByText('Your dashboard is empty')).toBeTruthy();
+  });
+
+  it('Req 3.5: the isLoading and isError branches are unchanged by the gate', () => {
+    // Both sit ahead of the zero-state, so they must win even for the user the
+    // zero-state is for.
+    layoutMockValue = baseLayout({ isLoading: true });
+    setOnboarding('pending');
+    accountsMock = { data: [], isLoading: false, isError: false };
+    const first = renderRoute();
+    expect(first.container.querySelector('[data-slot="dashboard-skeleton"]')).not.toBeNull();
+    expect(screen.queryByTestId('onboarding-zero-state')).toBeNull();
+    cleanup();
+
+    layoutMockValue = baseLayout({ isError: true });
+    renderRoute();
+    expect(screen.getByText("Couldn't load your dashboard")).toBeTruthy();
+    expect(screen.queryByTestId('onboarding-zero-state')).toBeNull();
+  });
+});
+
+// ---- The checklist beyond the zero-state (Req 4) ----------------------------
+//
+// `ZeroState` mounts `ActivationChecklist` itself, and for a while that was the
+// checklist's ONLY home — which meant it disappeared from the product the
+// instant the user created their first account. Items 2-4 became invisible
+// exactly when they were the outstanding work; R4.5's reopen row became
+// unreachable; and R4.7's retirement could never fire, so the status never
+// reached `done` and the gated reads never switched off. These cases pin the
+// mount on the two branches a user with accounts actually lands on.
+
+describe('_auth.dashboard route — the activation checklist beyond the zero-state', () => {
+  const populated = {
+    widgets: sixDefaultWidgets,
+    theme: 'light',
+    updatedAt: '2026-05-01T00:00:00.000Z',
+  };
+  const emptyLayout = { widgets: [], theme: 'light', updatedAt: '2026-05-01T00:00:00.000Z' };
+  const oneAccount = [{ id: 'acct-1' }];
+  const allDone = deriveChecklist({
+    accountCount: 1,
+    positionsEverCreatedCount: 1,
+    closedPositionCount: 1,
+    calculatorFirstUsedAt: '2026-05-01T00:00:00.000Z',
+  });
+
+  it('R4: a user with an account and pending onboarding sees the checklist ABOVE the grid', async () => {
+    layoutMockValue = baseLayout({ data: populated });
+    setOnboarding('pending');
+    accountsMock = { data: oneAccount, isLoading: false, isError: false };
+    const { container } = renderRoute();
+
+    const checklist = screen.getByTestId('activation-checklist');
+    // Items 2-4 are the outstanding work for this user, so they must be on
+    // screen — that is the whole point of mounting past the zero-state.
+    expect(screen.getByText('Size a trade in the calculator')).toBeTruthy();
+    expect(screen.getByText('Log a position')).toBeTruthy();
+    expect(screen.getByText('Close it and see the stats')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-grid-mode]')).not.toBeNull();
+    });
+    const grid = container.querySelector('[data-grid-mode]')!;
+    // Above the grid, not merely present somewhere on the page.
+    expect(checklist.compareDocumentPosition(grid) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('R4: the empty-layout branch mounts it too, and keeps its own empty state', () => {
+    layoutMockValue = baseLayout({ data: emptyLayout });
+    setOnboarding('pending');
+    accountsMock = { data: oneAccount, isLoading: false, isError: false };
+    renderRoute();
+    expect(screen.getByTestId('activation-checklist')).toBeTruthy();
+    // The branch itself is untouched (Req 3.5).
+    expect(screen.getByText('Your dashboard is empty')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Use the default layout/i })).toBeTruthy();
+  });
+
+  it('a retired (done) user with accounts sees no checklist and no reserved space', () => {
+    layoutMockValue = baseLayout({ data: populated });
+    setOnboarding('done');
+    accountsMock = { data: oneAccount, isLoading: false, isError: false };
+    const { container } = renderRoute();
+    expect(screen.queryByTestId('activation-checklist')).toBeNull();
+    expect(screen.queryByTestId('activation-checklist-loading')).toBeNull();
+    expect(screen.queryByTestId('activation-checklist-reopen')).toBeNull();
+    // The slot is present but EMPTY, and `empty:hidden` is what keeps it out of
+    // the flow. Without it the wrapper would still count as a child of the
+    // surrounding `space-y-*` and open a permanent gap between the header and
+    // the grid — for the majority of users, who are exactly the ones this
+    // branch is for.
+    const slot = container.querySelector('[data-slot="activation-checklist-slot"]')!;
+    expect(slot).not.toBeNull();
+    expect(slot.childNodes.length).toBe(0);
+    expect(slot.className).toContain('empty:hidden');
+  });
+
+  it('R4.5: a SKIPPED user with accounts still reaches the reopen row — dismissal stays recoverable', () => {
+    // Before the checklist had a home here, creating the first account deleted
+    // the product's only way back from a dismissal.
+    layoutMockValue = baseLayout({ data: populated });
+    setOnboarding('skipped');
+    accountsMock = { data: oneAccount, isLoading: false, isError: false };
+    renderRoute();
+    expect(screen.getByTestId('activation-checklist-reopen')).toBeTruthy();
+    expect(screen.queryByTestId('activation-checklist')).toBeNull();
+  });
+
+  it('R4.7: completing all four items retires the checklist and writes `done` once', async () => {
+    // Reachable ONLY from this mount: items 2-4 cannot be completed by a user
+    // who still qualifies for the zero-state, so retirement could never fire
+    // while the zero-state was the checklist's only home — and with it the read
+    // gate that turns the accounts and positions queries off stayed open.
+    const setStatus = vi.fn();
+    layoutMockValue = baseLayout({ data: populated });
+    setOnboarding('active', { checklist: allDone, setStatus });
+    accountsMock = { data: oneAccount, isLoading: false, isError: false };
+    renderRoute();
+    await waitFor(() => {
+      expect(setStatus).toHaveBeenCalledWith('done');
+    });
+    expect(setStatus).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('activation-checklist')).toBeNull();
+  });
+
+  it('no flash: nothing is rendered when the route falls through with the status still unknown', () => {
+    // The route normally holds the skeleton until the preference lands, so this
+    // branch is only reachable via a failed read — and there the checklist must
+    // occupy no space rather than paint a card an established user then loses.
+    layoutMockValue = baseLayout({ data: populated });
+    setOnboarding(undefined);
+    onboardingQueryMock = { data: undefined, isLoading: false, isError: true };
+    accountsMock = { data: oneAccount, isLoading: false, isError: false };
+    const { container } = renderRoute();
+    expect(container.querySelector('[data-slot="dashboard-skeleton"]')).toBeNull();
+    expect(screen.queryByTestId('activation-checklist')).toBeNull();
+    expect(screen.queryByTestId('activation-checklist-loading')).toBeNull();
+  });
+
+  it('Req 3.5: the loading, error and zero-state branches mount no checklist of their own', () => {
+    layoutMockValue = baseLayout({ isLoading: true });
+    setOnboarding('pending');
+    accountsMock = { data: oneAccount, isLoading: false, isError: false };
+    const first = renderRoute();
+    expect(first.container.querySelector('[data-slot="dashboard-skeleton"]')).not.toBeNull();
+    expect(screen.queryByTestId('activation-checklist')).toBeNull();
+    cleanup();
+
+    layoutMockValue = baseLayout({ isError: true });
+    renderRoute();
+    expect(screen.getByText("Couldn't load your dashboard")).toBeTruthy();
+    expect(screen.queryByTestId('activation-checklist')).toBeNull();
+    cleanup();
+
+    // And the zero-state is not double-mounted: ZeroState composes the checklist
+    // itself, so exactly one must be on screen there.
+    layoutMockValue = baseLayout({ data: populated });
+    accountsMock = { data: [], isLoading: false, isError: false };
+    renderRoute();
+    expect(screen.getByTestId('onboarding-zero-state')).toBeTruthy();
+    expect(screen.getAllByTestId('activation-checklist')).toHaveLength(1);
+  });
+});
+
+// ---- The checklist slot's reserved geometry --------------------------------
+//
+// `ActivationChecklist` paints a four-row card skeleton while its derived reads
+// are in flight, and that skeleton is 28px SHORTER than the card that replaces
+// it (210px vs 238px — the arithmetic is on `ChecklistSlot`). Mounted bare above
+// the widget grid, the swap dropped the whole grid by that much, once per load,
+// for every user still mid-onboarding — the layout jump `visual-design` R4.4
+// forbids of a loading state. The checklist is correct and untouched; the slot
+// it mounts into reserves the settled height.
+//
+// jsdom computes no layout, so these cases pin the two things it CAN see: the
+// reservation is declared against the skeleton's own test id, and the skeleton
+// and the settled card occupy ONE element — a reservation on a box that is
+// replaced rather than refilled would reserve nothing.
+
+describe('_auth.dashboard route — the checklist slot reserves its height', () => {
+  const populated = {
+    widgets: sixDefaultWidgets,
+    theme: 'light',
+    updatedAt: '2026-05-01T00:00:00.000Z',
+  };
+  const emptyLayout = { widgets: [], theme: 'light', updatedAt: '2026-05-01T00:00:00.000Z' };
+  const oneAccount = [{ id: 'acct-1' }];
+  const someChecklist = deriveChecklist({
+    accountCount: 1,
+    positionsEverCreatedCount: 0,
+    closedPositionCount: 0,
+  });
+
+  // The settled card's outer height. If the card's rows, padding or header
+  // change, this and `ChecklistSlot`'s class change together — that is what this
+  // constant is for.
+  const RESERVED = 'has-data-[testid=activation-checklist-loading]:min-h-[238px]';
+
+  it('reserves the settled card height while the skeleton is up, on the same element that then holds the card', () => {
+    layoutMockValue = baseLayout({ data: populated });
+    // Preference landed, gated reads still in flight: the one window in which
+    // the skeleton is on screen.
+    setOnboarding('pending', { checklist: undefined });
+    accountsMock = { data: oneAccount, isLoading: false, isError: false };
+    const { container, rerenderRoute } = renderRoute();
+
+    const slot = container.querySelector('[data-slot="activation-checklist-slot"]')!;
+    expect(slot).not.toBeNull();
+    expect(slot.contains(screen.getByTestId('activation-checklist-loading'))).toBe(true);
+    expect(slot.className).toContain(RESERVED);
+
+    // The positions read lands and the card replaces the skeleton.
+    setOnboarding('pending', { checklist: someChecklist });
+    rerenderRoute();
+
+    expect(screen.queryByTestId('activation-checklist-loading')).toBeNull();
+    // SAME node — the card refills the reserved box rather than replacing it,
+    // which is the only arrangement in which reserving anything helps.
+    const after = container.querySelector('[data-slot="activation-checklist-slot"]')!;
+    expect(after).toBe(slot);
+    expect(after.contains(screen.getByTestId('activation-checklist'))).toBe(true);
+  });
+
+  it('reserves on the empty-layout branch too — the same skeleton mounts there', () => {
+    layoutMockValue = baseLayout({ data: emptyLayout });
+    setOnboarding('pending', { checklist: undefined });
+    accountsMock = { data: oneAccount, isLoading: false, isError: false };
+    const { container } = renderRoute();
+
+    const slot = container.querySelector('[data-slot="activation-checklist-slot"]')!;
+    expect(slot).not.toBeNull();
+    expect(slot.contains(screen.getByTestId('activation-checklist-loading'))).toBe(true);
+    expect(slot.className).toContain(RESERVED);
+    // And the branch's own content is unchanged (Req 3.5).
+    expect(screen.getByText('Your dashboard is empty')).toBeTruthy();
+  });
+
+  it('does not reintroduce the flash of four unticked boxes', () => {
+    // The reservation must not tempt anyone into rendering the card early to
+    // fill it. While the reads are in flight the user sees a skeleton and the
+    // four item labels are nowhere on screen.
+    layoutMockValue = baseLayout({ data: populated });
+    setOnboarding('pending', { checklist: undefined });
+    accountsMock = { data: oneAccount, isLoading: false, isError: false };
+    renderRoute();
+
+    expect(screen.getByTestId('activation-checklist-loading')).toBeTruthy();
+    expect(screen.queryByTestId('activation-checklist')).toBeNull();
+    expect(screen.queryByText('Create a brokerage account')).toBeNull();
+    expect(screen.queryByText('Log a position')).toBeNull();
   });
 });

--- a/apps/web/src/routes/_auth.dashboard.tsx
+++ b/apps/web/src/routes/_auth.dashboard.tsx
@@ -11,11 +11,15 @@ import {
 import { EmptyState } from '@/components/EmptyState';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useAccounts } from '@/features/accounts/hooks/useAccounts';
 import { DashboardGrid } from '@/features/dashboard/components/DashboardGrid';
 import { DashboardHeader } from '@/features/dashboard/components/DashboardHeader';
 import { GRID_COLUMNS } from '@/features/dashboard/grid.constants';
 import { useDashboardLayout } from '@/features/dashboard/hooks/useDashboardLayout';
 import { findFirstSlot } from '@/features/dashboard/layout';
+import { ActivationChecklist } from '@/features/onboarding/components/ActivationChecklist';
+import { ZeroState } from '@/features/onboarding/components/ZeroState';
+import { useOnboardingQuery } from '@/features/onboarding/hooks/useOnboarding';
 import { useAuth } from '@/hooks/useAuth';
 
 /**
@@ -75,11 +79,89 @@ function ReadOnlyDefaultLayout(): ReactElement {
   );
 }
 
+/**
+ * The checklist's mount slot on the populated and empty-layout branches.
+ *
+ * WHY A SLOT AND NOT A BARE MOUNT. `ActivationChecklist` paints a four-row card
+ * skeleton while its derived reads are in flight, and the skeleton is SHORTER
+ * than the card that replaces it — so on the primary screen the widget grid
+ * dropped by the difference, once per load, for every user still mid-onboarding.
+ * The design system forbids exactly that ("no layout jump between loading →
+ * empty → loaded", visual-design R4.4). The checklist itself is correct and is
+ * left alone; the geometry is the mount site's problem, and this is the mount
+ * site.
+ *
+ * THE RESERVATION IS DRIVEN BY WHAT ACTUALLY RENDERED, via `:has()` on the
+ * skeleton's own test id, rather than by re-deciding here which users get a
+ * checklist. That matters twice over: nothing in this file restates the
+ * component's rules (a second copy of them is a second thing to get wrong), and
+ * the space is reserved ONLY while the skeleton is on screen — not for a retired
+ * user who renders nothing, and not for the beat between the last item being
+ * ticked and `status: 'done'` landing, where a status-driven reservation would
+ * leave an empty box behind.
+ *
+ * 238px is the settled card's outer height, and it is arithmetic, not a guess:
+ * 1px border + 16px (`py-4`) + 44px header (16px `text-base leading-none` title
+ * + 8px `gap-2` + 20px `text-sm` description) + 16px (`gap-4`) + 144px content
+ * (4 items × `min-h-9`) + 16px + 1px. The skeleton comes to 210px by the same
+ * sum, hence the 28px it was short by. If the card's rows, padding or header
+ * change, this number changes with them — `_auth.dashboard.test.tsx` pins it so
+ * the pair cannot drift silently.
+ *
+ * `empty:hidden` is not cosmetic. The checklist renders nothing at all for a
+ * `done` user — the majority — and a wrapper that stayed in the flow would count
+ * as a child of the surrounding `space-y-*`, adding a permanent gap of dead
+ * space between the header and the grid that was not there before.
+ */
+function ChecklistSlot(): ReactElement {
+  return (
+    <div
+      data-slot="activation-checklist-slot"
+      className="empty:hidden has-data-[testid=activation-checklist-loading]:min-h-[238px]"
+    >
+      <ActivationChecklist />
+    </div>
+  );
+}
+
 function DashboardPage(): ReactElement {
   const { user } = useAuth();
   const userId = user?.id ?? '';
   const layout = useDashboardLayout();
   const { data, isLoading, isError, refetch, flushPending, scheduleLayoutWrite } = layout;
+
+  // ===========================================================================
+  // THE ZERO-STATE GATE (Req 3.1, 3.4, 3.6).
+  //
+  // A user with no accounts gets a screen that tells them what to do instead of
+  // six widgets that are each individually empty for a different reason.
+  //
+  // TWO READS, NOT THREE. `useOnboardingQuery` is the CHEAP preference read; the
+  // full `useOnboarding` hook additionally pulls the whole unfiltered positions
+  // list down to count it, and this route has no use for a checklist — only for
+  // the stored status. The accounts list is the one the dashboard already needs:
+  // `account-balances` is one of the six default widgets and calls `useAccounts`
+  // itself, so hoisting the same `['accounts', 'list']` query up here shares one
+  // request with it rather than adding a second (Performance NFR).
+  //
+  // `enabled: !onboardingRetired` is TRUE on the first render, because the
+  // status is unknown until the preference read lands. That is deliberate: the
+  // accounts fetch goes out in parallel with the preference and the layout
+  // reads rather than waiting a round trip behind one of them. Once the status
+  // comes back `done` the observer switches off — and by then the response has
+  // usually already landed in the cache, where the balances widget picks it up
+  // for free. Nothing here is a new blocking request on first paint.
+  // ===========================================================================
+  const onboardingQuery = useOnboardingQuery();
+  const preference = onboardingQuery.data;
+  // `done` ONLY. `skipped` is an R4.5 dismissal of the CHECKLIST, not of
+  // onboarding: a skipped user with no accounts still has nothing to look at,
+  // and the zero-state is where `ActivationChecklist` — hence the product's only
+  // "Reopen setup checklist" control — is mounted. Retiring on `skipped` would
+  // delete that control from the product and make dismissal unrecoverable.
+  const onboardingRetired = preference?.status === 'done';
+  const accountsQuery = useAccounts({ enabled: !onboardingRetired });
+  const accounts = accountsQuery.data;
 
   // beforeunload: flush any pending debounced PUT (Req 1.9).
   useEffect(() => {
@@ -229,10 +311,74 @@ function DashboardPage(): ReactElement {
     );
   }
 
+  // Zero state — takes precedence over the empty layout below (Req 3.5), and
+  // sits behind isLoading/isError so neither of those branches changes.
+  //
+  // NO FLASH IN EITHER DIRECTION, which is the whole reason this is three
+  // conditions and not one. Deciding early would be wrong both ways: `accounts`
+  // is `undefined` before it lands, so `accounts?.length === 0` would show the
+  // zero-state to every established user for a beat; and falling through while
+  // the status is unknown would show the widget grid to a brand-new user for a
+  // beat. So the route stays on the skeleton it is ALREADY showing until both
+  // reads have answered, and only then picks a side. Same component as the
+  // isLoading branch, so the wait is invisible — the screen does not change
+  // twice.
+  //
+  // A FAILED READ FALLS THROUGH rather than parking on the skeleton forever.
+  // Onboarding is presentation over data the dashboard owns anyway; if we cannot
+  // tell whether this user is new, the right answer is the dashboard they asked
+  // for, not a spinner.
+  if (!onboardingQuery.isError && !accountsQuery.isError && !onboardingRetired) {
+    if (preference === undefined || accounts === undefined) {
+      return <DashboardSkeleton />;
+    }
+    // Req 3.4 needs nothing extra: `useCreateAccount` invalidates ['accounts'],
+    // this observer refetches, and the next render falls through to the grid.
+    if (accounts.length === 0) {
+      return <ZeroState />;
+    }
+  }
+
+  // ===========================================================================
+  // THE CHECKLIST'S HOME ON EVERY OTHER PATH (R4.5, R4.7).
+  //
+  // `ZeroState` composes `ActivationChecklist` itself, so the zero-state branch
+  // above needs nothing — and must not double-mount it. But the zero-state is
+  // the ONLY screen the checklist had, and a user leaves it the instant they
+  // create their first account. That is precisely when items 2-4 (size a trade,
+  // log a position, close it) become the outstanding work, when the "Reopen
+  // setup checklist" row R4.5 depends on would otherwise be unreachable, and
+  // when R4.7's retirement — which is what finally switches `useOnboarding`'s
+  // two expensive gated reads off for good — would never get a chance to fire.
+  // So both remaining branches mount it.
+  //
+  // UNCONDITIONALLY, and that is safe because the component answers for every
+  // state itself: nothing for a retired (`done`) user, nothing while the stored
+  // status is still unknown, the quiet reopen row for a `skipped` user, and the
+  // card otherwise. Nothing here may restate those rules — a second copy of them
+  // is a second thing to get wrong.
+  //
+  // NO LAYOUT JUMP, and it takes all three of these. `ActivationChecklist`
+  // occupies no space while `preference` is `undefined`, so it cannot appear and
+  // then vanish on an established user; this route never even reaches these
+  // branches with an unknown status unless a read failed, because the gate above
+  // holds the skeleton until the preference lands; and `ChecklistSlot` reserves
+  // the settled card's height for the one transition the first two do not cover,
+  // the skeleton → card swap a mid-onboarding user still sees. Mount through the
+  // slot, never `ActivationChecklist` directly.
+  //
+  // NO SECOND PRIMARY ACTION. The checklist carries no amber of its own by
+  // design, so the one primary each of these views is allowed stays where it is
+  // — "Use the default layout" below, and nothing on the populated dashboard.
+  // `onStartStep` is deliberately NOT passed: the walkthrough is Phase E, and a
+  // per-item "Start" button with nothing behind it is a dead control.
+  // ===========================================================================
+
   // Empty
   if (widgets.length === 0) {
     return (
       <div className="space-y-6">
+        <ChecklistSlot />
         <EmptyState
           title="Your dashboard is empty"
           description="Add widgets to get started, or load the default layout."
@@ -279,6 +425,9 @@ function DashboardPage(): ReactElement {
         }}
         resetBusy={defaultBusy}
       />
+      {/* Above the grid, below the page heading and its actions — see the note
+          on the empty branch. */}
+      <ChecklistSlot />
       <DashboardGrid
         widgets={widgets}
         onRemove={handleRemove}

--- a/e2e/tests/dashboard.spec.ts
+++ b/e2e/tests/dashboard.spec.ts
@@ -61,6 +61,17 @@ async function registerUser(req: APIRequestContext, label: string): Promise<Seed
   });
   expect(res.status(), `register ${email}`).toBe(201);
   const body = (await res.json()) as { user: { id: string } };
+  // The dashboard shows the onboarding zero-state INSTEAD of the widget grid
+  // while a user has no accounts, so a bare registration lands on a screen that
+  // has no widgets on it at all. Every case in this suite is about the grid —
+  // its defaults, the Add Widget popover, drag persistence, the theme toggle —
+  // not about onboarding, so each seeded user gets the one account that puts
+  // them past it. `register` set the session cookie on `req`, so this POST is
+  // already authenticated as the user just created.
+  const accountRes = await req.post('/api/accounts', {
+    data: { name: `${label} account`, currency: 'USD' },
+  });
+  expect(accountRes.status(), `POST /accounts for ${email}`).toBe(201);
   return { email, userId: body.user.id };
 }
 

--- a/e2e/tests/fixtures/performance-fixtures.ts
+++ b/e2e/tests/fixtures/performance-fixtures.ts
@@ -252,4 +252,19 @@ export async function mockAppShell(page: Page): Promise<void> {
   await page.route(/\/api\/performance(\?.*)?$/, (route) =>
     route.fulfill(json(NO_ACCOUNTS_RESPONSE)),
   );
+  // The /dashboard route reads the stored onboarding preference before it will
+  // paint anything: it holds its loading skeleton until BOTH this and
+  // /api/accounts have answered, and unmocked this one falls through to the real
+  // API, 401s against the synthetic session and trips the global redirect to
+  // /login described above.
+  //
+  // `done` is the honest answer for these specs' user. Their accounts, ledger
+  // and P&L are seeded through the mocks, so they are an established user, not a
+  // new one — the same state migration 0028 backfills for everyone who predates
+  // the feature. It also keeps the zero-state gate and the activation checklist
+  // out of the way entirely, so the dashboard these specs assert against is the
+  // one they were written for.
+  await page.route('**/api/users/me/onboarding', (route) =>
+    route.fulfill(json({ status: 'done', coachMarksSeen: [] })),
+  );
 }

--- a/e2e/tests/visual-design-parity.spec.ts
+++ b/e2e/tests/visual-design-parity.spec.ts
@@ -309,6 +309,18 @@ test.describe('visual-design parity smoke', () => {
   test.beforeAll(async ({ request }) => {
     await ensureStackOrSkip(request);
     user = await registerUser(request, 'main');
+    // The dashboard shows the onboarding zero-state INSTEAD of the widget grid
+    // while the user has no accounts. Neither case below is about that screen —
+    // one asserts token resolution on the populated dashboard, the other the
+    // money-direction encoding across its figures — so the account is seeded
+    // with the user rather than inside the second case, where it used to live.
+    // `register` set the session cookie on `request`, so this POST is already
+    // authenticated as the user just created.
+    const accountRes = await request.post('/api/accounts', {
+      data: { name: 'USD Account', currency: 'USD' },
+    });
+    expect(accountRes.status(), 'POST /accounts').toBe(201);
+    accountId = ((await accountRes.json()) as { id: string }).id;
   });
 
   test.beforeEach(async ({ page }) => {
@@ -339,14 +351,9 @@ test.describe('visual-design parity smoke', () => {
   }) => {
     await loginViaUi(page, user.email);
 
-    // Seed one real account so the mocked positions reference a real id (the
-    // mocks own the figure shapes; the account just exists for completeness).
-    const accountRes = await page.request.post('/api/accounts', {
-      data: { name: 'USD Account', currency: 'USD' },
-    });
-    expect(accountRes.status(), 'POST /accounts').toBe(201);
-    accountId = ((await accountRes.json()) as { id: string }).id;
-
+    // The account is seeded in `beforeAll` (the mocks own the figure shapes; the
+    // real account is what keeps the user past the onboarding zero-state and
+    // gives the mocked positions a real id to reference).
     await mockFigureData(page, { accountId, userId: user.userId });
     // Run the encoding checks in DARK so both themes are exercised (toggle test
     // covers light; this covers the dark-theme figure rendering).


### PR DESCRIPTION
A new user's first screen was the full dashboard with every widget empty, each phrasing its emptiness differently: "Close a position to see stats." / "No open positions." / "Close a position in this currency to see your chart." / "No accounts yet." Technically correct, and it reads as broken. Nothing told the user that a brokerage account is the thing everything else hangs off, so the one action that unblocks the product was the one action the screen never named.

## What changed

- A **zero-state screen** replaces the widget grid for a user with no accounts. It names the brokerage account as the prerequisite, says plainly that Tradr accounts mirror real brokerage accounts but are not connected to them and that Tradr never places or executes trades, and offers one clear way forward.
- An **activation checklist** — create an account, size a trade, log a position, close it — that stays available after the first account is created, not just on the empty screen.
- Completion is **derived from your own data**, never stored. A position imported from CSV ticks the same box as one entered by hand, and there is no stored progress that can drift out of step with reality or need repairing.
- Dismissing the checklist is **recoverable** — it can be reopened without support.
- Users who predate this feature are treated as **already onboarded**, so nobody with history is shown a welcome screen.

## What is not here yet

The guided walkthrough and the sample-data option are offered but not yet built; both are honest about that in the UI rather than being buttons that do nothing. The checklist's second item depends on the calculator recording first use, which lands with the walkthrough — until then the checklist will not retire itself.

## Checks

Typecheck across all packages; the migrations, api and web suites; eslint; and the generated reference artifacts regenerate to a clean tree.
