### PR TITLE
feat(metrics): add opt-in Prometheus exposition surface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,49 @@ CSV_IMPORT_NGINX_PROXY_TIMEOUT=300s
 # or oversized CSV imports are rejected by nginx before the api can size them.
 MAX_UPLOAD_SIZE=20m
 
+# ─── Metrics (Prometheus exposition) ─────────────────────────────────────────
+# Prometheus text-format metrics for the api container, served as GET /metrics
+# on a listener of its own — separate from the application port, so the
+# exposition is never reachable through the app's routes. It carries HTTP
+# request counters and latency, database connection-state and probe gauges,
+# Node.js process metrics, and a build-info gauge.
+#
+# OFF BY DEFAULT: the surface is absent, not broken, when unset. Set this to
+# true to arm it. Only the literal values true and false parse; anything else
+# is a startup error rather than a silent default.
+#
+# DO NOT PUBLISH THE METRICS PORT. The exposition is unauthenticated by design
+# — network isolation is the control, because a bearer token copied into every
+# scrape config is a worse posture than a private bind. It exposes no user
+# data, only aggregate operational counters and the build version.
+#
+# Every scrape is an ACTIVE DATABASE PROBE: the connection-state and probe
+# gauges are collected on demand, so the scrape interval you configure on the
+# Prometheus side is a database load knob — on top of the SELECT 1 the Fly
+# health check already issues every 15 seconds.
+METRICS_ENABLED=false
+
+# Port the metrics listener binds inside the api container. Chosen to collide
+# with neither the api port (3100), WEB_PORT, nor Fly's internal_port.
+#
+# Nothing publishes it: docker-compose.yml deliberately adds no ports: mapping
+# for the api service — only web publishes a host port — and that omission is
+# what keeps the surface off the public internet. Scrape it from another
+# container on the same compose network, or over 6PN on Fly.
+METRICS_PORT=9464
+
+# Address the metrics listener binds to. The default is deliberate, not lazy:
+# 127.0.0.1 would bind the CONTAINER's own loopback and be unreachable from a
+# Prometheus elsewhere on the compose network, and a Fly scrape arrives over
+# 6PN rather than loopback. Binding all interfaces is already private in both
+# documented deployments precisely because nothing publishes the port.
+#
+# Residual threat model: the listener becomes reachable from outside only if an
+# operator adds a ports: mapping for the api service or runs it with host
+# networking. This variable exists so those operators can narrow the bind to a
+# specific interface instead of widening their exposure.
+METRICS_HOST=0.0.0.0
+
 # ─── Advisor — encryption ────────────────────────────────────────────────────
 # Generate the active key:
 #   openssl rand -hex 32

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,6 +554,150 @@ jobs:
             exit 1
           fi
 
+      # (k) /metrics is ABSENT by default (observability REQ-7.1, REQ-7.5). The
+      # stack booted from the .env that ./docker/quickstart.sh copied from
+      # .env.example, where METRICS_ENABLED=false — so this is the REAL default
+      # path a self-hoster gets, not a contrived one. 10-runtime-config.sh
+      # therefore wrote no /usr/share/nginx/html/metrics, and Task 6's
+      # `location = /metrics` is an exact-match location with no try_files and
+      # no error_page, so nginx answers with its OWN 404. This step is the only
+      # mechanism that fails when the entrypoint's METRICS_ENABLED gate is
+      # dropped (the file would exist => 200) or when the exact-match location
+      # is deleted (the SPA fallback would swallow the path => 200 + index.html).
+      # `curl -fsS` — the form (b)/(j) use — is deliberately NOT used here: it
+      # exits non-zero on a 404 and would red this step on correct behaviour.
+      - name: Assert /metrics absent by default (k)
+        run: |
+          code=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${WEB_PORT}/metrics")
+          echo "default /metrics -> $code"
+          if [ "$code" != "404" ]; then
+            echo "expected 404 for /metrics with METRICS_ENABLED=false (got $code)"
+            exit 1
+          fi
+
+      # (l) /metrics is PRESENT and a valid exposition when METRICS_ENABLED=true
+      # (observability REQ-7.1, REQ-7.2, REQ-7.3, REQ-7.5). Recreate ONLY the
+      # `web` container with the flag on: a shell env var wins over .env for
+      # compose interpolation, and web has no `env_file:`, so
+      # ${METRICS_ENABLED:-false} in web.environment is the container's only
+      # source for the flag. The merged spec is re-applied, so the CI overlay's
+      # _probe.inc bind-mount and depends_on survive, and a fresh container start
+      # re-runs /docker-entrypoint.d/*.sh — the code path under test.
+      #
+      # --no-deps IS required (verified against compose v2 / Docker 29): the same
+      # shell var also interpolates into the API's `METRICS_ENABLED:` line, so
+      # the api service spec hashes differently and compose recreates it as a
+      # changed dependency — with or without --force-recreate. That restart is
+      # unwaited and unasserted here, so it would be pure churn (and misleading
+      # noise in the failure log dump). --no-deps pins the blast radius to `web`;
+      # postgres/api/sse-stub are already up from the steps above.
+      #
+      # Neither the base web service nor the CI overlay declares a healthcheck,
+      # so `--wait` would return as soon as the container is merely running and
+      # `ps --format '{{.Health}}'` comes back empty (verified: `<no value>`). We
+      # therefore borrow only the SHAPE of the api health-wait above — retry,
+      # sleep, fail on exhaustion — and poll /config.js, written unconditionally
+      # by the same entrypoint script, for readiness. Polling /config.js rather
+      # than /metrics is deliberate: a genuine METRICS_ENABLED-propagation bug
+      # then reports as "404 instead of 200" below instead of as an opaque
+      # readiness timeout. Every curl in the loop is `|| true`-guarded because
+      # the published port is briefly unbound while the container is replaced —
+      # an unguarded curl exits 7/56 there and `set -e` would kill the step
+      # before it ever retried. This step is what fails when the entrypoint's
+      # exposition writer or the nginx `location = /metrics` block regresses.
+      #
+      # The API's own :9464 listener is deliberately NOT smoke-tested here: it
+      # is covered by the metrics integration tests, and asserting it through
+      # compose would require publishing the metrics port — exactly what
+      # REQ-2.5/REQ-8.4 forbid and what the private-bind posture depends on.
+      - name: Assert /metrics served when METRICS_ENABLED=true (l)
+        run: |
+          METRICS_ENABLED=true docker compose -f docker-compose.yml -f docker-compose.ci.yml \
+            up -d --no-deps --force-recreate web
+
+          ready=""
+          for i in $(seq 1 30); do
+            probe=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${WEB_PORT}/config.js" || true)
+            echo "web readiness attempt $i (/config.js): $probe"
+            if [ "$probe" = "200" ]; then ready=1; break; fi
+            sleep 2
+          done
+          if [ -z "$ready" ]; then
+            echo "web did not come back up after --force-recreate"
+            exit 1
+          fi
+
+          code=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${WEB_PORT}/metrics" || true)
+          echo "enabled /metrics -> $code"
+          if [ "$code" != "200" ]; then
+            echo "expected 200 for /metrics with METRICS_ENABLED=true (got $code)"
+            exit 1
+          fi
+
+          body=$(curl -s "http://localhost:${WEB_PORT}/metrics" || true)
+          echo "$body"
+          echo "$body" | grep -q '^# TYPE tradr_web_build_info gauge$' || {
+            echo "exposition is missing its '# TYPE tradr_web_build_info gauge' line"
+            exit 1
+          }
+          echo "$body" | grep -q '^tradr_web_build_info[{]' || {
+            echo "exposition is missing a tradr_web_build_info{...} sample line"
+            exit 1
+          }
+
+          # Prometheus will not scrape a non-text/plain body, and the file is
+          # EXTENSIONLESS — the location's default_type is the only thing
+          # setting this, so it is worth asserting separately from the body.
+          ctype=$(curl -s -o /dev/null -w '%{content_type}' "http://localhost:${WEB_PORT}/metrics" || true)
+          echo "/metrics content-type: $ctype"
+          case "$ctype" in
+            text/plain*) ;;
+            *) echo "expected a text/plain Content-Type for /metrics (got '$ctype')"; exit 1 ;;
+          esac
+
+      # (m) Flipping METRICS_ENABLED back to false REMOVES an exposition that was
+      # already written (observability REQ-7.9). This is the ONLY assertion that
+      # fails when the entrypoint's unconditional `rm -f` is deleted, and it must
+      # run AFTER (l), against the very container (l) left running with the flag
+      # ON: the html root persists across a `docker compose exec`, so re-running
+      # the entrypoint in place with the flag off has stale state to clean up.
+      #
+      # A fresh-container assertion structurally CANNOT catch this — not (k), and
+      # not any one-shot `docker run` of the web image. A new container starts on a
+      # clean image layer with no /usr/share/nginx/html/metrics, so the
+      # METRICS_ENABLED gate alone already produces the 404 and there is nothing
+      # stale for a missing `rm -f` to leave behind. The regression only surfaces
+      # on a REUSED html root, which is exactly what an operator flipping the flag
+      # off on a persisted volume has (they would otherwise be served the previous
+      # exposition forever).
+      #
+      # `exec -T` addresses the compose service by name, as the other exec steps
+      # above do; `-e` scopes the override to this one exec, leaving the
+      # container's own METRICS_ENABLED=true (and nginx itself) untouched. The
+      # precondition is asserted first so a regression in (l) reports as a broken
+      # precondition rather than silently making the 404 below vacuous. `curl -fsS`
+      # is deliberately NOT used, for (k)'s reason: it exits non-zero on a 404 and
+      # would red this step on correct behaviour.
+      - name: Assert /metrics removed when METRICS_ENABLED flips to false (m)
+        run: |
+          before=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${WEB_PORT}/metrics" || true)
+          echo "before flip /metrics -> $before"
+          if [ "$before" != "200" ]; then
+            echo "precondition failed: (l) should have left /metrics served (got $before)"
+            exit 1
+          fi
+
+          docker compose -f docker-compose.yml -f docker-compose.ci.yml exec -T \
+            -e METRICS_ENABLED=false web /docker-entrypoint.d/10-runtime-config.sh
+
+          code=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${WEB_PORT}/metrics" || true)
+          echo "after flip /metrics -> $code"
+          if [ "$code" != "404" ]; then
+            echo "expected 404 after re-running the entrypoint with METRICS_ENABLED=false (got $code)"
+            echo "the stale exposition survived — the unconditional 'rm -f' is missing"
+            exit 1
+          fi
+
       # Dump container logs on ANY failure above (Req 8.6).
       - name: Dump container logs on failure
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,8 +128,9 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           platforms: linux/${{ matrix.arch }}
-          # APP_VERSION is only consumed by Dockerfile.api (GET /api/health);
-          # Dockerfile.web ignores an unknown build-arg.
+          # APP_VERSION is consumed by BOTH images: Dockerfile.api bakes it for
+          # GET /api/health and tradr_build_info, Dockerfile.web bakes it for the
+          # SPA's version badge and tradr_web_build_info in /metrics.
           build-args: |
             APP_VERSION=${{ github.ref_name }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -31,6 +31,7 @@
     "openai": "^4",
     "postgres": "^3.4",
     "posthog-node": "^5.38.0",
+    "prom-client": "^15.1.3",
     "stripe": "^19",
     "tiktoken": "^1.0.22",
     "zod": "^3.24",

--- a/apps/api/src/app.metrics-disabled.test.ts
+++ b/apps/api/src/app.metrics-disabled.test.ts
@@ -1,0 +1,48 @@
+// Task 5 (metrics-instrumentation): the DISABLED path, asserted on the composed
+// app. Named for the `app.split-origin.test.ts` precedent — a top-level
+// `app.*.test.ts` that asserts middleware behaviour of the assembled `app.ts`
+// rather than of a throwaway Hono instance.
+//
+// NOTHING IN THIS FILE MUTATES `config`. That is the point: it runs under
+// `vitest.workspace.ts`'s default pin (`METRICS_ENABLED: 'false'`), which is the
+// configuration a self-hoster gets out of the box, and asserts the surface is
+// ABSENT rather than empty (REQ-1.4, REQ-9.6).
+
+import { describe, expect, it } from 'vitest';
+
+import app from '@/app';
+import { httpRequestsTotal } from '@/features/metrics/metrics.registry';
+import { startMetricsServer } from '@/features/metrics/metrics.server';
+import { config, isMetricsConfigured } from '@/lib/config';
+
+describe('metrics disabled — the default pin (REQ-1.4, REQ-9.6)', () => {
+  it('is genuinely disabled, so the assertions below are not vacuous', () => {
+    expect(config.METRICS_ENABLED).toBe(false);
+    expect(isMetricsConfigured()).toBe(false);
+  });
+
+  it('binds no listener: startMetricsServer() returns undefined', () => {
+    // Also the reason this case is safe to run at all — a build that bound a
+    // socket here would hold METRICS_PORT for the rest of the worker.
+    expect(startMetricsServer()).toBeUndefined();
+  });
+
+  it('does not register the metrics middleware on the composed app', async () => {
+    // Outside /api on purpose: every router mounted under /api runs
+    // authMiddleware at router level and answers 401 before the miss, which is
+    // a fine drive but a confusing thing to assert on.
+    const res = await app.request('/not-a-route-anything-mounts');
+    expect(res.status).toBe(404);
+
+    // `get()` is ASYNC, and the `await` is load-bearing. Un-awaited this reads
+    // `undefined` off a Promise: it would red on a CORRECT build, and the
+    // natural "fix" — `toBeUndefined()` — then passes just as happily on a build
+    // where the middleware IS recording.
+    //
+    // The empty array is the right expectation: prom-client seeds a zero value
+    // only for LABEL-FREE counters, and this one carries three labels. With the
+    // middleware registered the request above would have recorded
+    // {method:"GET", route:"unmatched", status:"404"}.
+    expect((await httpRequestsTotal.get()).values).toEqual([]);
+  });
+});

--- a/apps/api/src/app.self-host-parity.test.ts
+++ b/apps/api/src/app.self-host-parity.test.ts
@@ -16,6 +16,7 @@ import { poolerDriverOptions } from '@/db';
 import {
   config,
   isDirectDatabaseConfigured,
+  isMetricsConfigured,
   isObjectStorageConfigured,
   isRedisConfigured,
   isSplitOriginConfigured,
@@ -59,5 +60,18 @@ describe('self-host default parity (REQ-1.6) — every gated capability off', ()
     const opts = poolerDriverOptions(config.DB_TRANSACTION_POOLER);
     expect(opts).toEqual({});
     expect('prepare' in opts).toBe(false);
+  });
+});
+
+// Deliberately a SIBLING block, not a case inside the gated-capability describe
+// above: the metrics surface is NOT a hosted-only capability. Nothing about it
+// sits behind FEATURE_GATING, and a self-hoster can turn it on freely. What it
+// shares with those capabilities is only that it defaults OFF — which is the one
+// thing this block proves (REQ-1.7), under the METRICS_* pin in
+// vitest.workspace.ts that keeps a stray ambient value from reddening it (REQ-1.8).
+describe('metrics exposition surface (REQ-1.7) — off by default', () => {
+  it('isMetricsConfigured() is false with METRICS_ENABLED unset/false', () => {
+    expect(config.METRICS_ENABLED).toBe(false);
+    expect(isMetricsConfigured()).toBe(false);
   });
 });

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -42,6 +42,7 @@ import {
 import { initStockQuoteCache } from '@/features/symbols/stock-quote.client';
 import symbolsRouter from '@/features/symbols/symbols.route';
 import { syncSymbolsIfStale } from '@/features/symbols/symbols.service';
+import { isMetricsConfigured } from '@/lib/config';
 import {
   loadEncryptionKeyMaterial,
   runEncryptionFingerprintCheckIfConfigured,
@@ -51,11 +52,36 @@ import { corsMiddleware } from '@/middleware/cors.middleware';
 import { csrfMiddleware } from '@/middleware/csrf.middleware';
 import { errorHandler } from '@/middleware/error.middleware';
 import { loggingMiddleware } from '@/middleware/logging.middleware';
+import { metricsMiddleware } from '@/middleware/metrics.middleware';
 
 const app = new Hono();
 
 // Global middleware
 app.use(loggingMiddleware);
+
+// HTTP metrics (REQ-1.4) — registered only when METRICS_ENABLED. Placed AFTER
+// loggingMiddleware so a metrics failure can never prevent the request log, and
+// before every app.route() mount below so it wraps route dispatch.
+//
+// Two classes of short-circuit therefore label a request by something other than
+// its route pattern, both pinned in metrics.middleware.test.ts so nobody reads
+// them as a bug:
+//
+//  1. GLOBAL — corsMiddleware/csrfMiddleware sit AFTER this and can return
+//     without calling next() (csrfMiddleware returns 403 CSRF_FORBIDDEN). Route
+//     dispatch never happens, so the request resolves to a global middleware's
+//     /* and is labelled route="unmatched" alongside genuine 404s. Only on the
+//     split-origin hosted tier — both are pure pass-through when
+//     isSplitOriginConfigured() is false.
+//  2. PER-ROUTER — the feature routers below call router.use(authMiddleware),
+//     which returns 401 without next() when unauthenticated. That resolves to
+//     the router's MOUNT WILDCARD (e.g. route="/api/positions/*"), not
+//     "unmatched" — a third bucket a dashboard shows next to /api/positions/:id.
+//     This is the highest-volume case, since 401s are routine.
+//
+// Both satisfy REQ-5.7's letter (no app route's handler ever matched) and stay
+// bounded: one extra label value per mounted router (REQ-8.2).
+if (isMetricsConfigured()) app.use(metricsMiddleware);
 
 // Split-origin CORS + anti-CSRF (REQ-5/6, design §Component 4/5). Both gate on
 // the single isSplitOriginConfigured() predicate (evaluated per request), so

--- a/apps/api/src/features/metrics/metrics.collectors.test.ts
+++ b/apps/api/src/features/metrics/metrics.collectors.test.ts
@@ -1,0 +1,471 @@
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import postgres from 'postgres';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Transaction } from '@/db';
+import { withTransaction } from '@/lib/transaction';
+
+import { refreshDbMetrics, resetDbProbeStateForTests } from './metrics.collectors';
+import { dbConnections, dbProbeDuration, dbUp, registry } from './metrics.registry';
+
+/**
+ * The ONLY seam. Deliberately NOT `vi.mock('@/db')`: `test-setup.ts` is the api
+ * project's `setupFiles` entry, it already mocks `@/db`, and it reassigns `db`
+ * to a live drizzle `Transaction` in every `beforeEach` — AFTER any per-file
+ * mock. A per-file `@/db` mock is therefore silently replaced and the
+ * "rejects" / "never settles" cases would quietly run real queries against
+ * `pg_stat_activity`, passing or failing for the wrong reason.
+ *
+ * For the same reason nothing here spies on `db.transaction`: by test time that
+ * is the live `PgTransaction` `test-setup.ts` installed, whose nested
+ * `.transaction()` issues a SAVEPOINT rather than a BEGIN.
+ *
+ * `@/lib/transaction` is a bare passthrough that `test-setup.ts` never touches.
+ */
+vi.mock('@/lib/transaction', () => ({ withTransaction: vi.fn() }));
+
+const withTransactionMock = vi.mocked(withTransaction);
+
+const dialect = new PgDialect();
+
+/** Render a drizzle `sql` template the way Postgres would receive it. */
+function render(query: unknown): string {
+  return dialect.sqlToQuery(query as SQL).sql;
+}
+
+/** The same, collapsed to single spaces, so the assertions are not formatting-brittle. */
+function renderNormalized(query: unknown): string {
+  return render(query).replace(/\s+/g, ' ').trim();
+}
+
+type StateRow = { state: string | null; count: number };
+type ProbeResult = { durationSeconds: number; rows: StateRow[] };
+
+/**
+ * Postgres's OWN vocabulary, verified against a live server below — NOT the
+ * emitted label spelling. `pg_stat_activity.state` is `idle in transaction`,
+ * three words with spaces; the collector translates that to the
+ * `idle_in_transaction` LABEL.
+ *
+ * These two spellings were once the same string in both the fixture and the
+ * code, which is exactly why the mismatch survived: the fixture asserted the
+ * code's assumption rather than Postgres's behaviour, so every case passed
+ * while the shipped series reported 0 forever.
+ */
+const HEALTHY_ROWS: StateRow[] = [
+  { state: 'active', count: 1 },
+  { state: 'idle', count: 2 },
+  { state: 'idle in transaction', count: 3 },
+];
+
+/**
+ * Deferreds created by a case, so `afterEach` can settle every one of them.
+ * A probe that never settles never clears the single-flight handle.
+ */
+const pendingSettlers: Array<() => void> = [];
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  pendingSettlers.push(() => reject(new Error('__afterEach_settle__')));
+  return { promise, resolve };
+}
+
+/**
+ * Make `withTransaction` actually RUN the collector's callback against a fake
+ * transaction whose `execute` is a spy. A plain `mockResolvedValue({...})`
+ * never runs the callback, so nothing would notice if the `SET LOCAL` were
+ * dropped.
+ */
+function stubTransaction(rows: StateRow[]): { execute: ReturnType<typeof vi.fn> } {
+  const execute = vi.fn();
+  execute.mockResolvedValueOnce([]); // SET LOCAL statement_timeout
+  execute.mockResolvedValueOnce([{ ok: 1 }]); // SELECT 1
+  execute.mockResolvedValueOnce(rows); // pg_stat_activity aggregate
+
+  withTransactionMock.mockImplementation(async (_db, callback) =>
+    callback({ execute } as unknown as Transaction),
+  );
+
+  return { execute };
+}
+
+async function readUp(): Promise<number | undefined> {
+  return (await dbUp.get()).values[0]?.value;
+}
+
+async function readProbeDuration(): Promise<number | undefined> {
+  return (await dbProbeDuration.get()).values[0]?.value;
+}
+
+async function readConnections(): Promise<Array<{ state: string; value: number }>> {
+  const { values } = await dbConnections.get();
+  return values.map((v) => ({ state: String(v.labels.state), value: v.value }));
+}
+
+/**
+ * Drive ONE successful probe, and assert it landed.
+ *
+ * Every failure case must start here. `prom-client` seeds a label-free gauge to
+ * `0` at construction and a labelled one to `values: []`, so `tradr_db_up 0`
+ * with zero `tradr_db_connections` samples is EXACTLY the state of a registry
+ * the collector has never run against — an empty `refreshDbMetrics()` body
+ * satisfies every failure assertion written the naive way. Only the transition
+ * is evidence.
+ */
+async function driveSuccessfulProbe(): Promise<void> {
+  stubTransaction(HEALTHY_ROWS);
+  await refreshDbMetrics();
+
+  expect(await readUp()).toBe(1);
+  expect(await readConnections()).toHaveLength(3);
+
+  withTransactionMock.mockReset();
+}
+
+beforeEach(() => {
+  withTransactionMock.mockReset();
+  resetDbProbeStateForTests();
+  registry.resetMetrics();
+});
+
+afterEach(async () => {
+  // Settle every deferred the case created — the deadline case's probe by
+  // definition never settles, which would otherwise wedge the single-flight
+  // handle for the rest of the file — then flush the microtasks its `.finally`
+  // runs on.
+  for (const settle of pendingSettlers.splice(0)) settle();
+  await Promise.resolve();
+  await Promise.resolve();
+
+  // Leaving fake timers installed can also hang `test-setup.ts`'s `sql.end()`.
+  vi.useRealTimers();
+  resetDbProbeStateForTests();
+});
+
+describe('refreshDbMetrics (REQ-4)', () => {
+  it('flips a healthy probe to tradr_db_up 0 with no connection samples when it rejects', async () => {
+    await driveSuccessfulProbe();
+
+    withTransactionMock.mockRejectedValue(new Error('CONNECTION_ENDED'));
+    await expect(refreshDbMetrics()).resolves.toBeUndefined();
+
+    expect(await readUp()).toBe(0);
+    expect(await readConnections()).toHaveLength(0);
+  });
+
+  it('trips the 5000 ms deadline when the probe never settles and lands on the same failure path', async () => {
+    await driveSuccessfulProbe();
+
+    const stuck = createDeferred<ProbeResult>();
+    withTransactionMock.mockReturnValue(stuck.promise);
+
+    vi.useFakeTimers();
+    const scrape = refreshDbMetrics();
+    await vi.advanceTimersByTimeAsync(5000);
+    await expect(scrape).resolves.toBeUndefined();
+
+    expect(await readUp()).toBe(0);
+    expect(await readConnections()).toHaveLength(0);
+  });
+
+  it('joins an in-flight probe and PUBLISHES its result, taking tradr_db_up 0 → 1', async () => {
+    // The one shape that can fail. Asserting only the call count, or asserting
+    // the exposition after both callers succeed, proves nothing: join-and-
+    // publish and join-and-return produce byte-identical output there, because
+    // the starter writes the values the joiner would. So the starter must
+    // already have TIMED OUT when the probe lands.
+    await driveSuccessfulProbe();
+
+    const probe = createDeferred<ProbeResult>();
+    withTransactionMock.mockReturnValue(probe.promise);
+    vi.useFakeTimers();
+
+    const starter = refreshDbMetrics(); // t=0, its deadline fires at t=5000
+    await vi.advanceTimersByTimeAsync(1000);
+    const joiner = refreshDbMetrics(); // t=1000, its own deadline is t=6000
+
+    expect(withTransactionMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(4000); // t=5000 — the STARTER's deadline
+    await starter;
+    expect(await readUp()).toBe(0);
+
+    probe.resolve({ durationSeconds: 0.25, rows: HEALTHY_ROWS });
+    await joiner;
+
+    // Under join-and-return this stays 0.
+    expect(await readUp()).toBe(1);
+    expect(await readConnections()).toHaveLength(3);
+    // …and the joiner published the duration THAT probe measured, not its own.
+    expect(await readProbeDuration()).toBe(0.25);
+    expect(withTransactionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not open a second transaction for a caller arriving AFTER the starter’s deadline fired', async () => {
+    // The pool-orphan property, and the ONLY case that can see it. The handle
+    // must clear from the PROBE promise's settlement, never from the race's:
+    // the starter's race settles at its 5000 ms deadline while the probe still
+    // holds a reserved connection, so clearing there lets the next scrape open
+    // a second one — and every scrape after that another, until DB_POOL_SIZE is
+    // exhausted and the application's own request path blocks. Case 3 cannot
+    // catch it: its joiner arrives at t=1000, before any race has settled, so
+    // both readings join. Only a caller entering after the starter timed out
+    // and while the probe is still unsettled distinguishes them.
+    await driveSuccessfulProbe();
+
+    const probe = createDeferred<ProbeResult>();
+    withTransactionMock.mockReturnValue(probe.promise);
+    vi.useFakeTimers();
+
+    const starter = refreshDbMetrics(); // t=0, deadline t=5000
+    await vi.advanceTimersByTimeAsync(5000); // the STARTER's deadline fires
+    await starter;
+    expect(await readUp()).toBe(0);
+
+    // The probe is STILL unsettled — its connection is still reserved.
+    const late = refreshDbMetrics();
+
+    // 1 under the correct implementation (the late caller joined); 2 if the
+    // handle was cleared from the race, i.e. a second orphaned connection.
+    expect(withTransactionMock).toHaveBeenCalledTimes(1);
+
+    probe.resolve({ durationSeconds: 0.5, rows: HEALTHY_ROWS });
+    await late;
+
+    expect(withTransactionMock).toHaveBeenCalledTimes(1);
+    // The late caller joined AND published: 0 → 1, with that probe's duration.
+    expect(await readUp()).toBe(1);
+    expect(await readProbeDuration()).toBe(0.5);
+    expect(await readConnections()).toHaveLength(3);
+  });
+
+  it('issues SET LOCAL statement_timeout = 1000 as the transaction’s first statement', async () => {
+    // The only coverage the server-side half of REQ-4.8 gets. Without it,
+    // dropping the statement — or writing it as a session-level SET, which
+    // leaks the GUC onto a pooled connection — would red nothing.
+    const { execute } = stubTransaction(HEALTHY_ROWS);
+    await refreshDbMetrics();
+
+    expect(render(execute.mock.calls[0]?.[0])).toBe('SET LOCAL statement_timeout = 1000');
+    expect(await readUp()).toBe(1);
+  });
+
+  it('issues the pg_stat_activity aggregate with the ::int cast and GROUP BY state', async () => {
+    // The whole aggregate, not just its WHERE clause. `GROUP BY state` is what
+    // makes the row set per-state at all, and the `::int` cast is what stops
+    // Postgres returning `count(*)` as a bigint — which `postgres.js` delivers
+    // as a STRING, so `dbConnections.set()` throws on a non-number and EVERY
+    // scrape reports `tradr_db_up 0` for a perfectly healthy database.
+    const { execute } = stubTransaction(HEALTHY_ROWS);
+    await refreshDbMetrics();
+
+    expect(renderNormalized(execute.mock.calls[2]?.[0])).toBe(
+      'SELECT state, count(*)::int AS count FROM pg_stat_activity ' +
+        'WHERE datname = current_database() GROUP BY state',
+    );
+    expect(await readUp()).toBe(1);
+  });
+
+  it('does not let a late-resolving abandoned probe overwrite the failure values', async () => {
+    await driveSuccessfulProbe();
+
+    const abandoned = createDeferred<ProbeResult>();
+    withTransactionMock.mockReturnValue(abandoned.promise);
+
+    vi.useFakeTimers();
+    const scrape = refreshDbMetrics();
+    await vi.advanceTimersByTimeAsync(5000);
+    await scrape;
+
+    expect(await readUp()).toBe(0);
+    const failureDuration = await readProbeDuration();
+
+    abandoned.resolve({ durationSeconds: 42, rows: HEALTHY_ROWS });
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+
+    expect(await readUp()).toBe(0);
+    expect(await readConnections()).toHaveLength(0);
+    expect(await readProbeDuration()).toBe(failureDuration);
+    expect(await readProbeDuration()).not.toBe(42);
+  });
+
+  it('bounds the label set to the three enumerated states, dropping unexpected and NULL states', async () => {
+    stubTransaction([
+      { state: 'active', count: 3 },
+      { state: 'fastpath function call', count: 7 },
+      { state: null, count: 11 },
+      { state: 'disabled', count: 13 },
+      { state: 'idle', count: 4 },
+      { state: 'idle in transaction', count: 1 },
+    ]);
+    await refreshDbMetrics();
+
+    expect(await readConnections()).toEqual([
+      { state: 'active', value: 3 },
+      { state: 'idle', value: 4 },
+      { state: 'idle_in_transaction', value: 1 },
+    ]);
+  });
+
+  it('maps Postgres’s "idle in transaction" (SPACES) onto the idle_in_transaction label', async () => {
+    // The regression this file previously could not see. The collector once
+    // looked its states up by the LABEL spelling, so this row — the literal
+    // string a real Postgres returns — matched nothing and the series read 0
+    // forever, hiding the pool-exhaustion precursor REQ-4 exists to surface.
+    //
+    // Asserted as a literal, and deliberately NOT re-derived from the
+    // collector's own mapping table: comparing the output against the table
+    // that produced it would pass for any spelling at all, which is precisely
+    // the fixture-shares-the-bug failure that let this ship.
+    stubTransaction([{ state: 'idle in transaction', count: 9 }]);
+    await refreshDbMetrics();
+
+    expect(await readConnections()).toEqual([
+      { state: 'active', value: 0 },
+      { state: 'idle', value: 0 },
+      { state: 'idle_in_transaction', value: 9 },
+    ]);
+  });
+
+  it('folds "idle in transaction (aborted)" into the same label by SUMMING, not overwriting', async () => {
+    // The stated choice: an aborted-but-open transaction reserves its backend
+    // and pins the xmin horizon exactly as a live one does, so it is the same
+    // saturation signal and is counted. Because the mapping is many-to-one, the
+    // two rows must ACCUMULATE — a plain assignment would silently drop
+    // whichever arrived first and under-report by that amount.
+    stubTransaction([
+      { state: 'idle in transaction', count: 2 },
+      { state: 'idle in transaction (aborted)', count: 5 },
+    ]);
+    await refreshDbMetrics();
+
+    expect(await readConnections()).toEqual([
+      { state: 'active', value: 0 },
+      { state: 'idle', value: 0 },
+      { state: 'idle_in_transaction', value: 7 },
+    ]);
+  });
+
+  it('defaults a state the query returned no row for to 0', async () => {
+    stubTransaction([{ state: 'active', count: 5 }]);
+    await refreshDbMetrics();
+
+    expect(await readConnections()).toEqual([
+      { state: 'active', value: 5 },
+      { state: 'idle', value: 0 },
+      { state: 'idle_in_transaction', value: 0 },
+    ]);
+  });
+});
+
+/**
+ * The vocabulary check that no hand-written fixture can give.
+ *
+ * Every case above still feeds the collector strings THIS FILE typed. That is
+ * the shape of the original defect: the fixture and the code shared one wrong
+ * assumption about what Postgres returns, so the suite was green while the
+ * shipped metric read 0. Re-typing the strings correctly fixes today's bug and
+ * leaves tomorrow's — nothing here is anchored to the database.
+ *
+ * So this case never writes a state string down. It parks two real backends in
+ * the two transaction states on a dedicated connection, asks Postgres what it
+ * calls them, and feeds THOSE strings to the collector. If Postgres's spelling
+ * ever differs from the collector's table — today's underscore bug, a future
+ * rename, a fixture retyped wrong — this reds and the others do not.
+ *
+ * Deterministic, not timing-dependent: the states are created by this test
+ * rather than observed ambiently, and the lookup is by `pid`, so a concurrent
+ * worker's connections cannot influence it. The short retry covers only the one
+ * documented race — Postgres marks a backend idle just AFTER it flushes
+ * ReadyForQuery, so the client can observe itself a few microseconds early.
+ */
+describe('pg_stat_activity vocabulary (live database)', () => {
+  const DATABASE_URL =
+    process.env.DATABASE_URL ?? 'postgresql://postgres:postgres@localhost:5433/tradr_test';
+
+  it('maps the state strings Postgres ITSELF reports, not ones this file wrote', async () => {
+    // `max: 3` — two parked backends plus the observer. Its own client, never
+    // the shared test connection, which is inside test-setup.ts's per-test
+    // transaction and would deadlock on itself.
+    const client = postgres(DATABASE_URL, { max: 3 });
+
+    const release: Array<() => void> = [];
+    const parked: Array<Promise<unknown>> = [];
+
+    /** Park a backend inside a transaction and hand back the pid Postgres gave it. */
+    async function park(abort: boolean): Promise<number> {
+      let ready!: (pid: number) => void;
+      const pidReady = new Promise<number>((resolve) => (ready = resolve));
+
+      parked.push(
+        client
+          .begin(async (tx) => {
+            // `.unsafe()`, not the template tag: postgres.js declares
+            // `TransactionSql` as `Omit<Sql, …>`, and `Omit` strips an
+            // interface's CALL signature, so `tx` type-checks as non-callable
+            // even though it works at runtime. No interpolation happens here.
+            const [row] = await tx.unsafe<Array<{ pid: number }>>('SELECT pg_backend_pid() AS pid');
+            // Poison the transaction so Postgres reports the ABORTED variant.
+            if (abort) await tx.unsafe('SELECT 1 / 0').catch(() => undefined);
+            ready(row!.pid);
+            await new Promise<void>((resolve) => release.push(resolve));
+          })
+          .catch(() => undefined),
+      );
+
+      return pidReady;
+    }
+
+    try {
+      const idlePid = await park(false);
+      const abortedPid = await park(true);
+
+      /** What Postgres calls this backend right now, once it has gone idle. */
+      async function stateOf(pid: number): Promise<string> {
+        for (let attempt = 0; attempt < 40; attempt += 1) {
+          const [row] = await client<Array<{ state: string | null }>>`
+            SELECT state FROM pg_stat_activity WHERE pid = ${pid}`;
+          if (row?.state != null && row.state !== 'active') return row.state;
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+        throw new Error(`backend ${pid} never reported a settled state`);
+      }
+
+      const idleState = await stateOf(idlePid);
+      const abortedState = await stateOf(abortedPid);
+
+      // Guard the guard: if these ever came back equal, or as the label
+      // spelling, the case below would prove nothing.
+      expect(idleState).not.toBe(abortedState);
+      expect(idleState).not.toContain('_');
+
+      // Postgres's strings, straight into the collector. Counts are arbitrary
+      // and distinct so a fold that overwrites rather than sums is visible.
+      stubTransaction([
+        { state: idleState, count: 4 },
+        { state: abortedState, count: 3 },
+      ]);
+      await refreshDbMetrics();
+
+      expect(await readConnections()).toEqual([
+        { state: 'active', value: 0 },
+        { state: 'idle', value: 0 },
+        { state: 'idle_in_transaction', value: 7 },
+      ]);
+    } finally {
+      for (const resolve of release) resolve();
+      await Promise.all(parked);
+      await client.end({ timeout: 5 });
+    }
+  });
+});

--- a/apps/api/src/features/metrics/metrics.collectors.ts
+++ b/apps/api/src/features/metrics/metrics.collectors.ts
@@ -1,0 +1,222 @@
+import { sql } from 'drizzle-orm';
+
+import { db } from '@/db';
+import { withTransaction } from '@/lib/transaction';
+
+import { dbConnections, dbProbeDuration, dbUp } from './metrics.registry';
+
+/**
+ * Scrape-time database sampling (REQ-4).
+ *
+ * `refreshDbMetrics()` is awaited by the `/metrics` handler before
+ * serialization, so every scrape is an active database probe (REQ-4.9) — one
+ * round trip, one timeout to reason about, rather than three independent
+ * `prom-client` `collect()` hooks interleaving unpredictably.
+ *
+ * It NEVER throws. Every failure — a rejection, a dead socket, a database that
+ * simply stops answering — lands on the same path: `tradr_db_up 0`, the elapsed
+ * time, and a reset connection gauge.
+ */
+
+/**
+ * The single authoritative ceiling on the whole scrape, client-side.
+ *
+ * This is deliberately NOT "the sum of the statement timeouts". `SET LOCAL
+ * statement_timeout` binds only statements issued *after* it, so `BEGIN` and
+ * the `SET LOCAL` itself run unbounded and the five-statement total is not a
+ * bounded quantity. What `statement_timeout = 1000` gives is a 2 s bounded term
+ * covering the only two statements that do real work; the remaining ~3 s of
+ * this deadline is slack for `BEGIN`, `SET LOCAL`, `COMMIT` and five round
+ * trips.
+ *
+ * 5000 ms is half of Prometheus's default 10 s `scrape_timeout`, so the scrape
+ * reports a down database rather than timing out. This is a failure-path
+ * ceiling only — the normal probe is well under 100 ms.
+ */
+const PROBE_DEADLINE_MS = 5000;
+
+/**
+ * The bounded label set (REQ-8.2). Enumerated explicitly and NEVER pivoted from
+ * whatever `pg_stat_activity` returns: `state` is also `fastpath function
+ * call`, `disabled`, or `NULL`, any of which would add unplanned series.
+ *
+ * These are LABEL values, not Postgres state strings — see `STATE_LABELS`.
+ */
+const CONNECTION_STATES = ['active', 'idle', 'idle_in_transaction'] as const;
+
+type ConnectionState = (typeof CONNECTION_STATES)[number];
+
+/**
+ * Postgres `pg_stat_activity.state` string → emitted `state` label value.
+ *
+ * The KEYS are Postgres's own vocabulary, which spells the transaction states
+ * with SPACES and no parenthetical-free shorthand: `idle in transaction`, not
+ * `idle_in_transaction`. Keying the lookup on the underscored label is the bug
+ * this table exists to prevent — it matches nothing, so the series reports 0
+ * forever and pool exhaustion stays invisible, which is precisely what REQ-4
+ * exists to surface.
+ *
+ * The VALUES are the bounded label set above, which REQ-8.2 specifies and both
+ * the `# HELP` text and the operator docs describe. The mapping is deliberately
+ * many-to-one, so the label contract never has to follow Postgres's spelling.
+ *
+ * `idle in transaction (aborted)` is FOLDED IN rather than excluded or given a
+ * fourth label. It is a distinct real state, and this is a stated choice: an
+ * aborted-but-open transaction reserves its backend and holds back the xmin
+ * horizon exactly as a live one does, so it is the same pool-saturation signal —
+ * arguably the worse half of it, since it can never do useful work. Excluding it
+ * would rebuild the blind spot one level down; a fourth label would break the
+ * three-value contract already published in the help text and the docs. Folding
+ * keeps the label set bounded at exactly three.
+ *
+ * Every other state Postgres can report — `fastpath function call`, `disabled`,
+ * and `NULL` — is absent from this table and therefore contributes no series.
+ */
+const STATE_LABELS = new Map<string, ConnectionState>([
+  ['active', 'active'],
+  ['idle', 'idle'],
+  ['idle in transaction', 'idle_in_transaction'],
+  ['idle in transaction (aborted)', 'idle_in_transaction'],
+]);
+
+/** One `pg_stat_activity` group. `state` is nullable in Postgres. */
+type StateRow = { state: string | null; count: number };
+
+type ProbeResult = { durationSeconds: number; rows: StateRow[] };
+
+/**
+ * The single-flight handle: the in-flight probe, or null.
+ *
+ * This is what bounds the POOL. Without it the client-side deadline below still
+ * makes the scrape succeed, so Prometheus keeps its schedule and each scrape
+ * orphans another reserved connection until `DB_POOL_SIZE` is exhausted and the
+ * application blocks. `postgres.js` cancels its idle timer once `BEGIN`
+ * executes, so a JS race alone cannot reclaim them. With the handle, at most
+ * one connection is ever orphaned however often Prometheus scrapes.
+ */
+let inFlight: Promise<ProbeResult> | null = null;
+
+/**
+ * One transaction: bound it server-side, probe liveness, then sample state.
+ *
+ * `SET LOCAL` (never a session-level `SET`) so the GUC auto-cleans on
+ * COMMIT/ROLLBACK and the pooled connection returns clean — the
+ * `advisor/persistence.ts` idiom. A session-level `SET` would leak the timeout
+ * across every later borrower of that connection.
+ *
+ * `start` is captured OUTSIDE the callback and the elapsed time computed
+ * inside, so the reported duration covers the `BEGIN` and the `SET LOCAL` as
+ * well. Nothing here writes a gauge: the caller does that, from the race's
+ * result.
+ */
+async function runProbe(): Promise<ProbeResult> {
+  const start = performance.now();
+
+  return withTransaction(db, async (tx) => {
+    await tx.execute(sql`SET LOCAL statement_timeout = 1000`);
+    await tx.execute(sql`SELECT 1`);
+    const durationSeconds = (performance.now() - start) / 1000;
+
+    const rows = await tx.execute<StateRow>(
+      sql`SELECT state, count(*)::int AS count FROM pg_stat_activity WHERE datname = current_database() GROUP BY state`,
+    );
+
+    return { durationSeconds, rows: [...rows] };
+  });
+}
+
+function startProbe(): Promise<ProbeResult> {
+  const probe = runProbe();
+  inFlight = probe;
+
+  // The handle clears from the PROBE's settlement, never the race's: a caller
+  // whose deadline fired has abandoned a probe that is still holding a
+  // connection, and clearing the handle there would let the next scrape open a
+  // second one. The trailing catch keeps a late rejection from surfacing as an
+  // unhandled rejection once every racing caller has already settled.
+  void probe
+    .finally(() => {
+      if (inFlight === probe) inFlight = null;
+    })
+    .catch(() => {
+      /* published as tradr_db_up 0 by whichever caller was racing it */
+    });
+
+  return probe;
+}
+
+/**
+ * Sample the database into `tradr_db_up`, `tradr_db_probe_duration_seconds` and
+ * `tradr_db_connections`. Never throws.
+ *
+ * A caller that finds a probe already in flight JOINS it — it never opens a
+ * second transaction — and on success publishes THAT probe's result, including
+ * the duration that probe measured. Joining and returning silently would leave
+ * the previous scrape's values in place for an unbounded number of scrapes and,
+ * on the very first concurrent pair, republish the constructor's zero-seeded
+ * `tradr_db_up 0` for a perfectly healthy database.
+ *
+ * Every gauge write happens from the race's RESULT, never inside the
+ * transaction callback. A callback that writes gauges would, when its
+ * transaction is abandoned and finally answers minutes later, set
+ * `tradr_db_up 1` against a database that is down — and could land between a
+ * later scrape's `reset()` and serialization, producing `tradr_db_up 1` with no
+ * `tradr_db_connections` samples at all, a combination REQ-4.7's doctrine does
+ * not define.
+ */
+export async function refreshDbMetrics(): Promise<void> {
+  const start = performance.now();
+  const probe = inFlight ?? startProbe();
+
+  // The joiner's deadline is measured from its OWN entry, so no caller ever
+  // waits longer than the ceiling.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`database probe exceeded ${PROBE_DEADLINE_MS}ms`)),
+      PROBE_DEADLINE_MS,
+    );
+  });
+
+  try {
+    const result = await Promise.race([probe, deadline]);
+
+    // Translate Postgres's vocabulary into the label set, dropping every state
+    // absent from the table (including NULL). ACCUMULATE rather than assign:
+    // the mapping is many-to-one, so both idle-in-transaction states land on one
+    // label and a plain `set` would silently discard whichever row came first.
+    const counts = new Map<ConnectionState, number>();
+    for (const row of result.rows) {
+      const label = row.state === null ? undefined : STATE_LABELS.get(row.state);
+      if (label !== undefined) counts.set(label, (counts.get(label) ?? 0) + row.count);
+    }
+
+    dbUp.set(1);
+    dbProbeDuration.set(result.durationSeconds);
+    dbConnections.reset();
+    for (const state of CONNECTION_STATES) {
+      dbConnections.set({ state }, counts.get(state) ?? 0);
+    }
+  } catch {
+    // REQ-4.6: omit rather than report stale. With `tradr_db_up 0` still
+    // present, the absent connection series reads as "database down" —
+    // REQ-4.7's disambiguation doctrine.
+    dbUp.set(0);
+    dbProbeDuration.set((performance.now() - start) / 1000);
+    dbConnections.reset();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Test-only: drop the single-flight handle.
+ *
+ * A test that exercises the deadline leaves a probe that never settles, so the
+ * handle never clears and every later test in the file would join a dead
+ * promise and hang. Same shape as `positions.service.ts`'s
+ * `unregisterCloseHook`, which `test-setup.ts` consumes for the same reason.
+ */
+export function resetDbProbeStateForTests(): void {
+  inFlight = null;
+}

--- a/apps/api/src/features/metrics/metrics.registry.test.ts
+++ b/apps/api/src/features/metrics/metrics.registry.test.ts
@@ -1,0 +1,161 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { config } from '@/lib/config';
+
+import {
+  DURATION_BUCKETS,
+  buildInfo,
+  dbPoolMax,
+  httpRequestDuration,
+  initMetrics,
+  parseAppVersion,
+  registry,
+} from './metrics.registry';
+
+/**
+ * The REQ-5.3 boundaries as LITERALS, restated here on purpose. Comparing the
+ * export against itself (`toEqual(DURATION_BUCKETS)`) passes for any array, so
+ * the expected side of every bucket assertion below is this list and never the
+ * constant under test.
+ */
+const SPEC_DURATION_BUCKETS = [
+  0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 300,
+];
+
+describe('parseAppVersion (REQ-3.3, REQ-3.4, REQ-3.6)', () => {
+  it('splits the established v<semver>-<sha> form on the final dash', () => {
+    expect(parseAppVersion('v0.2.0-f51f9f5')).toEqual({
+      version: 'v0.2.0-f51f9f5',
+      commit: 'f51f9f5',
+    });
+  });
+
+  it('reports commit "unknown" for a bare semver with no dash', () => {
+    expect(parseAppVersion('v0.5.0')).toEqual({ version: 'v0.5.0', commit: 'unknown' });
+  });
+
+  it('treats a pre-release tag as a commit, matching the web half exactly', () => {
+    // The divergence case. This is NOT a sha, but the rule is "contains a dash",
+    // not a `v<semver>-<sha>` pattern match, because that is what the web half's
+    // shell `case` does. A tighter rule here would make the two halves disagree
+    // and report drift where there is none (REQ-3.6).
+    expect(parseAppVersion('v0.5.0-rc.1')).toEqual({ version: 'v0.5.0-rc.1', commit: 'rc.1' });
+  });
+
+  it('falls back to "unknown"/"unknown" when APP_VERSION is undefined', () => {
+    expect(parseAppVersion(undefined)).toEqual({ version: 'unknown', commit: 'unknown' });
+  });
+
+  it('falls back to "unknown"/"unknown" when APP_VERSION is set but EMPTY', () => {
+    // The regression case. `Dockerfile.api`'s `ENV APP_VERSION=${APP_VERSION}`
+    // always SETS the variable, and config's APP_VERSION is a bare
+    // z.string().optional() with no ''→undefined preprocess — so an image built
+    // without a build-arg delivers ''. Anything but the fallback emits
+    // version="" and breaks the REQ-3.6 join with tradr_web_build_info.
+    expect(parseAppVersion('')).toEqual({ version: 'unknown', commit: 'unknown' });
+  });
+});
+
+describe('metric contract', () => {
+  it('exposes the Prometheus text exposition content type verbatim (REQ-2.2)', () => {
+    // Asserted against the literal, not against prom-client's own constant, so a
+    // library change to the served content type fails loudly here.
+    expect(registry.contentType).toBe('text/plain; version=0.0.4; charset=utf-8');
+  });
+
+  it('pins DURATION_BUCKETS to the boundaries the spec names (REQ-5.3)', () => {
+    expect(DURATION_BUCKETS).toEqual(SPEC_DURATION_BUCKETS);
+    // Restated as intent: the long tail is the whole reason these are explicit —
+    // prom-client's defaults top out at 10 s.
+    expect(DURATION_BUCKETS).toContain(300);
+  });
+
+  it('declares exactly one label on the duration histogram — method, NEVER route (REQ-8.3)', () => {
+    // The DECLARED label set, not one read back off an observation: an
+    // observation only ever carries the labels this test itself passed in, so
+    // reading it back proves nothing about the contract. `labelNames` is
+    // assigned onto the instance by prom-client's Metric constructor but is not
+    // on its public type, hence the cast.
+    const declared = (httpRequestDuration as unknown as { labelNames: readonly string[] })
+      .labelNames;
+
+    // The mechanically-checkable half of the REQ-8.3 series budget: `route` on
+    // this histogram would cost ~2,730 series instead of ~85.
+    expect(declared).toEqual(['method']);
+  });
+
+  it('carries exactly those boundaries on the duration histogram', async () => {
+    // `get()` is async — awaiting it is what makes these assertions capable of
+    // failing at all. A labelled histogram has no values until something is
+    // observed, so observe once and read the bucket boundaries back out.
+    httpRequestDuration.observe({ method: 'GET' }, 0.3);
+    const metric = await httpRequestDuration.get();
+
+    const bucketBounds = metric.values
+      .filter((v) => v.metricName?.endsWith('_bucket'))
+      // `le` is a bucket label prom-client adds at serialization time, so it is
+      // absent from the declared label type.
+      .map((v) => (v.labels as Record<string, string | number>).le);
+    expect(bucketBounds).toEqual([...SPEC_DURATION_BUCKETS, '+Inf']);
+  });
+});
+
+describe('initMetrics (armed)', () => {
+  // ARM THE SURFACE FIRST, or every assertion below passes vacuously:
+  // initMetrics() returns at line 1 when !isMetricsConfigured(), and
+  // vitest.workspace.ts pins METRICS_ENABLED off — so under the default pin a
+  // build with NO idempotency guard at all would still satisfy "called twice
+  // does not throw", and tradr_build_info would have no samples to assert on.
+  // `config` is a plain mutable object read live by isMetricsConfigured().
+  //
+  // APP_VERSION is pinned for the same reason, one step further: it is NOT in
+  // vitest.workspace.ts's env block, so it is whatever the ambient environment
+  // happens to hold and the emitted labels would otherwise be unknowable. '' is
+  // the value that actually ships from `Dockerfile.api` when no build-arg is
+  // given, so pinning it here makes the label assertion deterministic AND keeps
+  // it sensitive to the empty-string fallback regressing.
+  const prev = { METRICS_ENABLED: config.METRICS_ENABLED, APP_VERSION: config.APP_VERSION };
+
+  beforeAll(() => {
+    config.METRICS_ENABLED = true;
+    config.APP_VERSION = '';
+  });
+
+  afterAll(() => {
+    config.METRICS_ENABLED = prev.METRICS_ENABLED;
+    config.APP_VERSION = prev.APP_VERSION;
+  });
+
+  it('is idempotent — a second call does not throw', () => {
+    expect(() => initMetrics()).not.toThrow();
+    expect(() => initMetrics()).not.toThrow();
+  });
+
+  it('emits tradr_build_info exactly once, as a constant 1 (REQ-3.1, REQ-3.5)', async () => {
+    const metric = await buildInfo.get();
+
+    expect(metric.values).toHaveLength(1);
+    expect(metric.values[0]?.value).toBe(1);
+    // LITERALS, not `parseAppVersion(config.APP_VERSION)` — comparing the
+    // emitted labels against the same function that produced them passes for
+    // any parse rule at all, including one that emits version="". These are the
+    // labels implied by the APP_VERSION='' pinned above.
+    expect(metric.values[0]?.labels).toEqual({ version: 'unknown', commit: 'unknown' });
+  });
+
+  it('seeds tradr_db_pool_max from DB_POOL_SIZE (REQ-4.4)', async () => {
+    // Label-free gauges are seeded to 0 by prom-client's constructor, so this
+    // assertion is only evidence while DB_POOL_SIZE is non-zero.
+    expect(config.DB_POOL_SIZE).toBeGreaterThan(0);
+
+    const metric = await dbPoolMax.get();
+    expect(metric.values[0]?.value).toBe(config.DB_POOL_SIZE);
+  });
+
+  it('collects the default process and Node runtime metrics (REQ-6.1, REQ-6.3)', async () => {
+    const names = (await registry.getMetricsAsJSON()).map((m) => m.name);
+
+    // Conventional names, deliberately NOT renamed under the tradr_ prefix.
+    expect(names.some((n) => n.startsWith('process_') || n.startsWith('nodejs_'))).toBe(true);
+  });
+});

--- a/apps/api/src/features/metrics/metrics.registry.ts
+++ b/apps/api/src/features/metrics/metrics.registry.ts
@@ -1,0 +1,177 @@
+import { Counter, Gauge, Histogram, Registry, collectDefaultMetrics } from 'prom-client';
+
+import { config, isMetricsConfigured } from '@/lib/config';
+
+/**
+ * The metric contract, in one file.
+ *
+ * A DEDICATED registry — never `prom-client`'s global default register. The
+ * default register is process-global shared state: anything else that ever
+ * imports `prom-client` (a dependency, a test helper) would silently land its
+ * metrics in our exposition, and `registry.clear()` in a test would wipe theirs.
+ *
+ * Everything here is allocation only. No timer is scheduled, no query is
+ * issued, and no sample is taken at module scope — `app.ts` builds the Hono app
+ * at module scope and imports the middleware statically, so this module is
+ * evaluated on every boot, including the ones where metrics are disabled.
+ * `initMetrics()` is the single gated step.
+ */
+export const registry = new Registry();
+
+/**
+ * Explicit histogram boundaries (REQ-5.3). NOT `prom-client`'s defaults, which
+ * top out at 10 s: the CSV import path sits behind a 300 s nginx timeout and an
+ * advisor turn behind a 180 s read timeout, so the defaults would drop every one
+ * of them into `+Inf` and report no latency at all for the slowest paths.
+ */
+export const DURATION_BUCKETS = [
+  0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 300,
+];
+
+/**
+ * Deployed build identity as labels on a constant `1` (REQ-3.1, REQ-3.5).
+ * The label set is IDENTICAL to `tradr_web_build_info` so the two join cleanly
+ * for drift detection after a two-half deploy (REQ-3.6, REQ-7.4).
+ */
+export const buildInfo = new Gauge<'version' | 'commit'>({
+  name: 'tradr_build_info',
+  help:
+    'Deployed build identity, always the constant 1 — the information is in the labels. ' +
+    'version is APP_VERSION as baked into the image at build time (the same value GET /api/health reports); ' +
+    'commit is the text after its final "-", or "unknown". ' +
+    'Join on version+commit against tradr_web_build_info to detect API/SPA drift after a partial deploy.',
+  labelNames: ['version', 'commit'],
+  registers: [registry],
+});
+
+/** Request counter (REQ-5.1). `route` is the matched PATTERN, never the raw path (REQ-5.5). */
+export const httpRequestsTotal = new Counter<'method' | 'route' | 'status'>({
+  name: 'tradr_http_requests_total',
+  help:
+    'Total HTTP requests handled by the API, by method, matched route pattern and numeric status. ' +
+    'route is the registered pattern (e.g. /api/positions/:positionId), never the raw request path, ' +
+    'and is "unmatched" when no application route matched.',
+  labelNames: ['method', 'route', 'status'],
+  registers: [registry],
+});
+
+/**
+ * Request latency (REQ-5.2). Labelled by `method` ONLY — deliberately NOT by
+ * `route`. A per-route histogram would cost ~2,730 series against the 2,000
+ * ceiling in REQ-8.3; per-route ERROR rate survives on the counter above, and
+ * per-route LATENCY is the accepted sacrifice.
+ */
+export const httpRequestDuration = new Histogram<'method'>({
+  name: 'tradr_http_request_duration_seconds',
+  help:
+    'HTTP request latency in seconds, measured to response start (headers flushed), not to connection close — ' +
+    'for the SSE advisor streams those differ by minutes and only response start is meaningful. ' +
+    'Labelled by method only, not by route: a per-route histogram would not fit the series budget, ' +
+    'so use tradr_http_requests_total for per-route error rate.',
+  labelNames: ['method'],
+  buckets: DURATION_BUCKETS,
+  registers: [registry],
+});
+
+/** Database liveness (REQ-4.1). */
+export const dbUp = new Gauge({
+  name: 'tradr_db_up',
+  help:
+    'Database liveness: 1 when the scrape-time SELECT 1 succeeded, 0 when it failed or timed out. ' +
+    'A scrape that finds a probe already in flight joins it rather than opening a second transaction, ' +
+    "so a concurrent scrape publishes ANOTHER scrape's SELECT 1 result rather than one it took itself — " +
+    "exactly as tradr_db_connections may publish another scrape's row counts. " +
+    'This is also the discriminator for absent tradr_db_connections: absent with tradr_db_up 0 means ' +
+    'the database is down; absent with no tradr_db_up at all means the instance is not scrapeable.',
+  registers: [registry],
+});
+
+/** Probe latency (REQ-4.2) — a gauge, because one sample per scrape supports no quantiles. */
+export const dbProbeDuration = new Gauge({
+  name: 'tradr_db_probe_duration_seconds',
+  help:
+    'Duration in seconds of the scrape-time database probe. This is WIDER than the SELECT 1 alone: ' +
+    'it is measured from before the transaction opens, so it includes the BEGIN and the SET LOCAL statement_timeout ' +
+    'that bound the probe. It can also exceed the 5 s scrape deadline — a scrape that finds a probe already in flight ' +
+    "joins it and publishes THAT probe's measured duration, a probe it did not itself take and which started earlier.",
+  registers: [registry],
+});
+
+/** Connection load from `pg_stat_activity` (REQ-4.3). */
+export const dbConnections = new Gauge<'state'>({
+  name: 'tradr_db_connections',
+  help:
+    'Backend connections to the current database by state, from pg_stat_activity. ' +
+    'DATABASE-GLOBAL, NOT PROCESS-LOCAL: every API instance reports the same counts, and those counts also include ' +
+    'the CLI, running migrations and any psql session — so a dashboard that SUMS this across instances over-counts ' +
+    'by the replica factor. Compare a single instance against tradr_db_pool_max instead. ' +
+    "A scrape that finds a probe already in flight publishes that probe's row counts rather than sampling again, " +
+    'and the series is omitted entirely (rather than reported stale) when the probe fails.',
+  labelNames: ['state'],
+  registers: [registry],
+});
+
+/** The saturation denominator (REQ-4.4) — without it the connection gauge cannot express pressure. */
+export const dbPoolMax = new Gauge({
+  name: 'tradr_db_pool_max',
+  help:
+    "Configured maximum size of this instance's database connection pool (DB_POOL_SIZE). " +
+    'The denominator for tradr_db_connections — postgres.js exposes no pool statistics of its own, ' +
+    'so this is the only saturation reference available.',
+  registers: [registry],
+});
+
+/**
+ * Split `APP_VERSION` into the `version` + `commit` label pair (REQ-3.3, REQ-3.4).
+ *
+ * Exported and pure so the cases are testable: `initMetrics()` is deliberately
+ * idempotent and can therefore only ever be driven with one value.
+ *
+ * The fallback triggers on EMPTY as well as undefined. `Dockerfile.api`'s
+ * `ENV APP_VERSION=${APP_VERSION}` always *sets* the variable, and config's
+ * `APP_VERSION` is a bare `z.string().optional()` with no ''→undefined
+ * preprocess, so an image built without a build-arg delivers `''`. Emitting
+ * `version=""` there would break the REQ-3.6 join with the web half — hence the
+ * same truthiness test `health.route.ts` uses.
+ *
+ * The commit split is "contains a `-`", NOT a `v<semver>-<sha>` pattern match.
+ * That is exactly what the web half's shell `case` does, and any tighter rule
+ * makes the two halves disagree on values like `v0.5.0-rc.1` and report drift
+ * where there is none.
+ */
+export function parseAppVersion(raw: string | undefined): { version: string; commit: string } {
+  if (!raw) return { version: 'unknown', commit: 'unknown' };
+
+  const lastDash = raw.lastIndexOf('-');
+  if (lastDash === -1) return { version: raw, commit: 'unknown' };
+
+  return { version: raw, commit: raw.slice(lastDash + 1) };
+}
+
+let initialised = false;
+
+/**
+ * The one gated boot step: seed the static facts and start default collection.
+ *
+ * A no-op when metrics are disabled (REQ-1.5, REQ-6.4) and idempotent.
+ *
+ * The guard exists for `collectDefaultMetrics()`, which schedules an interval —
+ * NOT for module re-imports. A second module evaluation constructs new metric
+ * objects and `prom-client` throws on the first duplicate name, which no boolean
+ * here could prevent; `vitest.workspace.ts`'s `pool: 'forks'` already gives each
+ * test file its own module graph.
+ */
+export function initMetrics(): void {
+  if (!isMetricsConfigured()) return;
+  if (initialised) return;
+  initialised = true;
+
+  const { version, commit } = parseAppVersion(config.APP_VERSION);
+  buildInfo.set({ version, commit }, 1);
+
+  dbPoolMax.set(config.DB_POOL_SIZE);
+
+  // REQ-6: process_* / nodejs_* keep their conventional names, unprefixed, so
+  // community dashboards and alert rules work unmodified.
+  collectDefaultMetrics({ register: registry });
+}

--- a/apps/api/src/features/metrics/metrics.server.test.ts
+++ b/apps/api/src/features/metrics/metrics.server.test.ts
@@ -1,0 +1,369 @@
+import { Gauge } from 'prom-client';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import type { Transaction } from '@/db';
+import { config } from '@/lib/config';
+import { withTransaction } from '@/lib/transaction';
+
+import { resetDbProbeStateForTests } from './metrics.collectors';
+import { httpRequestDuration, httpRequestsTotal, initMetrics, registry } from './metrics.registry';
+import { createMetricsApp } from './metrics.server';
+
+/**
+ * The SAME seam Task 3's collector test uses, and for the same reason:
+ * `test-setup.ts` already mocks `@/db` and reassigns `db` to a live drizzle
+ * `Transaction` in every `beforeEach`, AFTER any per-file mock — so a per-file
+ * `@/db` mock is silently replaced and the "database is down" scrape would
+ * quietly run a real `pg_stat_activity` query and succeed. `@/lib/transaction`
+ * is a bare passthrough `test-setup.ts` never touches.
+ */
+vi.mock('@/lib/transaction', () => ({ withTransaction: vi.fn() }));
+
+const withTransactionMock = vi.mocked(withTransaction);
+
+/** REQ-2.2, as a literal — never `registry.contentType`, which compares the served value to itself. */
+const CONTENT_TYPE = 'text/plain; version=0.0.4; charset=utf-8';
+
+/**
+ * APP_VERSION is the one telemetry-relevant variable `vitest.workspace.ts` does
+ * NOT pin, so without this it is whatever the ambient environment holds and the
+ * emitted `tradr_build_info` labels are unknowable. Pinned to the established
+ * `v<semver>-<sha>` shape, and the assertion below states the resulting labels as
+ * LITERALS rather than re-deriving them with `parseAppVersion` — comparing the
+ * emitted labels against the function that produced them passes for any parse
+ * rule at all.
+ */
+const APP_VERSION_PIN = 'v9.9.9-abc1234';
+const EXPECTED_VERSION_LABEL = 'version="v9.9.9-abc1234"';
+const EXPECTED_COMMIT_LABEL = 'commit="abc1234"';
+
+/**
+ * Postgres's OWN spelling, not the label spelling. `pg_stat_activity.state`
+ * returns `idle in transaction` — spaces, no underscores — and the collector
+ * translates it to the `idle_in_transaction` LABEL. A fixture written in the
+ * label spelling would exercise a vocabulary Postgres never emits.
+ */
+const HEALTHY_ROWS = [
+  { state: 'active', count: 1 },
+  { state: 'idle', count: 2 },
+  { state: 'idle in transaction', count: 3 },
+];
+
+/**
+ * Make `withTransaction` actually RUN the collector's callback against a fake
+ * transaction, so the probe walks its real three-statement path. A plain
+ * `mockResolvedValue` never runs the callback.
+ */
+function stubHealthyTransaction(): void {
+  const execute = vi.fn();
+  execute.mockResolvedValueOnce([]); // SET LOCAL statement_timeout
+  execute.mockResolvedValueOnce([{ ok: 1 }]); // SELECT 1
+  execute.mockResolvedValueOnce(HEALTHY_ROWS); // pg_stat_activity aggregate
+
+  withTransactionMock.mockReset();
+  withTransactionMock.mockImplementation(async (_db, callback) =>
+    callback({ execute } as unknown as Transaction),
+  );
+}
+
+/**
+ * One scrape against a FRESH app instance. `createMetricsApp()` is a factory
+ * precisely so this never binds a socket — `startMetricsServer()` is the only
+ * thing that ever listens, and nothing in this file calls it.
+ *
+ * The single-flight handle is cleared first: a probe left in flight by an earlier
+ * scrape would be JOINED rather than re-run, and the join would publish the
+ * previous stub's result.
+ */
+async function scrape(path = '/metrics'): Promise<Response> {
+  resetDbProbeStateForTests();
+  return createMetricsApp().request(path);
+}
+
+// ── The structural checker (rules stated with the assertions that use them) ──
+//
+// Hand-rolled on purpose: no Prometheus text parser exists in this workspace and
+// this spec authorises exactly one new dependency (`prom-client`), which is not
+// one. Four rules, all four exercised below.
+
+/** Rule 1: the shape of a sample line — `name`, an optional `{labels}`, whitespace, one value token. */
+const SAMPLE_LINE = /^[a-zA-Z_:][a-zA-Z0-9_:]*(\{[^}]*\})?\s+\S+$/;
+
+/** Rule 4: the closed set of Prometheus metric types. */
+const METRIC_TYPES = new Set(['counter', 'gauge', 'histogram', 'summary', 'untyped']);
+
+/**
+ * Rule 2's suffix strip, and it is CONDITIONAL.
+ *
+ * Prometheus histograms and summaries serialise as `X_bucket` / `X_sum` /
+ * `X_count` samples while `# HELP` and `# TYPE` are emitted under the base name
+ * `X` only. A naive "every sample name has a HELP and a TYPE" check therefore
+ * reds on every histogram in the registry — including this spec's own
+ * `tradr_http_request_duration_seconds`, and nondeterministically on
+ * `nodejs_gc_duration_seconds` once a GC has fired.
+ *
+ * The strip is applied only when the stripped base actually names a family whose
+ * declared type is `histogram` or `summary`, so a counter or gauge that happens
+ * to END in one of these words keeps its full name.
+ *
+ * `_total` is NEVER stripped: seven real families here are *named* with it —
+ * `tradr_http_requests_total`, `process_cpu_seconds_total`,
+ * `nodejs_active_resources_total` and friends — and stripping it would look up
+ * families that do not exist.
+ */
+const COMPONENT_SUFFIXES = ['_bucket', '_sum', '_count'] as const;
+
+function familyOf(sampleName: string, types: Map<string, string>): string {
+  for (const suffix of COMPONENT_SUFFIXES) {
+    if (!sampleName.endsWith(suffix)) continue;
+    const base = sampleName.slice(0, -suffix.length);
+    const baseType = types.get(base);
+    if (baseType === 'histogram' || baseType === 'summary') return base;
+  }
+  return sampleName;
+}
+
+function nameOf(sampleLine: string): string {
+  return /^[a-zA-Z_:][a-zA-Z0-9_:]*/.exec(sampleLine)?.[0] ?? '';
+}
+
+function contentLines(body: string): string[] {
+  return body.split('\n').filter((line) => line.trim() !== '');
+}
+
+function sampleLines(body: string): string[] {
+  return contentLines(body).filter((line) => !line.startsWith('#'));
+}
+
+function helpNames(body: string): string[] {
+  return contentLines(body)
+    .filter((line) => line.startsWith('# HELP '))
+    .map((line) => line.split(/\s+/)[2] ?? '');
+}
+
+/** Every `# TYPE` line as `{ name, type }` — `type` is the FOURTH token, after `#`, `TYPE`, name. */
+function typeLines(body: string): Array<{ name: string; type: string }> {
+  return contentLines(body)
+    .filter((line) => line.startsWith('# TYPE '))
+    .map((line) => {
+      const tokens = line.split(/\s+/);
+      return { name: tokens[2] ?? '', type: tokens[3] ?? '' };
+    });
+}
+
+/** Sample lines for `tradr_db_connections`, which is labelled and so never zero-seeded. */
+function connectionSamples(body: string): string[] {
+  return sampleLines(body).filter((line) => line.startsWith('tradr_db_connections{'));
+}
+
+// ── Arming the surface ───────────────────────────────────────────────────────
+// WITHOUT THIS EVERY ASSERTION BELOW IS VACUOUS. `initMetrics()` returns at its
+// first line when `!isMetricsConfigured()`, and `vitest.workspace.ts` pins
+// METRICS_ENABLED off — so `tradr_build_info` would have no sample and no
+// `process_*`/`nodejs_*` series would exist at all. `config` is a plain mutable
+// object read live by `isMetricsConfigured()` (the `app.split-origin.test.ts`
+// mutate-and-restore precedent).
+
+const previous = { METRICS_ENABLED: config.METRICS_ENABLED, APP_VERSION: config.APP_VERSION };
+
+/** The exposition every structural case reads, captured once from a healthy scrape. */
+let body: string;
+let response: Response;
+
+beforeAll(async () => {
+  config.METRICS_ENABLED = true;
+  config.APP_VERSION = APP_VERSION_PIN;
+  initMetrics();
+
+  // Seed the two shapes rule 2 exists for. Without an observation the histogram
+  // emits HELP/TYPE and no samples, so the `_bucket`/`_sum`/`_count` case the
+  // conditional strip handles would never appear in the body being checked; and
+  // without an increment there is no `_total`-named sample to prove the strip
+  // leaves `_total` alone.
+  httpRequestDuration.observe({ method: 'GET' }, 0.42);
+  httpRequestsTotal.inc({ method: 'GET', route: '/metrics', status: '200' });
+
+  stubHealthyTransaction();
+  response = await scrape();
+  body = await response.text();
+});
+
+afterAll(() => {
+  config.METRICS_ENABLED = previous.METRICS_ENABLED;
+  config.APP_VERSION = previous.APP_VERSION;
+});
+
+describe('GET /metrics (REQ-2.1, REQ-2.2, REQ-9.1)', () => {
+  it('answers 200 with the Prometheus text exposition content type, verbatim', () => {
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe(CONTENT_TYPE);
+  });
+
+  it('rule 1 — every non-blank, non-comment line is a well-formed sample', () => {
+    const samples = sampleLines(body);
+    expect(samples.length).toBeGreaterThan(0);
+
+    for (const line of samples) {
+      expect(line, `malformed sample line: ${line}`).toMatch(SAMPLE_LINE);
+    }
+  });
+
+  it('rule 2 — every family named by a sample carries both a # HELP and a # TYPE line', () => {
+    const types = new Map(typeLines(body).map(({ name, type }) => [name, type]));
+    const help = new Set(helpNames(body));
+
+    const families = new Set(sampleLines(body).map((line) => familyOf(nameOf(line), types)));
+    expect(families.size).toBeGreaterThan(0);
+
+    for (const family of families) {
+      expect(help.has(family), `no # HELP for ${family}`).toBe(true);
+      expect(types.has(family), `no # TYPE for ${family}`).toBe(true);
+    }
+
+    // The two cases the conditional strip exists for, asserted directly so the
+    // rule above cannot pass merely because the body lacked them. A histogram
+    // whose components resolve to their base, and a counter NAMED with `_total`
+    // whose name must survive intact.
+    expect(families.has('tradr_http_request_duration_seconds')).toBe(true);
+    expect(families.has('tradr_http_requests_total')).toBe(true);
+    expect(
+      sampleLines(body).some((line) =>
+        line.startsWith('tradr_http_request_duration_seconds_bucket{'),
+      ),
+    ).toBe(true);
+  });
+
+  it('rule 3 — no metric family has a duplicate # TYPE line', () => {
+    const names = typeLines(body).map(({ name }) => name);
+    expect(names.length).toBeGreaterThan(0);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('rule 4 — every # TYPE line declares a known type in its fourth token', () => {
+    const declared = typeLines(body);
+    expect(declared.length).toBeGreaterThan(0);
+
+    for (const { name, type } of declared) {
+      expect(METRIC_TYPES.has(type), `${name} declares unknown type "${type}"`).toBe(true);
+    }
+  });
+
+  it('emits the tradr_build_info sample with the pinned version/commit labels (REQ-3.1)', () => {
+    // The assertion that actually proves initMetrics() RAN. prom-client emits
+    // `# HELP`/`# TYPE` for every registered metric whether or not it holds a
+    // value, so the structural rules above pass unchanged on a build that
+    // silently lost tradr_build_info, tradr_db_pool_max and all of REQ-6.
+    const [line, ...rest] = sampleLines(body).filter((l) => l.startsWith('tradr_build_info{'));
+
+    expect(line).toBeDefined();
+    expect(rest).toEqual([]);
+    expect(line).toContain(EXPECTED_VERSION_LABEL);
+    expect(line).toContain(EXPECTED_COMMIT_LABEL);
+    expect(line?.endsWith(' 1')).toBe(true);
+  });
+
+  it('emits at least one default runtime sample — process_* or nodejs_* (REQ-6.1, REQ-6.2)', () => {
+    // The disjunction is deliberate. Naming a specific default metric
+    // reintroduces a platform flake: process_open_fds / process_max_fds are
+    // Linux-gated while the heap and version metrics are not.
+    expect(
+      sampleLines(body).some((line) => line.startsWith('process_') || line.startsWith('nodejs_')),
+    ).toBe(true);
+  });
+});
+
+describe('the 404 is structural (REQ-2.7, REQ-9.2)', () => {
+  it('mounts exactly one route and serves no application route', async () => {
+    const metricsApp = createMetricsApp();
+
+    // The structural assertion: nothing but GET /metrics is registered, so
+    // Hono's default not-found is the whole answer. This reds on ANY second
+    // route, including one no behavioural probe below happens to hit.
+    expect(metricsApp.routes.map((r) => `${r.method} ${r.path}`)).toEqual(['GET /metrics']);
+
+    expect((await metricsApp.request('/')).status).toBe(404);
+    expect((await metricsApp.request('/metrics/extra')).status).toBe(404);
+    expect((await metricsApp.request('/metrics', { method: 'POST' })).status).toBe(404);
+    // An application route the composed app really does serve.
+    expect((await metricsApp.request('/api/health')).status).toBe(404);
+  });
+});
+
+describe('a database failure degrades the exposition, never the scrape (REQ-4.6, REQ-9.4)', () => {
+  it('takes tradr_db_up 1 → 0 and drops the connection samples, still answering 200', async () => {
+    // THE TRANSITION IS THE EVIDENCE. prom-client seeds a label-free gauge to 0
+    // at construction and a labelled one to no values at all, so "tradr_db_up 0
+    // with no tradr_db_connections samples" is EXACTLY the state of a registry
+    // the collector has never run against — a one-scrape assertion passes on a
+    // build with metrics.collectors.ts deleted outright.
+    stubHealthyTransaction();
+    const healthy = await scrape();
+    const healthyBody = await healthy.text();
+
+    expect(healthy.status).toBe(200);
+    expect(sampleLines(healthyBody)).toContain('tradr_db_up 1');
+    expect(connectionSamples(healthyBody).length).toBeGreaterThan(0);
+
+    withTransactionMock.mockReset();
+    withTransactionMock.mockRejectedValue(new Error('CONNECTION_ENDED'));
+
+    const down = await scrape();
+    const downBody = await down.text();
+
+    expect(down.status).toBe(200);
+    expect(down.headers.get('Content-Type')).toBe(CONTENT_TYPE);
+    expect(sampleLines(downBody)).toContain('tradr_db_up 0');
+    expect(connectionSamples(downBody)).toEqual([]);
+    // PARTIAL, not empty: everything unrelated to the database is still served.
+    expect(sampleLines(downBody).some((line) => line.startsWith('tradr_build_info{'))).toBe(true);
+  });
+});
+
+describe('a serialization failure degrades the exposition, never the scrape (REQ-4.6)', () => {
+  /** Test-only, removed in the `finally` below — it must never reach a real exposition. */
+  const EXPLOSIVE = 'tradr_test_explosive_collect';
+
+  it('answers 200 when a registered collect() hook throws during serialization', async () => {
+    // THE FAILURE THE COLLECTOR SEAM CANNOT REACH. `refreshDbMetrics()` swallows
+    // every database failure itself, so the stubbed `@/lib/transaction` above
+    // drives nothing past the handler's collector catch — while
+    // `registry.metrics()` runs the scrape-time `collect()` hook of every
+    // registered metric, exactly as `collectDefaultMetrics()` installs them, and
+    // a hook that throws rejects the serialization. Unwrapped, that rejection is
+    // a 500 and Prometheus marks the whole target down.
+    const explosive = new Gauge({
+      name: EXPLOSIVE,
+      help: 'test-only: a collect() hook that throws, to drive a real serialization failure',
+      registers: [registry],
+      collect() {
+        throw new Error('COLLECT_EXPLODED');
+      },
+    });
+
+    try {
+      expect(registry.getSingleMetric(EXPLOSIVE)).toBe(explosive);
+
+      // NOT VACUOUS: the hook genuinely takes serialization down. Without this
+      // the case below would pass just as happily on a prom-client that
+      // swallowed collect() errors, i.e. with nothing to wrap at all.
+      await expect(registry.metrics()).rejects.toThrow('COLLECT_EXPLODED');
+
+      stubHealthyTransaction();
+      const res = await scrape();
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Content-Type')).toBe(CONTENT_TYPE);
+      // Empty, not partial — a failed serialization leaves nothing to serve. The
+      // status and the content type are the whole assertion: an empty 200 reads
+      // as "this instance reports no metrics", a 500 as "this instance is
+      // unreachable".
+      expect(await res.text()).toBe('');
+    } finally {
+      registry.removeSingleMetric(EXPLOSIVE);
+    }
+
+    // The registry is whole again, so nothing here leaks into a later case or a
+    // repeat run of this file.
+    await expect(registry.metrics()).resolves.toContain('tradr_build_info{');
+  });
+});

--- a/apps/api/src/features/metrics/metrics.server.ts
+++ b/apps/api/src/features/metrics/metrics.server.ts
@@ -1,0 +1,134 @@
+import { type ServerType, serve } from '@hono/node-server';
+import { Hono } from 'hono';
+
+import { config, isMetricsConfigured } from '@/lib/config';
+import { logger } from '@/lib/logger';
+
+import { refreshDbMetrics } from './metrics.collectors';
+import { initMetrics, registry } from './metrics.registry';
+
+/**
+ * The scrape target, on its OWN listener (REQ-2.1, REQ-2.5).
+ *
+ * A second port rather than a route on the application server, because the
+ * exposition must not be reachable from wherever the API is reachable: network
+ * isolation is the whole access control (REQ-8.5 — no bearer token, no shared
+ * secret replicated into every scrape config). Nothing here is published in any
+ * OpenAPI document either, hence no `@swagger` block (REQ-10.4).
+ */
+
+/**
+ * Build the metrics app. A FACTORY, not an exported singleton, so a test can
+ * take a clean instance and drive it with `app.request()` without binding a
+ * socket — `startMetricsServer()` is the only thing that ever listens.
+ *
+ * Exactly ONE route is mounted. REQ-2.7's "404 on every other path" is therefore
+ * structural: there is nothing else to serve, so Hono's default not-found is the
+ * whole answer. No `notFound()` handler, no catch-all, and above all no
+ * application route — `metrics.server.test.ts` pins the registered route list to
+ * a single entry so adding a second one cannot pass unnoticed.
+ */
+export function createMetricsApp(): Hono {
+  const metricsApp = new Hono();
+
+  metricsApp.get('/metrics', async (c) => {
+    // THE WHOLE BODY IS WRAPPED, SERIALIZATION INCLUDED. `registry.metrics()` is
+    // not a pure string build: `collectDefaultMetrics()` registers scrape-time
+    // `collect()` hooks and serialization invokes every one of them
+    // (`prom-client/lib/gauge.js:108-112`), so a hook that throws rejects the
+    // serialization. Left outside the wrap that rejection propagates out of the
+    // handler and Hono answers 500 — which Prometheus records as `up == 0`, an
+    // instance that cannot be scraped at all, for a reason unrelated to the
+    // database. REQ-4.6 and the Reliability NFR are absolute here: a scrape
+    // NEVER throws, and a partial failure degrades to a partial exposition
+    // with `200`.
+    let exposition = '';
+
+    try {
+      // Every scrape is an ACTIVE database probe (REQ-4.9), awaited before
+      // serialization so the gauges it writes are in this response rather than
+      // the next one.
+      //
+      // Its OWN catch, nested rather than folded into the outer one, because the
+      // two failures degrade differently. `refreshDbMetrics()` never throws by
+      // contract — it publishes `tradr_db_up 0` and omits the connection series
+      // instead — and this is the second line of defence: a collector failure
+      // must still leave the process, runtime and build-info series to serve,
+      // which is exactly REQ-4.6's PARTIAL exposition. Folded into the outer
+      // catch it would skip serialization and degrade an unreachable database
+      // all the way down to an empty body.
+      try {
+        await refreshDbMetrics();
+      } catch (err) {
+        logger.warn('metrics: database collection failed; serving a partial exposition', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+
+      exposition = await registry.metrics();
+    } catch (err) {
+      // A failed serialization leaves nothing to serve, so the degraded body is
+      // empty — still `200`, and still the right content type, so the target
+      // stays up and the failure reads as "this instance reports no metrics"
+      // rather than "this instance is unreachable". Logged at `error`, not
+      // `warn`: unlike a database blip there is no external cause and no partial
+      // result, so it is always a defect in the exposition itself.
+      logger.error('metrics: serialization failed; serving an empty exposition', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    // `registry.contentType` is prom-client's own constant and is exactly
+    // `text/plain; version=0.0.4; charset=utf-8` (REQ-2.2). Taken from the
+    // registry rather than restated, so the served header can never drift from
+    // the format actually produced. On EVERY path, degraded or not.
+    return c.body(exposition, 200, { 'Content-Type': registry.contentType });
+  });
+
+  return metricsApp;
+}
+
+/**
+ * Start the metrics listener, or return `undefined` when metrics are disabled
+ * (REQ-1.4 — no listener is bound at all, the surface is absent rather than
+ * empty).
+ *
+ * DELIBERATELY SYNCHRONOUS. `index.ts` calls this straight after the main
+ * `serve()`, and same-tick execution is what guarantees no scrape can arrive
+ * before `initMetrics()` has run: an `async` variant would return at its first
+ * `await` with the listener already accepting connections and the registry not
+ * yet seeded, so an unlucky first scrape would report neither
+ * `tradr_build_info` nor any `process_*` series.
+ *
+ * `initMetrics()` is called here rather than in `app.ts` because this is the
+ * only place the metric VALUES are ever read; `app.ts` only needs the metric
+ * objects, which the registry module allocates at import.
+ */
+export function startMetricsServer(): ServerType | undefined {
+  if (!isMetricsConfigured()) return undefined;
+
+  initMetrics();
+
+  const metricsApp = createMetricsApp();
+  const server = serve({
+    fetch: metricsApp.fetch,
+    port: config.METRICS_PORT,
+    hostname: config.METRICS_HOST,
+  });
+
+  // A bind failure (EADDRINUSE) is logged at `error` and is NOT fatal, by
+  // design: refusing to serve the product because an observability port is taken
+  // inverts the priority. Unlike a mis-set SMTP config, the failure is
+  // immediately visible to the very system being configured — Prometheus reports
+  // `up == 0` for the target. Without this listener the same `error` event would
+  // instead reach the process as an unhandled `'error'` and kill the API.
+  server.on('error', (err: Error) => {
+    logger.error('Metrics listener failed; the API continues serving normally', {
+      host: config.METRICS_HOST,
+      port: config.METRICS_PORT,
+      error: err.message,
+    });
+  });
+
+  return server;
+}

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Stub the batching PostHog client so we control flush timing without a live
@@ -59,5 +62,67 @@ describe('flushTelemetry', () => {
     h.shutdownPostHog.mockRejectedValueOnce(new Error('flush down'));
 
     await expect(flushTelemetry()).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shutdown-ordering tripwire (metrics-instrumentation REQ-2.8).
+//
+// `main()` runs only under `NODE_ENV !== 'test'` and its `shutdown` closure is
+// not exported, so no behavioural test reaches the ordering at all — moving
+// `metricsServer?.close()` past `sql.end()` currently reds nothing. Rather than
+// restructure the bootstrap to make a signal handler drivable, this asserts the
+// order over the SOURCE, the `ledger-hook.ts` tripwire precedent in
+// accounting.service.test.ts (which likewise checks a property whose real
+// enforcement lives elsewhere). It cannot prove the handler behaves; it can and
+// does prove the one line whose position is the requirement.
+//
+// Kept deliberately narrow — three tokens, nothing else. Anything the
+// requirement does not pin (statement wrapping, comments, the order of the two
+// concurrent `Promise.all` drains) must be free to change without reddening it.
+// ---------------------------------------------------------------------------
+
+describe('shutdown ordering in index.ts (REQ-2.8) — source tripwire', () => {
+  it('closes the metrics listener after server.close() and before sql.end()', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'index.ts'), 'utf-8');
+
+    // Comments are stripped first, BOTH line-leading and trailing: the shutdown
+    // block's own prose NAMES `sql.end()` above the line being located, and
+    // index.ts already carries trailing comments on the shutdown statements, so
+    // an index taken over the raw text would order the comments rather than the
+    // code. Stripping can only ever remove text, so the worst it can do is turn
+    // a token unfindable — which fails loudly on the "not found" assertion.
+    const code = source
+      .replace(/\/\*[\s\S]*?\*\//g, '') // block and JSDoc comments
+      .replace(/\/\/.*$/gm, ''); // line comments, leading or trailing
+
+    // Scoped to the shutdown closure, because `flushTelemetry` is also DECLARED
+    // earlier in the file and a whole-file search would find that declaration
+    // instead of the call.
+    const start = code.indexOf('const shutdown = async');
+    expect(start, 'the shutdown closure was not found in index.ts').toBeGreaterThanOrEqual(0);
+    const shutdownBody = code.slice(start);
+
+    // Only the three tokens the requirement is actually about. The drains are
+    // deliberately NOT pinned: they sit inside a `Promise.all`, so swapping them
+    // is a semantic no-op that must not red this test.
+    //
+    // `server.close()` does not match inside `metricsServer?.close()` — that
+    // reads `Server?.close()`, capitalised and with the optional chain.
+    const ORDER = ['server.close()', 'metricsServer?.close()', 'sql.end()'];
+
+    const positions = ORDER.map((token) => ({ token, at: shutdownBody.indexOf(token) }));
+    for (const { token, at } of positions) {
+      expect(at, `not found in shutdown(): ${token}`).toBeGreaterThanOrEqual(0);
+    }
+
+    for (let i = 1; i < positions.length; i++) {
+      const before = positions[i - 1]!;
+      const after = positions[i]!;
+      expect(
+        before.at,
+        `${before.token} must come before ${after.token} in shutdown() — REQ-2.8 requires ${ORDER.join(' → ')}, because the collectors probe the database on every scrape: the listener has to stop after the server stops accepting connections and before the pool is torn down`,
+      ).toBeLessThan(after.at);
+    }
   });
 });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,6 +3,7 @@ import { serve } from '@hono/node-server';
 import { sql } from '@/db';
 import { runPostMigrations } from '@/db/migrate';
 import { bootstrapFirstAdmin } from '@/features/admin/admin.service';
+import { startMetricsServer } from '@/features/metrics/metrics.server';
 import { config } from '@/lib/config';
 import { logger } from '@/lib/logger';
 import { drainMailer, initMailer } from '@/lib/mailer';
@@ -92,12 +93,25 @@ async function main() {
 
   logger.info(`Server started on port ${config.PORT}`);
 
+  // The exposition listener (REQ-2.1), on its own private port. `undefined` when
+  // METRICS_ENABLED is off — nothing is bound at all (REQ-1.4). Synchronous, so
+  // initMetrics() has run before this line returns and no scrape can beat it.
+  const metricsServer = startMetricsServer();
+  if (metricsServer) {
+    logger.info(`Metrics listening on ${config.METRICS_HOST}:${config.METRICS_PORT}`);
+  }
+
   let shuttingDown = false;
   const shutdown = async () => {
     if (shuttingDown) return; // REQ-7.5 double-signal guard (SIGTERM then SIGINT)
     shuttingDown = true;
     logger.info('Shutting down...');
     server.close(); // stop accepting NEW connections (REQ-7.2 ordering)
+    // Closed alongside the main server and BEFORE the drains and sql.end()
+    // (REQ-2.8): a scrape arriving mid-shutdown runs an active database probe,
+    // so leaving the listener open past the connection teardown would answer it
+    // against a closed pool.
+    metricsServer?.close();
     // Concurrent bounded drains — telemetry 3 s, mailer 5 s (worst case 5 s,
     // inside the ~10 s Docker grace, D9). Neither ever rejects, so Promise.all
     // is safe. Does NOT await in-flight/SSE request drain.

--- a/apps/api/src/lib/config.test.ts
+++ b/apps/api/src/lib/config.test.ts
@@ -7,6 +7,7 @@ import {
   getCorsAllowedOrigins,
   isDirectDatabaseConfigured,
   isEmailConfigured,
+  isMetricsConfigured,
   isObjectStorageConfigured,
   isPostHogConfigured,
   isProSubscriptionConfigured,
@@ -815,6 +816,74 @@ describe('isEmailConfigured', () => {
     expect(isEmailConfigured()).toBe(true);
     config.SMTP_HOST = undefined;
     expect(isEmailConfigured()).toBe(false);
+  });
+});
+
+describe('envSchema.METRICS_ENABLED', () => {
+  it('parses "true" to boolean true', () => {
+    const parsed = envSchema.parse({ ...baseEnv, METRICS_ENABLED: 'true' });
+    expect(parsed.METRICS_ENABLED).toBe(true);
+  });
+
+  it('parses "false" to boolean false', () => {
+    const parsed = envSchema.parse({ ...baseEnv, METRICS_ENABLED: 'false' });
+    expect(parsed.METRICS_ENABLED).toBe(false);
+  });
+
+  it('defaults to false when unset', () => {
+    const parsed = envSchema.parse(baseEnv);
+    expect(parsed.METRICS_ENABLED).toBe(false);
+  });
+
+  it.each(['1', 'yes', '', '0', 'TRUE'])('rejects %j', (v) => {
+    const result = envSchema.safeParse({ ...baseEnv, METRICS_ENABLED: v });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('envSchema.METRICS_PORT', () => {
+  it('defaults to 9464 when unset', () => {
+    const parsed = envSchema.parse(baseEnv);
+    expect(parsed.METRICS_PORT).toBe(9464);
+  });
+
+  it('coerces a numeric string', () => {
+    const parsed = envSchema.parse({ ...baseEnv, METRICS_PORT: '9100' });
+    expect(parsed.METRICS_PORT).toBe(9100);
+  });
+});
+
+describe('envSchema.METRICS_HOST', () => {
+  it('defaults to 0.0.0.0 when unset', () => {
+    const parsed = envSchema.parse(baseEnv);
+    expect(parsed.METRICS_HOST).toBe('0.0.0.0');
+  });
+
+  it('passes through a provided value', () => {
+    const parsed = envSchema.parse({ ...baseEnv, METRICS_HOST: '127.0.0.1' });
+    expect(parsed.METRICS_HOST).toBe('127.0.0.1');
+  });
+});
+
+describe('isMetricsConfigured predicate', () => {
+  // Mutate + restore the live `config` object — the established config-mutation
+  // test pattern (isPostHogConfigured above). The self-host parity test only ever
+  // sees the pinned-off env, so the TRUE branch is exercised here.
+  const prev = { METRICS_ENABLED: config.METRICS_ENABLED };
+
+  afterEach(() => {
+    config.METRICS_ENABLED = prev.METRICS_ENABLED;
+  });
+
+  it('is false in the test env (vitest workspace pin-off)', () => {
+    expect(isMetricsConfigured()).toBe(false);
+  });
+
+  it('follows METRICS_ENABLED both ways (live read per call)', () => {
+    config.METRICS_ENABLED = true;
+    expect(isMetricsConfigured()).toBe(true);
+    config.METRICS_ENABLED = false;
+    expect(isMetricsConfigured()).toBe(false);
   });
 });
 

--- a/apps/api/src/lib/config.ts
+++ b/apps/api/src/lib/config.ts
@@ -341,6 +341,24 @@ export const envSchema = z.object({
     (v) => (v === '' ? undefined : v),
     z.string().url().default('https://www.sec.gov/files/company_tickers_exchange.json'),
   ),
+  // ─── Prometheus metrics exposition (REQ-1) ───────────────────────────────
+  // Default OFF — the surface is absent, not broken, when unconfigured. The
+  // SKIP_POST_MIGRATIONS / FEATURE_GATING idiom above — NOT z.coerce.boolean(),
+  // which coerces the STRING 'false' to true and would silently arm metrics on
+  // every instance that followed the documented compose default.
+  METRICS_ENABLED: z
+    .enum(['true', 'false'])
+    .default('false')
+    .transform((v) => v === 'true'),
+  // NOT presence signals — the SMTP_PORT / SMTP_TLS_MODE reasoning recorded on
+  // assertEmailConfigCoherence below: the production compose gives them value
+  // defaults on every instance, so their presence carries no operator intent.
+  // METRICS_ENABLED alone gates the capability, which is why there is no
+  // coherence assert here — one boolean plus two value-defaulted knobs has no
+  // partial state. A malformed port is already a boot error via z.coerce.number().
+  // 9464 collides with neither PORT (3100), WEB_PORT (8080), nor Fly's internal_port.
+  METRICS_PORT: z.coerce.number().default(9464),
+  METRICS_HOST: z.string().default('0.0.0.0'),
 });
 
 /** Where an operator can look up every variable, its default, and its format. */
@@ -441,6 +459,11 @@ export function isStockQuoteConfigured(): boolean {
 /** True when admin-platform feature gating is enabled (REQ-5.1 — default off). */
 export function isFeatureGatingEnabled(): boolean {
   return config.FEATURE_GATING;
+}
+
+/** True when the Prometheus exposition surface is enabled (REQ-1.1). */
+export function isMetricsConfigured(): boolean {
+  return config.METRICS_ENABLED;
 }
 
 /** Returns the platform API key for a provider, or undefined when unconfigured (REQ-10.3). */

--- a/apps/api/src/middleware/metrics.middleware.test.ts
+++ b/apps/api/src/middleware/metrics.middleware.test.ts
@@ -1,0 +1,170 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  httpRequestDuration,
+  httpRequestsTotal,
+  registry,
+} from '@/features/metrics/metrics.registry';
+
+import { metricsMiddleware } from './metrics.middleware';
+
+/**
+ * The middleware is exercised against a THROWAWAY Hono app, never the composed
+ * `app.ts`: registration there is import-time and gated on `isMetricsConfigured()`,
+ * so there is nothing to toggle post-import.
+ */
+
+/** Every `{method, route, status}` triple the counter holds, with its value. */
+async function counterSamples(): Promise<
+  { labels: Partial<Record<string, string | number>>; value: number }[]
+> {
+  const metric = await httpRequestsTotal.get();
+  return metric.values.map((v) => ({ labels: v.labels, value: v.value }));
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  registry.resetMetrics();
+});
+
+describe('metricsMiddleware route label (REQ-5.5, REQ-9.3)', () => {
+  it('labels a parameterised route with the PATTERN, not the raw path', async () => {
+    const app = new Hono();
+    app.use(metricsMiddleware);
+    app.get('/things/:id', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/things/abc');
+    expect(res.status).toBe(200);
+
+    // The cardinality guarantee: `/things/abc`, `/things/def`, … must all fold
+    // into one series. Reading routePath BEFORE `await next()` would yield the
+    // middleware's own registered path instead.
+    expect(await counterSamples()).toEqual([
+      { labels: { method: 'GET', route: '/things/:id', status: '200' }, value: 1 },
+    ]);
+  });
+
+  it('labels a genuinely unmatched path "unmatched" (REQ-5.7)', async () => {
+    const app = new Hono();
+    app.use(metricsMiddleware);
+    app.get('/things/:id', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/nope');
+    expect(res.status).toBe(404);
+
+    // Nothing matched, so the deepest dispatched handler is this middleware
+    // itself, registered at `/*`. That is the sentinel's whole mechanism.
+    expect(await counterSamples()).toEqual([
+      { labels: { method: 'GET', route: 'unmatched', status: '404' }, value: 1 },
+    ]);
+  });
+
+  it("keeps a MATCHED handler's pattern when it returns 404", async () => {
+    const app = new Hono();
+    app.use(metricsMiddleware);
+    // What `GET /api/positions/:positionId` does routinely for a missing id.
+    app.get('/things/:id', (c) => c.json({ error: 'NOT_FOUND' }, 404));
+
+    const res = await app.request('/things/abc');
+    expect(res.status).toBe(404);
+
+    // The distinction the sentinel rests on: a 404 from a matched handler is
+    // NOT `unmatched`. It rests on a hono implementation detail rather than a
+    // documented contract, so it is pinned here.
+    expect(await counterSamples()).toEqual([
+      { labels: { method: 'GET', route: '/things/:id', status: '404' }, value: 1 },
+    ]);
+  });
+
+  it('folds a short-circuiting later middleware into "unmatched" (the known merge)', async () => {
+    const app = new Hono();
+    app.use(metricsMiddleware);
+    // Stands in for csrfMiddleware returning 403 CSRF_FORBIDDEN without calling
+    // next(). Because it sits AFTER the metrics middleware, route dispatch never
+    // happens and the deepest handler is a global middleware at `/*` — so a
+    // pre-dispatch rejection shares the `unmatched` bucket with genuine 404s.
+    // Accepted (REQ-5.7's letter holds: no app route's handler ever matched)
+    // rather than reordering csrfMiddleware in front of instrumentation.
+    app.use(async (c) => c.json({ error: 'CSRF_FORBIDDEN' }, 403));
+    app.post('/things/:id', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/things/abc', { method: 'POST' });
+    expect(res.status).toBe(403);
+
+    expect(await counterSamples()).toEqual([
+      { labels: { method: 'POST', route: 'unmatched', status: '403' }, value: 1 },
+    ]);
+  });
+
+  it("labels a router-level short-circuit with the router's MOUNT WILDCARD", async () => {
+    const app = new Hono();
+    app.use(metricsMiddleware);
+
+    // Stands in for the 19 feature routers that call `router.use(authMiddleware)`:
+    // on an unauthenticated request it returns 401 without calling next(), so the
+    // router's own route is never dispatched.
+    const router = new Hono();
+    router.use(async (c) => c.json({ error: 'UNAUTHORIZED' }, 401));
+    router.get('/:id', (c) => c.json({ ok: true }));
+    app.route('/api/things', router);
+
+    const res = await app.request('/api/things/abc');
+    expect(res.status).toBe(401);
+
+    // A THIRD bucket, distinct from both the route pattern and the `unmatched`
+    // sentinel: `app.route()` merges the sub-router's bare `use()` (registered at
+    // `*`) onto the mount base, so the deepest dispatched handler's registered
+    // path is `/api/things/*`. Only a bare `/*` folds into `unmatched`, so this
+    // survives verbatim. Bounded at one extra value per mounted router (REQ-8.2).
+    expect(await counterSamples()).toEqual([
+      { labels: { method: 'GET', route: '/api/things/*', status: '401' }, value: 1 },
+    ]);
+  });
+});
+
+describe('metricsMiddleware histogram (REQ-5.2, REQ-8.3)', () => {
+  it('records a sample carrying method (and le) but NEVER a route label', async () => {
+    const app = new Hono();
+    app.use(metricsMiddleware);
+    app.get('/things/:id', (c) => c.json({ ok: true }));
+
+    await app.request('/things/abc');
+
+    const metric = await httpRequestDuration.get();
+    // Non-empty matters: observing with an undeclared `route` label makes
+    // prom-client throw, which the recorder swallows and leaves NO samples —
+    // an empty list would satisfy a bare "no route label" loop vacuously.
+    expect(metric.values.length).toBeGreaterThan(0);
+
+    const labelKeys = new Set(metric.values.flatMap((v) => Object.keys(v.labels)));
+    expect(labelKeys.has('route')).toBe(false);
+    expect(labelKeys).toEqual(new Set(['method', 'le']));
+
+    const count = metric.values.find((v) => v.metricName?.endsWith('_count'));
+    expect(count?.value).toBe(1);
+    expect(count?.labels).toEqual({ method: 'GET' });
+  });
+});
+
+describe('metricsMiddleware reliability NFR', () => {
+  it('a recorder that throws does not change the response', async () => {
+    // logger.warn writes a JSON line to stdout; keep the run quiet.
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(httpRequestsTotal, 'inc').mockImplementation(() => {
+      throw new Error('registry exploded');
+    });
+
+    const app = new Hono();
+    app.use(metricsMiddleware);
+    app.get('/things/:id', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/things/abc');
+
+    // Recording happens strictly after `await next()`, so the response is
+    // already produced — the worst case is one lost sample.
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(log).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/middleware/metrics.middleware.ts
+++ b/apps/api/src/middleware/metrics.middleware.ts
@@ -1,0 +1,70 @@
+import { createMiddleware } from 'hono/factory';
+import { routePath } from 'hono/route';
+
+import { httpRequestDuration, httpRequestsTotal } from '@/features/metrics/metrics.registry';
+import { logger } from '@/lib/logger';
+
+/**
+ * The bounded stand-in for "no application route matched" (REQ-5.7).
+ *
+ * With nothing matched, the deepest dispatched handler is the last global
+ * middleware, whose registered path is `/*` — hono's `#addRoute` merges a bare
+ * `app.use(handler)` (registered with `#path = "*"`) onto the base path. A
+ * MATCHED handler that returns 404 resolves to its own pattern instead, so the
+ * two are distinguishable; `metrics.middleware.test.ts` pins that, because it
+ * rests on an implementation detail rather than a documented contract.
+ */
+const UNMATCHED = 'unmatched';
+
+/**
+ * Per-request rate, error rate and latency (REQ-5).
+ *
+ * Three mechanics that are easy to get silently wrong:
+ *
+ * 1. `routePath` comes from `hono/route`. `c.req.routePath` is `@deprecated` in
+ *    the installed hono 4.12.8 and points here.
+ * 2. It MUST be read AFTER `await next()`. The helper resolves
+ *    `matchedRoutes(c).at(c.req.routeIndex)`, and `compose.js` assigns
+ *    `context.req.routeIndex = i` before each dispatched handler and never
+ *    restores it on unwind — so read beforehand, a global middleware gets its
+ *    own registered path (`/*`) for every request.
+ * 3. Recording is wrapped so a throw can never reach the response path (design
+ *    §Error Scenario 4, Reliability NFR). The response is already produced by
+ *    then, so the worst case is one lost sample.
+ *
+ * The elapsed time is measured to the point `await next()` returns, which is
+ * REQ-5.4's "response start": a Hono handler returns its `Response` as soon as
+ * the headers are settled, so for the SSE advisor streams this excludes the
+ * minutes of streaming that follow.
+ *
+ * FORWARD CONSTRAINT: the `route` label value must never contain `}`, which
+ * would break any consumer parsing the exposition's label block. Today it
+ * cannot — no route under `apps/api/src` uses hono's `{regex}` path-constraint
+ * syntax — so this is a note for whoever adds the first one, not a defect.
+ */
+export const metricsMiddleware = createMiddleware(async (c, next) => {
+  const start = performance.now();
+
+  await next();
+
+  const seconds = (performance.now() - start) / 1000;
+
+  try {
+    const method = c.req.method;
+    // `''` is `routePath`'s documented "nothing at this index" return. It is
+    // unreachable from inside a running middleware — this middleware is itself
+    // in the match result whenever it executes — so it is mapped defensively,
+    // not as a second sentinel value.
+    const resolved = routePath(c);
+    const route = resolved === '' || resolved === '/*' ? UNMATCHED : resolved;
+
+    httpRequestsTotal.inc({ method, route, status: String(c.res.status) });
+    // Labelled by method ONLY — deliberately no `route` label, which would not
+    // fit the series budget (registry, REQ-8.3).
+    httpRequestDuration.observe({ method }, seconds);
+  } catch (e) {
+    logger.warn('metrics recording failed', {
+      error: e instanceof Error ? e.message : String(e),
+    });
+  }
+});

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -188,6 +188,10 @@ export default defineConfig({
             },
             { label: 'Put TLS in front of the stack', slug: 'self-hosting/tls-reverse-proxy' },
             { label: 'Environment variables', slug: 'self-hosting/reference/env-vars' },
+            {
+              label: 'Operational metrics (Prometheus)',
+              slug: 'self-hosting/reference/operational-metrics',
+            },
             { label: 'CLI reference (tradr)', slug: 'self-hosting/reference/cli' },
             openAPISidebarGroup,
           ],

--- a/apps/docs/src/content/docs/self-hosting/reference/env-vars.mdx
+++ b/apps/docs/src/content/docs/self-hosting/reference/env-vars.mdx
@@ -7,7 +7,7 @@ description: Every environment variable Tradr reads, its default, and what it do
     Source: .env.example · Generator: apps/docs/scripts/gen-env-vars.mjs
     Run `pnpm --filter @tradr/docs env-vars:generate` after changing .env.example. */}
 
-Tradr reads **80 environment variables**, of which **3 are required** —
+Tradr reads **83 environment variables**, of which **3 are required** —
 everything else has a working default or turns a feature off when unset.
 
 This page is generated from [`.env.example`](https://github.com/madmatt112/tradr/blob/main/.env.example),
@@ -33,7 +33,7 @@ original `ENCRYPTION_KEY` nothing can decrypt them. See
 
 ## Reading the tables
 
-Of the 80 variables, **52 ship unset** — either commented out in the
+Of the 83 variables, **52 ship unset** — either commented out in the
 template or present with an empty value. An unset optional variable means the feature
 is **absent, not broken**: nothing logs an error and no outbound call is made.
 
@@ -81,6 +81,14 @@ is **absent, not broken**: nothing logs an error and no outbound call is made.
 | `ADVISOR_NGINX_PROXY_TIMEOUT` | `180s` | nginx proxy read timeout for advisor streaming responses. MUST exceed the app ADVISOR_STREAM_TIMEOUT_MS below, or nginx will cut the stream early. |
 | `CSV_IMPORT_NGINX_PROXY_TIMEOUT` | `300s` | nginx proxy read timeout for the dedicated /api/csv-import/ route. A large within-cap synchronous import can exceed nginx's default 60s; this raises the timeout for that route only (other routes unchanged). Keep CSV_IMPORT_CLAIM_TIMEOUT_SECONDS (api) ≥ 2 × this value — the two live in different containers and are hand-synced. |
 | `MAX_UPLOAD_SIZE` | `20m` | nginx client_max_body_size for uploads. Must accommodate ADVISOR_MAX_IMAGES_PER_MESSAGE images per request, or large uploads 413. OPERATOR CONSTRAINT: keep MAX_UPLOAD_SIZE ≥ CSV_IMPORT_MAX_FILE_BYTES (below), or oversized CSV imports are rejected by nginx before the api can size them. |
+
+## Metrics (Prometheus exposition)
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `METRICS_ENABLED` | `false` | Prometheus text-format metrics for the api container, served as GET /metrics on a listener of its own — separate from the application port, so the exposition is never reachable through the app's routes. It carries HTTP request counters and latency, database connection-state and probe gauges, Node.js process metrics, and a build-info gauge. OFF BY DEFAULT: the surface is absent, not broken, when unset. Set this to true to arm it. Only the literal values true and false parse; anything else is a startup error rather than a silent default. DO NOT PUBLISH THE METRICS PORT. The exposition is unauthenticated by design — network isolation is the control, because a bearer token copied into every scrape config is a worse posture than a private bind. It exposes no user data, only aggregate operational counters and the build version. Every scrape is an ACTIVE DATABASE PROBE: the connection-state and probe gauges are collected on demand, so the scrape interval you configure on the Prometheus side is a database load knob — on top of the SELECT 1 the Fly health check already issues every 15 seconds. |
+| `METRICS_PORT` | `9464` | Port the metrics listener binds inside the api container. Chosen to collide with neither the api port (3100), WEB_PORT, nor Fly's internal_port. Nothing publishes it: docker-compose.yml deliberately adds no ports: mapping for the api service — only web publishes a host port — and that omission is what keeps the surface off the public internet. Scrape it from another container on the same compose network, or over 6PN on Fly. |
+| `METRICS_HOST` | `0.0.0.0` | Address the metrics listener binds to. The default is deliberate, not lazy: 127.0.0.1 would bind the CONTAINER's own loopback and be unreachable from a Prometheus elsewhere on the compose network, and a Fly scrape arrives over 6PN rather than loopback. Binding all interfaces is already private in both documented deployments precisely because nothing publishes the port. Residual threat model: the listener becomes reachable from outside only if an operator adds a ports: mapping for the api service or runs it with host networking. This variable exists so those operators can narrow the bind to a specific interface instead of widening their exposure. |
 
 ## Advisor — encryption
 

--- a/apps/docs/src/content/docs/self-hosting/reference/operational-metrics.mdx
+++ b/apps/docs/src/content/docs/self-hosting/reference/operational-metrics.mdx
@@ -1,0 +1,512 @@
+---
+title: Operational metrics
+description: The Prometheus metric contract Tradr exposes — every metric name, type, label set, and meaning, how to turn the surface on, and what this feature deliberately does not deliver.
+---
+
+Tradr can expose operational metrics in the Prometheus text format: request
+rate, request latency, database health, Node.js process health, and the deployed
+build version. The surface is off by default. One variable turns it on.
+
+This page is the whole contract. It gives you enough to build a dashboard
+without reading the source.
+
+**This is not the [Metrics glossary](/user-guide/reference/metrics-glossary/).**
+That page defines the _trading_ figures Tradr computes — win rate, expectancy,
+profit factor. This page covers the _operational_ metrics an instance reports
+about itself.
+
+## What this feature does not deliver
+
+Read this first, so you know what you are getting.
+
+Tradr exposes metrics. It does not collect them. This feature ships no
+Prometheus, no Grafana, no agent, and no scrape configuration.
+
+- **Nothing scrapes these metrics.** This repository ships no scrape
+  configuration of any kind — no `prometheus.yml`, no service discovery, no
+  agent, and nothing in `docker-compose.yml` that reads either surface. Arming
+  the surface publishes it; bringing something to read it is your job.
+- **No dashboards ship.** There is no committed Grafana dashboard and no
+  observability overlay for the compose stack.
+- **No alert rules ship.** Collection, dashboarding, and alerting are all out of
+  scope.
+
+You point your own collector at the surface. Everything below tells you what it
+will find there.
+
+## Turn the surface on
+
+Set one variable in `.env`:
+
+```bash
+METRICS_ENABLED=true
+```
+
+Recreate the stack:
+
+```bash
+docker compose up -d
+```
+
+**Expected result:** `GET /metrics` on the api container's metrics port returns
+`200` with a Prometheus exposition.
+
+The variable reaches both the `api` and the `web` service. Only the literal
+values `true` and `false` parse. Any other value is a startup error, not a
+silent default.
+
+Two more variables tune the api listener. Both have working defaults. See
+[Environment variables](/self-hosting/reference/env-vars/) for the full entries.
+
+| Variable          | Default   | Does                                    |
+| ----------------- | --------- | --------------------------------------- |
+| `METRICS_ENABLED` | `false`   | Arms both exposition surfaces.          |
+| `METRICS_PORT`    | `9464`    | Port the api metrics listener binds.    |
+| `METRICS_HOST`    | `0.0.0.0` | Address the api metrics listener binds. |
+
+## The two surfaces
+
+Tradr exposes metrics from two places, and they behave differently.
+
+### The api container
+
+A **second listener**, separate from the application port. It serves exactly one
+route:
+
+```
+GET http://<api-container>:9464/metrics
+```
+
+The content type is `text/plain; version=0.0.4; charset=utf-8`. Every other path
+on that listener returns `404`, and no application route is reachable through
+it. The exposition carries no authentication and appears in no OpenAPI document.
+
+The listener is bound inside the container only. `docker-compose.yml` publishes
+no host port for the `api` service — `web` is the only service with a `ports:`
+mapping. Scrape the api from another container on the same compose network, or
+over 6PN on Fly.
+
+### The web container
+
+A **static file**, not a live endpoint. nginx has no runtime, so the container's
+entrypoint writes `/usr/share/nginx/html/metrics` at container start and nginx
+serves it at `/metrics` with content type `text/plain; version=0.0.4`.
+
+The file is rewritten on every container start, so a stale version cannot
+survive a redeploy. With `METRICS_ENABLED` unset or `false` the entrypoint
+deletes the file and `/metrics` returns nginx's own `404`.
+
+**The web `/metrics` path sits on the published port.** `web` is the only
+publicly reachable service in the compose stack. Arming metrics on the web
+container therefore publishes your exact build identity to anyone who can reach
+the app. That is the whole reason the file is gated rather than always written.
+It contains one metric and nothing else.
+
+## The metric contract
+
+### API metrics
+
+| Metric                                | Type                      | Labels                      | Meaning                                                                                         |
+| ------------------------------------- | ------------------------- | --------------------------- | ----------------------------------------------------------------------------------------------- |
+| `tradr_build_info`                    | gauge                     | `version`, `commit`         | API build identity. Always the constant `1` — the information is in the labels.                 |
+| `tradr_http_requests_total`           | counter                   | `method`, `route`, `status` | HTTP requests handled, by method, matched route pattern, and numeric status.                    |
+| `tradr_http_request_duration_seconds` | histogram                 | `method`                    | Request latency in seconds, measured to response start. No `route` label.                       |
+| `tradr_db_up`                         | gauge                     | —                           | `1` when the scrape-time `SELECT 1` succeeded, `0` when it failed or timed out.                 |
+| `tradr_db_probe_duration_seconds`     | gauge                     | —                           | Duration in seconds of the scrape-time database probe.                                          |
+| `tradr_db_connections`                | gauge                     | `state`                     | Backend connections to the current database by state, from `pg_stat_activity`. Database-global. |
+| `tradr_db_pool_max`                   | gauge                     | —                           | Configured maximum size of this instance's connection pool (`DB_POOL_SIZE`, default `10`).      |
+| `process_*`, `nodejs_*`               | counter, gauge, histogram | various                     | Node.js process and runtime metrics.                                                            |
+
+`tradr_db_probe_duration_seconds` and `tradr_db_pool_max` are gauges by
+decision, not by accident. One probe sample per scrape supports no quantiles, so
+a histogram of it would be misleading.
+
+The `process_*` and `nodejs_*` metrics keep their conventional names rather than
+taking the `tradr_` prefix, so standard community dashboards and alert rules work
+unmodified.
+
+The set is 31 metrics. It covers resident memory, heap size and use, event-loop
+lag (including percentiles), and garbage-collection duration. It also covers CPU
+time, open file descriptors, active handles and requests, process start time, and
+the Node.js version.
+
+### Web metrics
+
+| Metric                 | Type  | Labels              | Meaning                                      |
+| ---------------------- | ----- | ------------------- | -------------------------------------------- |
+| `tradr_web_build_info` | gauge | `version`, `commit` | SPA build identity. Always the constant `1`. |
+
+That is the entire web exposition. Three lines: `# HELP`, `# TYPE`, and one
+sample.
+
+## The labels
+
+### `route` has three classes of value
+
+A dashboard shows all three. Each means something different.
+
+| Class                   | Example                      | Means                                                                                                                                                                         |
+| ----------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A matched route pattern | `/api/positions/:positionId` | An application route handled the request. The label is always the registered pattern, never the raw path — so `/api/positions/abc` and `/api/positions/def` share one series. |
+| A router mount wildcard | `/api/positions/*`           | A per-router middleware answered before route dispatch. Almost always `authMiddleware` returning `401`.                                                                       |
+| `unmatched`             | `unmatched`                  | No route matched, or a _global_ middleware answered before route dispatch.                                                                                                    |
+
+The middle class is the one that surprises people, and it is the highest-volume
+non-`2xx` class in the product. Most feature routers apply authentication as a
+wildcard middleware over the whole router, so an unauthenticated request is
+rejected before it reaches a route pattern and is counted against the router's
+mount path with a trailing `*`. Routers mounted bare at `/api` produce `/api/*`.
+
+Not all of them do. A handful of routes attach authentication per route instead
+— `GET /api/auth/me` among them — and those `401`s carry their own route pattern
+rather than a wildcard. So a wildcard value is the common shape of an
+unauthenticated request, not the only one.
+
+`unmatched` covers two cases that a dashboard cannot tell apart. The first is a
+genuine `404` for a path no route declares. The second is a request that
+split-origin CORS or anti-CSRF rejected before dispatch. That second case arises
+only on a split-origin deployment. With `CORS_ALLOWED_ORIGINS` unset, both
+middleware are pure pass-through.
+
+A route that _matched_ and then returned `404` — `GET /api/positions/:positionId`
+for an id that does not exist — keeps its own pattern. It is not counted as
+`unmatched`.
+
+The set stays bounded. Each mounted router adds at most one wildcard value.
+
+### The other labels
+
+| Label     | On                                                                 | Values                                                                                                                                     |
+| --------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `method`  | `tradr_http_requests_total`, `tradr_http_request_duration_seconds` | The HTTP method: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`.                                                                                  |
+| `status`  | `tradr_http_requests_total`                                        | The numeric HTTP status code, as a string.                                                                                                 |
+| `state`   | `tradr_db_connections`                                             | `active`, `idle`, `idle_in_transaction`. Exactly three, enumerated explicitly, so a state outside that set adds no series. See below.      |
+| `version` | `tradr_build_info`, `tradr_web_build_info`                         | `APP_VERSION` verbatim, or `unknown`.                                                                                                      |
+| `commit`  | `tradr_build_info`, `tradr_web_build_info`                         | The text after the final `-` in `APP_VERSION`, or `unknown`.                                                                               |
+
+### `state` is not Postgres's spelling
+
+The `state` label values are Tradr's, not `pg_stat_activity`'s. Postgres writes
+the transaction states as words with spaces; the label uses underscores, and the
+mapping is deliberately many-to-one:
+
+| `pg_stat_activity.state`        | `state` label         |
+| ------------------------------- | --------------------- |
+| `active`                        | `active`              |
+| `idle`                          | `idle`                |
+| `idle in transaction`           | `idle_in_transaction` |
+| `idle in transaction (aborted)` | `idle_in_transaction` |
+
+**The aborted variant is folded in, not dropped.** A transaction that has errored
+but not yet rolled back still holds its backend and still pins the oldest
+transaction id, so it saturates the pool exactly as a live one does — and it can
+never do useful work, which makes it the worse half of the signal. Counting it
+separately would add a fourth label value; discarding it would hide the problem.
+
+Every remaining state Postgres can report — `fastpath function call`, `disabled`,
+and a null state — is excluded and contributes no series. That is what keeps the
+set at three regardless of what the database returns.
+
+`tradr_http_request_duration_seconds` carries **no `route` label**, deliberately.
+A per-route histogram costs about 2,730 series against a 2,000-series budget. Per-route
+error rate survives on `tradr_http_requests_total`; per-route latency is the
+sacrifice. Its buckets are explicit, not the library defaults, and reach the long
+tail of this API: `0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30,
+60, 300` seconds. CSV import sits behind a 300-second timeout, so the library's
+10-second ceiling would report no latency at all for the slowest path.
+
+Latency is measured to **response start**, when the headers flush, not to
+connection close. For the advisor's streaming responses the two differ by
+minutes, and only response start is meaningful.
+
+## Every scrape is a database probe
+
+`tradr_db_up`, `tradr_db_probe_duration_seconds`, and `tradr_db_connections` are
+sampled on demand. The api opens a transaction, sets a statement timeout, runs
+`SELECT 1`, then queries `pg_stat_activity`. It does this _while answering the
+scrape_, before it serializes the exposition.
+
+**Your scrape interval is therefore a database load knob.** Scraping every 5
+seconds runs that probe every 5 seconds, on top of any health check your platform
+already issues. Choose the interval accordingly.
+
+The probe is bounded on both sides. A server-side `statement_timeout` of 1 second
+caps the two statements that do work. A client-side deadline of 5 seconds caps
+the whole probe. That is half of Prometheus's default 10-second scrape timeout,
+so a hung database reports as down rather than timing the scrape out.
+
+### At most one probe per scrape, not exactly one
+
+A scrape that finds a probe already in flight **joins it** instead of opening a
+second transaction. This bounds the connection pool: however often you scrape, at
+most one connection is ever committed to the probe.
+
+The consequence matters when you read the numbers. Two overlapping scrapes share
+one probe, and the second one publishes values it did not measure. That applies
+to `tradr_db_up`, `tradr_db_probe_duration_seconds`, and `tradr_db_connections`
+alike.
+
+This is also why `tradr_db_probe_duration_seconds` can exceed the 5-second
+ceiling. A joining scrape publishes the duration the _original_ probe measured,
+and that probe started earlier.
+
+`tradr_db_probe_duration_seconds` is also wider than the `SELECT 1` alone. The
+clock starts before the transaction opens, so the value includes the `BEGIN` and
+the `SET LOCAL statement_timeout` that bound the probe.
+
+## Reading `tradr_db_connections`
+
+**The value is database-global, not process-local.** It comes from
+`pg_stat_activity` scoped to the current database, so every api instance reports
+the same counts. Those counts also include the `tradr` CLI, a migration run, and
+any open `psql` session.
+
+A dashboard that **sums** this metric across instances over-counts by the replica
+factor. Compare a single instance against `tradr_db_pool_max` instead. That gauge
+exists because the Postgres driver exposes no pool statistics of its own, so it
+is the only saturation reference available.
+
+## Worked queries
+
+Enough PromQL to build the first panel of a dashboard. Adjust the range vector
+(`[5m]`) to at least four times your scrape interval.
+
+**Request rate**, per second, broken out by route:
+
+```promql
+sum by (route) (rate(tradr_http_requests_total[5m]))
+```
+
+**Error rate** as a fraction of all requests. `status` is a string, so match it
+with a regex rather than a numeric comparison:
+
+```promql
+(sum(rate(tradr_http_requests_total{status=~"5.."}[5m])) or vector(0))
+  / sum(rate(tradr_http_requests_total[5m]))
+```
+
+The `or vector(0)` is not decoration. An instance that has served no `5xx` has no
+series matching the regex, so the numerator is empty and the whole expression
+returns nothing — which reads as a broken panel rather than a healthy one.
+
+**Latency quantile.** A Prometheus histogram is exposed as a set of cumulative
+`_bucket` series carrying an `le` ("less than or equal") label — one per boundary
+listed above, plus `le="+Inf"` — alongside `_sum` and `_count`. You do not query
+those series directly; `histogram_quantile` interpolates across them. The `le`
+label must survive the aggregation, so it belongs in the `by` clause:
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le) (rate(tradr_http_request_duration_seconds_bucket[5m]))
+)
+```
+
+Keep `method` as well to get a quantile per verb — `sum by (le, method) (...)`.
+There is no `route` label here, so a per-route quantile is not available; that is
+the documented trade-off above.
+
+**Pool saturation**, the fraction of one instance's pool in use:
+
+```promql
+sum without (state) (tradr_db_connections) / tradr_db_pool_max
+```
+
+`without (state)` is the load-bearing part, and a bare `sum()` breaks this query
+twice over. `sum()` drops *every* label, `job` and `instance` included, so the
+left-hand side has nothing left to match `tradr_db_pool_max` on and the
+expression returns no result at all — not a wrong number, nothing. It would also
+be exactly the across-instance sum the section above warns against, because these
+counts are database-global. `sum without (state)` collapses only the three
+`state` series of a single target and leaves its identity intact, so each
+instance divides by its own pool ceiling.
+
+Prefer `without (state)` to `by (job, instance)`. The two agree on a plain scrape
+config, but the moment you attach an extra target label — `env`, `region`,
+`cluster` — the `by` form drops it from the left-hand side, the match fails
+again, and the panel goes empty.
+
+Alert on the idle-in-transaction series on its own. It is the classic
+pool-exhaustion precursor: connections held open by transactions that are no
+longer doing work.
+
+```promql
+tradr_db_connections{state="idle_in_transaction"}
+```
+
+## When the database is down
+
+The scrape still returns `200`. A database failure never fails a scrape.
+
+Static facts stay published; sampled facts disappear. So a failed probe leaves
+`tradr_db_up 0`, a `tradr_db_probe_duration_seconds` value, and **no**
+`tradr_db_connections` series at all. The series is omitted rather than reported
+stale.
+
+Use `tradr_db_up` to tell the two failure modes apart:
+
+| What you see                                       | Means                           |
+| -------------------------------------------------- | ------------------------------- |
+| No `tradr_db_connections`, `tradr_db_up 0` present | The database is down.           |
+| No `tradr_db_connections`, no `tradr_db_up` either | The instance is not scrapeable. |
+
+If serialization itself fails, the api serves an empty body with `200` and the
+correct content type, and logs at `error`. The target stays up.
+
+## Security
+
+### There is no auth secret, by design
+
+The exposition carries no bearer token and no shared secret. **Network isolation
+is the control.** A token copied into every scrape config is a worse posture than
+a private bind. It lands in more files. It rotates rarely. It grants the same
+access to anyone who reads one of them.
+
+So the rule is short. **Do not publish the metrics port.**
+
+### The bind address
+
+`METRICS_HOST` defaults to `0.0.0.0`. That default is deliberate, not lazy.
+`127.0.0.1` binds the _container's_ own loopback, which is unreachable from a
+Prometheus elsewhere on the compose network, and a Fly scrape arrives over 6PN
+rather than loopback. Binding all interfaces is already private in both
+documented deployments, because nothing publishes the port.
+
+**Residual threat model.** The api metrics listener becomes reachable from
+outside only if you add a `ports:` mapping for the `api` service, or run the
+container with host networking. `METRICS_HOST` exists so an operator in that
+position can narrow the bind to one interface instead of widening the exposure.
+
+The web `/metrics` file is different: it is already on the published port. See
+[The web container](#the-web-container) above.
+
+### What an exposed port would leak
+
+If you publish the port against this guidance, the surface still leaks nothing
+beyond **aggregate operational counters and the build version**.
+
+No metric name, label name, or label value carries user data. There are no email
+addresses, no user or account identifiers, no ticker symbols, no position or
+trade data, no monetary amounts, and no secrets. The `route` label is a
+registered pattern, never a raw path, so it cannot carry an id from a URL.
+
+A stranger learns your request volume by route and status, and your latency
+distribution. They also learn your connection counts, and your memory and
+event-loop health.
+
+They learn **two** versions, and both are the sensitive part. `tradr_build_info`
+carries the Tradr version you run. `nodejs_version_info`, one of the standard
+default metrics, carries the exact **Node.js runtime version** in its `version`
+label — it ships with that default set rather than being something Tradr chose to
+publish, and it is easy to overlook when reasoning about what the surface
+discloses. Between them they tell an attacker which application advisories and
+which runtime advisories apply to you.
+
+The api listener is deliberately **not** smoke-tested in CI, because testing it
+would mean publishing the port. CI covers the web container's `/metrics` in both
+states instead.
+
+## Operational behaviour
+
+### A metrics port conflict does not stop the api
+
+If `METRICS_PORT` is already in use, the api logs at `error` and **keeps serving
+requests**. Tradr does not refuse to boot over an observability port.
+
+The failure is visible where it matters: your collector reports `up == 0` for
+that target. Check the api container's logs for
+`Metrics listener failed; the API continues serving normally`.
+
+The listener also closes with the main server during graceful shutdown.
+
+### Recording never breaks a request
+
+The HTTP middleware records after the response is produced, inside a guard. A
+recording failure costs one sample and logs a warning. It cannot change a status
+code, a body, or a header.
+
+## Getting a real version instead of `unknown`
+
+If you build the images yourself with `docker compose build`, **both**
+`tradr_build_info` and `tradr_web_build_info` report `version="unknown"` and
+`commit="unknown"`.
+
+This is expected, not a bug. Neither `build:` block in the shipped
+`docker-compose.yml` declares an `args:` entry for `APP_VERSION`, so both
+Dockerfiles fall back to their empty `ARG APP_VERSION=""` default.
+
+Drift detection between the api and the SPA is therefore meaningful only on the
+documented GHCR image path. On that path the release workflow bakes the release
+tag into both images. Put both series on one panel and compare their `version`
+labels:
+
+```promql
+tradr_build_info
+tradr_web_build_info
+```
+
+Two different values mean a half-finished deploy. Two `unknown` values mean you
+built the images yourself.
+
+To get a real version from a local build, pass the build argument to both
+services:
+
+```bash
+docker compose build \
+  --build-arg APP_VERSION="v0.5.0-$(git rev-parse --short HEAD)"
+docker compose up -d
+```
+
+**Expected result:** `tradr_build_info` and `tradr_web_build_info` both report
+that string as `version`, and the short sha as `commit`.
+
+The `commit` label is the text after the final `-`, on both halves. A value with
+no `-` gives `commit="unknown"`. A value like `v0.5.0-rc.1` gives
+`commit="rc.1"` on both halves — which is the point: the two must agree, or a
+join reports drift where there is none.
+
+**Do not set `APP_VERSION` in `.env`.** The `api` service reads that file, and a
+blank value there overrides the version baked into the image. That would turn the
+drift metric into a drift source.
+
+## Series budget
+
+A single api instance emits under 2,000 active series. The budget:
+
+| Source                                                               | Series     |
+| -------------------------------------------------------------------- | ---------- |
+| `tradr_http_requests_total` — 195 routes × about 5 observed statuses | ~1,000     |
+| `tradr_http_request_duration_seconds` — 5 methods × 17 series each   | ~85        |
+| `process_*` and `nodejs_*`                                           | ~69        |
+| Database metrics                                                     | 6          |
+| `tradr_build_info`                                                   | 1          |
+| **Total**                                                            | **~1,161** |
+
+The `process_*` and `nodejs_*` row is a measured figure, not an estimate: 69
+series on a freshly armed instance, give or take one or two —
+`nodejs_active_handles` and `nodejs_active_resources` carry a series per live
+handle and resource type, so a container whose stdio are pipes rather than files
+reports slightly more. Read a difference of a series or two against your own
+instance as normal, not as a leak.
+
+It is also the one row that **grows after boot**, by around 40%.
+`nodejs_gc_duration_seconds` contributes nine series per garbage-collection kind,
+and a kind appears only once that collector has actually run. A busy instance
+that has exercised three GC kinds measures about 96.
+
+Even at the top of that range the total stays near 1,200, so the headroom under
+2,000 is real rather than a rounding artefact. The dominant term is the route ×
+status product, and that is what to watch if you add routes.
+
+The web container adds one series.
+
+## Next steps
+
+- [Environment variables](/self-hosting/reference/env-vars/) — the three metrics
+  variables in full, with the rest of the configuration surface.
+- [Install with Docker Compose](/self-hosting/docker-compose/) — where the `api`
+  and `web` services are defined.
+- [Security model](/self-hosting/explanation/security/) — the rest of the
+  exposure surface.
+- [Metrics glossary](/user-guide/reference/metrics-glossary/) — the trading
+  figures, which this page does not cover.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,15 @@ services:
       EMAIL_FROM: ${EMAIL_FROM:-}
       EMAIL_FROM_NAME: ${EMAIL_FROM_NAME:-}
       WEB_BASE_URL: ${WEB_BASE_URL:-}
+      # Prometheus metrics exposition (api container). Default OFF. Value
+      # defaults — same no-bare-${VAR:-} rule as FEATURE_GATING above: '' is
+      # present-not-undefined to Zod and would crash-loop METRICS_ENABLED's enum
+      # and METRICS_PORT's z.coerce.number(). Deliberately NO `ports:` mapping
+      # for METRICS_PORT: api publishes nothing, and that omission is what keeps
+      # the listener off the public internet in both documented deployments.
+      METRICS_ENABLED: ${METRICS_ENABLED:-false}
+      METRICS_PORT: ${METRICS_PORT:-9464}
+      METRICS_HOST: ${METRICS_HOST:-0.0.0.0}
     depends_on:
       postgres:
         condition: service_healthy
@@ -171,6 +180,13 @@ services:
       POSTHOG_PUBLIC_KEY: ${POSTHOG_PUBLIC_KEY:-}
       POSTHOG_PUBLIC_HOST: ${POSTHOG_PUBLIC_HOST:-}
       POSTHOG_PUBLIC_ENVIRONMENT: ${POSTHOG_PUBLIC_ENVIRONMENT:-}
+      # Prometheus metrics (web container). Gates the static build-info
+      # exposition the entrypoint writes for GET /metrics. Value default, same
+      # rule as api above. APP_VERSION is deliberately NOT listed here: web has
+      # no `env_file:`, so the image ENV baked at build time is its only source,
+      # and injecting '' would erase it — turning the drift-detection metric
+      # into a drift source.
+      METRICS_ENABLED: ${METRICS_ENABLED:-false}
     networks:
       - tradr
     restart: unless-stopped

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -33,6 +33,16 @@ RUN pnpm --filter @tradr/web build
 # ---------------------------------------------------------------------------
 FROM nginx:1.27-alpine AS runner
 
+# Deployed-version string, BAKED at build time (observability REQ-7.6), mirroring
+# Dockerfile.api:64-65. Read by 10-runtime-config.sh for two things: the SPA's
+# corner version badge (config.js `appVersion`) and the tradr_web_build_info
+# labels in /metrics. Stamped by the release workflow; empty in local builds, so
+# `emit` skips appVersion and config.js is unchanged. Deliberately NOT routed
+# through .env (REQ-7.7) — the `api` service reads that same file via env_file:,
+# where a blank APP_VERSION would OVERRIDE its own baked value.
+ARG APP_VERSION=""
+ENV APP_VERSION=${APP_VERSION}
+
 # Restrict envsubst to the two runtime vars; leaves $host/$uri/$proxy_add_x_forwarded_for intact.
 ENV NGINX_ENVSUBST_FILTER="ADVISOR_NGINX_PROXY_TIMEOUT|MAX_UPLOAD_SIZE|CSV_IMPORT_NGINX_PROXY_TIMEOUT"
 

--- a/docker/docker-entrypoint.d/10-runtime-config.sh
+++ b/docker/docker-entrypoint.d/10-runtime-config.sh
@@ -13,6 +13,9 @@
 #     stamped on every frontend event; absent => events are unstamped)
 #   APP_VERSION          -> appVersion   (corner version badge; absent => the SPA shows "localdev")
 #
+# APP_VERSION is BAKED into the image (Dockerfile.web ARG/ENV), not injected from
+# .env — see the metrics section at the bottom of this script.
+#
 # ONE deliberate exception to the absent-when-unset rule: advisorImageMaxBytes is
 # ALWAYS emitted (as an unquoted JSON number) so the client pre-upload cap check
 # always has a value — the always-on image byte cap (hosted-platform REQ-4.6).
@@ -24,6 +27,12 @@
 # API_BASE_URL only -> window.__TRADR_CONFIG__={"apiBaseUrl":"<value>","advisorImageMaxBytes":4500000};
 # advisorImageMaxBytes is ALWAYS emitted (the default when unset), so the output
 # is no longer byte-for-byte identical to the previous API_BASE_URL-only/unset script.
+#
+# The script ALSO writes the Prometheus exposition file /usr/share/nginx/html/metrics
+# (served at /metrics), but ONLY when METRICS_ENABLED=true (observability REQ-7.1).
+# Additional vars read for that half:
+#   METRICS_ENABLED      -> gates the /metrics file entirely (default false => absent)
+#   APP_VERSION          -> the version/commit labels on tradr_web_build_info (REQ-7.4)
 #
 # Runs under the official nginx:alpine entrypoint, which sources/execs
 # /docker-entrypoint.d/*.sh before launching nginx. nginx serves this file
@@ -75,3 +84,35 @@ esac
 emit_num advisorImageMaxBytes "$advisor_image_max_bytes"
 
 printf 'window.__TRADR_CONFIG__={%s};\n' "$body" > "$config_file"
+
+# ---------------------------------------------------------------------------
+# Prometheus exposition for the SPA's build identity (observability REQ-7).
+#
+# Absent by default: written ONLY when METRICS_ENABLED=true (REQ-7.1). The
+# `rm -f` is UNCONDITIONAL and load-bearing — without it, flipping
+# METRICS_ENABLED from true to false on an existing volume/root would leave the
+# previous file being served forever (REQ-7.9).
+#
+# The version/commit split MIRRORS the api's parseAppVersion()
+# (apps/api/src/features/metrics/metrics.registry.ts): version is APP_VERSION
+# verbatim ("unknown" when unset/empty), commit is the text after its final
+# "-", or "unknown" when there is no "-". The two halves must agree on VALUES,
+# not just label names, or joining tradr_web_build_info against
+# tradr_build_info reports drift where there is none (REQ-3.6, REQ-7.4).
+# ---------------------------------------------------------------------------
+metrics_file="/usr/share/nginx/html/metrics"
+rm -f "$metrics_file"
+
+if [ "${METRICS_ENABLED:-false}" = "true" ]; then
+  app_version="${APP_VERSION:-unknown}"
+  case "$app_version" in
+    *-*) commit="${app_version##*-}" ;;
+    *)   commit="unknown" ;;
+  esac
+  {
+    printf '# HELP tradr_web_build_info Deployed web (SPA) build information.\n'
+    printf '# TYPE tradr_web_build_info gauge\n'
+    printf 'tradr_web_build_info{version="%s",commit="%s"} 1\n' \
+      "$(json_str "$app_version")" "$(json_str "$commit")"
+  } > "$metrics_file"
+fi

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -24,6 +24,20 @@ server {
         add_header Cache-Control "no-store" always;
     }
 
+    # SPA build identity for Prometheus (observability REQ-7.5). Unlike
+    # /config.js, the file is EXTENSIONLESS, so it needs both halves of this
+    # block: without the exact-match location `try_files $uri $uri/ /index.html`
+    # below would swallow it, and without default_type it would be served as
+    # application/octet-stream. Written by 10-runtime-config.sh only when
+    # METRICS_ENABLED=true — when it is absent this exact-match location
+    # declares no try_files and no error_page, so nginx returns its own 404
+    # rather than the SPA shell. No ${...} placeholder here, so
+    # NGINX_ENVSUBST_FILTER (Dockerfile.web) needs no change.
+    location = /metrics {
+        default_type "text/plain; version=0.0.4";
+        add_header Cache-Control "no-store" always;
+    }
+
     # SSE streaming: matches both advisor stream routes
     # (/api/advisor/conversations/<id|new>/messages/stream). [^/]+ matches the
     # conversation :id and the literal `new`. Response buffering is disabled via

--- a/lychee.toml
+++ b/lychee.toml
@@ -67,4 +67,9 @@ exclude = [
   # Vendor endpoints that answer only to an authenticated client.
   "^https://api\\.github\\.com",
   "^https://us\\.i\\.posthog\\.com",
+  # Bot-walled: 403s CI runner egress while serving browsers normally, so the
+  # check fails intermittently on a page that is not rotten. This is the case
+  # the `accept` comment above describes; excluding the one host that does it
+  # keeps 403 meaningful everywhere else.
+  "^https://developers\\.google\\.com",
 ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,7 +67,7 @@ importers:
         version: 10.6.0
       drizzle-orm:
         specifier: ^0.38
-        version: 0.38.4(@types/react@19.2.14)(postgres@3.4.8)(react@19.2.4)
+        version: 0.38.4(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(postgres@3.4.8)(react@19.2.4)
       hono:
         specifier: ^4
         version: 4.12.8
@@ -86,6 +86,9 @@ importers:
       posthog-node:
         specifier: ^5.38.0
         version: 5.38.0
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       stripe:
         specifier: ^19
         version: 19.3.1(@types/node@25.5.0)
@@ -295,7 +298,7 @@ importers:
         version: link:../packages/shared
       drizzle-orm:
         specifier: ^0.38
-        version: 0.38.4(@types/react@19.2.14)(postgres@3.4.8)(react@19.2.4)
+        version: 0.38.4(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(postgres@3.4.8)(react@19.2.4)
       postgres:
         specifier: ^3.4
         version: 3.4.8
@@ -2049,6 +2052,10 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
       '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -3867,6 +3874,9 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -5963,6 +5973,10 @@ packages:
     resolution: {integrity: sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg==}
     engines: {node: '>=18.0.0'}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -6568,6 +6582,9 @@ packages:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   terminal-link@5.0.0:
     resolution: {integrity: sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA==}
@@ -8850,6 +8867,8 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@oslojs/encoding@1.1.0': {}
 
   '@oxc-project/types@0.142.0': {}
@@ -10766,6 +10785,8 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  bintrees@1.0.2: {}
+
   boolbase@1.0.0: {}
 
   bowser@2.14.1: {}
@@ -11133,8 +11154,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.38.4(@types/react@19.2.14)(postgres@3.4.8)(react@19.2.4):
+  drizzle-orm@0.38.4(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(postgres@3.4.8)(react@19.2.4):
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/react': 19.2.14
       postgres: 3.4.8
       react: 19.2.4
@@ -13239,6 +13261,11 @@ snapshots:
 
   process-ancestry@0.1.0: {}
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -14098,6 +14125,10 @@ snapshots:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   terminal-link@5.0.0:
     dependencies:

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -68,6 +68,18 @@ export default defineWorkspace([
         EMAIL_FROM: '',
         EMAIL_FROM_NAME: '',
         WEB_BASE_URL: '',
+        // Affirmative pin-off of the Prometheus exposition surface (REQ-1.8) — a
+        // stray ambient METRICS_* must not arm the surface or red the REQ-1.7
+        // parity assertion. All three are pinned to their REAL values, never '':
+        // METRICS_ENABLED is an enum, so '' fails it and boot-crashes
+        // envSchema.parse (the rule recorded on the gated-capability block above);
+        // METRICS_PORT is a bare z.coerce.number() with NO empty-tolerant
+        // preprocess (unlike SMTP_PORT), so '' would coerce to the valid number 0;
+        // METRICS_HOST's .default() fires only on `undefined`, so '' would yield
+        // an empty host.
+        METRICS_ENABLED: 'false',
+        METRICS_PORT: '9464',
+        METRICS_HOST: '0.0.0.0',
       },
     },
     resolve: {
@@ -124,6 +136,14 @@ export default defineWorkspace([
         EMAIL_FROM: '',
         EMAIL_FROM_NAME: '',
         WEB_BASE_URL: '',
+        // Pin the Prometheus exposition surface off for the migration tests too
+        // (REQ-1.8). Real values, never '': METRICS_ENABLED is an enum ('' fails
+        // it and boot-crashes envSchema.parse), METRICS_PORT is a bare
+        // z.coerce.number() with no empty-tolerant preprocess ('' → 0), and
+        // METRICS_HOST's .default() fires only on `undefined` ('' → empty host).
+        METRICS_ENABLED: 'false',
+        METRICS_PORT: '9464',
+        METRICS_HOST: '0.0.0.0',
       },
     },
     resolve: {


### PR DESCRIPTION
Adds a self-hostable Prometheus metrics surface, **off by default**.

With `METRICS_ENABLED` unset nothing changes: no listener binds, no port opens, no middleware registers, no default collectors are registered, and neither container writes an exposition file. `app.self-host-parity.test.ts` and a new `app.metrics-disabled.test.ts` enforce that.

When enabled, the API serves a private `GET /metrics` on `METRICS_HOST:METRICS_PORT` (9464 by default, **published nowhere** — network isolation is the control, so there is deliberately no auth secret). The web container serves a static `tradr_web_build_info` exposition so operators can detect API/SPA version drift.

## Two things reviewers should weigh

**1. `@opentelemetry/api` becomes a hard runtime dependency.** `prom-client@15.1.3` requires it eagerly (it was previously only an optional peer via drizzle-orm), and also pulls `tdigest` → `bintrees`. All three are pure JS, so the esbuild external set is unchanged — `build:prod` still asserts exactly Node builtins + `bcrypt` + `tiktoken`. Flagging it because it moves our OSV-Scanner/CodeQL surface. No advisories against any of them at time of writing.

**2. Released web images now emit `appVersion`, which is a frontend change.** `Dockerfile.web` gains `ARG`/`ENV APP_VERSION` so the build-info exposition has a version to report. The entrypoint already emitted `appVersion` into `window.__TRADR_CONFIG__` when set, so a side effect is that the SPA's corner version badge flips from "localdev" to the release tag on released images. This is wanted, but it ships from a metrics PR and should be seen. Local `docker compose build` is unaffected (no build-arg → empty → badge unchanged), and the byte-exact `config.js` assertion in `docker-smoke` still holds.

## Design decisions worth knowing

- **The duration histogram carries no `route` label.** That single decision is what keeps the active series count inside its ceiling (~1,161 measured against a 2,000 budget). Pinned by a test on the declared label set.
- **The `route` label on the counter has three bounded value classes**: the matched route pattern; a router **mount wildcard** (`/api/positions/*`) when a per-router middleware short-circuits — overwhelmingly `authMiddleware` on a 401, the highest-volume non-2xx class; and an `unmatched` sentinel for genuinely unmatched paths and global middleware short-circuits. All three are documented and test-pinned.
- **Database collectors are bounded by three independent mechanisms**, all load-bearing: a server-side `SET LOCAL statement_timeout` (a hung query is cancelled, not leaked), a client-side deadline (the only bound that covers a socket which never answers), and a **single-flight guard** (which is what bounds the *pool* — without it, `postgres.js` cancels the idle timer once `BEGIN` executes, and each scrape would orphan another reserved connection until `DB_POOL_SIZE` is exhausted and the app's own request path blocks).
- **A scrape is an active database probe**, so scrape interval is a database load knob. Single-flight makes it *at most* one probe per scrape; two overlapping scrapes share one, and the second publishes values it did not measure. Disclosed in the `# HELP` text and the operator docs.
- **No database work**: no migration, no schema change, no new table.

## Verification

Full suite green: `check-types`, `lint`, `build:prod`, docs build with link validation, zero generated-docs drift, `actionlint`. Disabled and enabled paths were driven over **real sockets** and a **real compose stack**, not just through test harnesses: DB-down scrape returns 200 in <5 ms, `SIGTERM` exits in ~200 ms with the metrics listener closed before pool teardown, and the API/web build-info halves were confirmed to join on both the released and local-build paths.

`docker-smoke` gains three steps: `/metrics` returns nginx's own 404 by default, serves a valid exposition when enabled, and — the third one exists because a fresh container layer is always clean — a re-run of the entrypoint with the flag off proves the unconditional `rm -f` is present, which is the only thing stopping a true→false flip from serving a stale exposition forever on a persisted root.

## One bug this found in itself

`tradr_db_connections{state="idle_in_transaction"}` was permanently `0`: Postgres reports `idle in transaction` (spaces), and the collector keyed on the underscore form. The unit tests missed it because they mock the transaction boundary and fed back rows written in the same wrong spelling — so the fixture and the code shared one wrong belief. It surfaced only while writing the operator documentation, which forced a claim checkable against a live database. Fixed with an explicit state→label map, proved end to end (`0` → `2`), and pinned by a test that parks real backends and asks Postgres what it calls them. `idle in transaction (aborted)` is deliberately folded into the same label — it reserves a backend and pins the xmin horizon identically, and a fourth value would break the published three-value contract.

## Operator-facing

New page: **Run it yourself → Operational metrics (Prometheus)** — the full contract (every name, type, label set, bucket boundaries), the threat model, the database-load caveat, the `unknown`-version path on local builds, and worked PromQL for request rate, error rate, latency quantiles and pool saturation. Every query on that page was executed against a real Prometheus, which caught two that silently returned empty.

**No scraper is wired by this PR** — collection, dashboarding and alerting are out of scope, and the docs say so plainly so nobody expects dashboards when this ships.
