### PR TITLE
fix: three user-facing defects and a fail-open e2e fixture

### DIFF
--- a/apps/api/src/features/dashboard/dashboard.route.ts
+++ b/apps/api/src/features/dashboard/dashboard.route.ts
@@ -67,6 +67,13 @@ export function buildThemeCookie(value: Theme): string {
  *       Authed. Returns the user's widget placements on a 12-column grid, their
  *       theme, and when the layout was last saved. A user who has never
  *       customised the dashboard gets the default layout, not an empty one.
+ *       A saved layout is reconciled against the current geometry before it is
+ *       returned: a widget stored below its type's minimum size — which only
+ *       happens when that minimum has been raised since the layout was saved —
+ *       is given the current default size for its type, and the widgets below
+ *       it move down so none overlap. The stored row is not rewritten; the
+ *       next save persists the reconciled placements. The response is
+ *       therefore always a body this endpoint will accept back on a PUT.
  *     tags: [Dashboard]
  *     responses:
  *       200:

--- a/apps/api/src/features/dashboard/dashboard.service.ts
+++ b/apps/api/src/features/dashboard/dashboard.service.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_WIDGETS,
   WIDGET_DEFAULT_NAMESPACE,
+  reconcileStoredLayout,
   uuidv5Batch,
   type DashboardLayoutResponse,
   type PutDashboardLayoutRequest,
@@ -104,13 +105,25 @@ export async function buildDefaultLayout(userId: string): Promise<WidgetPlacemen
   return widgets;
 }
 
+/**
+ * EVERY stored layout leaves this service reconciled — see
+ * `reconcileStoredLayout`. A row is written once and read forever, so raising a
+ * pinned default or a per-type minimum reaches nobody who has ever arranged
+ * their dashboard unless the read does it; and because the client PUTs what it
+ * was given, a response that carried stale geometry is what made the next add,
+ * remove or timeframe change 400 against the bound it fails.
+ *
+ * The row itself is left alone. This is idempotent and runs on a layout of at
+ * most six widgets, so repairing on read costs nothing worth writing for, and a
+ * GET has no business mutating. The user's next real save persists it.
+ */
 export async function getLayoutForUser(userId: string): Promise<DashboardLayoutResponse> {
   const { widgets, updatedAt, theme } = await selectLayoutAndTheme(db, userId);
   if (widgets === null) {
     const defaults = await buildDefaultLayout(userId);
     return { widgets: defaults, theme, updatedAt: null };
   }
-  return { widgets, theme, updatedAt };
+  return { widgets: reconcileStoredLayout(widgets), theme, updatedAt };
 }
 
 export async function getThemeForUser(userId: string): Promise<Theme> {
@@ -150,7 +163,11 @@ export async function putLayoutForUser(
         // updatedAt:null.
         const existing = await selectLayout(tx, userId);
         if (existing) {
-          widgetsOut = existing.widgets;
+          // Same reconciliation as the GET. A theme-only write answers with the
+          // stored layout it did not touch, and the endpoint may only have ONE
+          // answer to "what is this user's layout" — a caller that took this
+          // one would be handed exactly the geometry the GET repairs.
+          widgetsOut = reconcileStoredLayout(existing.widgets);
           updatedAtOut = existing.updatedAt;
         } else {
           widgetsOut = await buildDefaultLayout(userId);

--- a/apps/api/src/features/dashboard/dashboard.test.ts
+++ b/apps/api/src/features/dashboard/dashboard.test.ts
@@ -298,7 +298,7 @@ describe('dashboard routes', () => {
   });
 
   // -------------------------------------------------------------------------
-  // A layout saved before the geometry was fixed (deferral d-d3fb2fc7).
+  // A layout saved before the widget geometry was fixed.
   //
   // Every height in `staleWidgets` was legal when it was written — `h` values
   // from the 80px era, doubled by migration 0021, with the charts landing on

--- a/apps/api/src/features/dashboard/dashboard.test.ts
+++ b/apps/api/src/features/dashboard/dashboard.test.ts
@@ -3,7 +3,7 @@ import { createHash, randomBytes, randomUUID } from 'node:crypto';
 import { eq, sql } from 'drizzle-orm';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { BODY_LIMIT_BYTES, PerWidgetMinSize } from '@tradr/shared';
+import { BODY_LIMIT_BYTES, DEFAULT_WIDGETS, PerWidgetMinSize } from '@tradr/shared';
 
 import app from '@/app';
 import { db } from '@/db';
@@ -77,6 +77,12 @@ function authedRequest(method: string, path: string, cookie: string, body?: unkn
 
 // Two non-overlapping minimal-valid widgets. Each must satisfy:
 //   - x + w <= 12, w/h >= PerWidgetMinSize, unique types, no overlap.
+//
+// Every height is read from the schema's own minimum rather than written out.
+// The minimums are DERIVED — a chart widget's from the height its chart needs,
+// Stats Summary's from the tile grid it renders — so a literal here goes stale
+// the next time one of those changes, and every case below then fails on the
+// fixture instead of on what it tests.
 function makeValidWidgets() {
   return [
     {
@@ -85,18 +91,14 @@ function makeValidWidgets() {
       x: 0,
       y: 0,
       w: 12,
-      h: 2,
+      h: PerWidgetMinSize['stats-summary'].h,
     },
     {
       id: randomUUID(),
       type: 'performance-chart' as const,
       x: 0,
-      y: 2,
+      y: PerWidgetMinSize['stats-summary'].h,
       w: 6,
-      // Read from the schema's own minimum rather than written out: a chart
-      // widget's minimum height is derived from the height its chart needs, so
-      // a literal here goes stale the next time that changes and every case
-      // below starts failing on the fixture instead of on what it tests.
       h: PerWidgetMinSize['performance-chart'].h,
     },
   ];
@@ -295,6 +297,86 @@ describe('dashboard routes', () => {
     expect(secondBody.updatedAt).toBe(firstBody.updatedAt);
   });
 
+  // -------------------------------------------------------------------------
+  // A layout saved before the geometry was fixed (deferral d-d3fb2fc7).
+  //
+  // Every height in `staleWidgets` was legal when it was written — `h` values
+  // from the 80px era, doubled by migration 0021, with the charts landing on
+  // the h=4 minimum they had before it was derived from the height a chart
+  // needs. Nothing revisits a saved row, so without reconciliation on read the
+  // owner of this row kept geometry the write schema now rejects: the dashboard
+  // rendered (gridstack clamps on the way in) but every edit that was not a
+  // drag or a resize sent the stale heights back and 400d, with a Retry that
+  // could only re-send the same body.
+  // -------------------------------------------------------------------------
+  function staleWidgets() {
+    return [
+      { id: randomUUID(), type: 'stats-summary' as const, x: 0, y: 0, w: 12, h: 2 },
+      { id: randomUUID(), type: 'performance-chart' as const, x: 0, y: 2, w: 8, h: 4 },
+      { id: randomUUID(), type: 'account-balances' as const, x: 8, y: 2, w: 4, h: 4 },
+      { id: randomUUID(), type: 'equity-curve' as const, x: 0, y: 6, w: 8, h: 4 },
+      { id: randomUUID(), type: 'position-sizing' as const, x: 8, y: 6, w: 4, h: 6 },
+      { id: randomUUID(), type: 'open-positions' as const, x: 0, y: 12, w: 12, h: 4 },
+    ];
+  }
+
+  async function seedStaleLayout(userId: string): Promise<void> {
+    // Written straight to the row, because the endpoint would refuse it — which
+    // is the point: the row predates the bound.
+    await db.insert(dashboardLayouts).values({ userId, widgets: staleWidgets() });
+  }
+
+  it('GET on a stale saved layout answers with the current pinned geometry', async () => {
+    const { cookie, userId } = await registerAndGetCookie();
+    await seedStaleLayout(userId);
+
+    const res = await authedRequest('GET', '/api/dashboard/layout', cookie);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { widgets: Array<{ type: string; h: number }> };
+
+    // The geometry fix reaches a user who already has a saved layout. Read from
+    // DEFAULT_WIDGETS, not written out: this must keep holding the NEXT time a
+    // pinned height moves, which is the whole reason the reconciliation exists.
+    for (const type of ['stats-summary', 'performance-chart', 'equity-curve'] as const) {
+      const pinned = DEFAULT_WIDGETS.find((d) => d.type === type)!.h;
+      const got = body.widgets.find((w) => w.type === type)!.h;
+      expect(got, `${type} should have been repaired to its pinned height`).toBe(pinned);
+    }
+
+    // The stored row is deliberately NOT rewritten — a GET does not mutate.
+    const [row] = await db
+      .select({ widgets: dashboardLayouts.widgets })
+      .from(dashboardLayouts)
+      .where(eq(dashboardLayouts.userId, userId));
+    expect(row.widgets.find((w) => w.type === 'stats-summary')!.h).toBe(2);
+  });
+
+  it('removing a widget from a stale saved layout saves instead of 400ing', async () => {
+    const { cookie, userId } = await registerAndGetCookie();
+    await seedStaleLayout(userId);
+
+    // Exactly what the client does: PUT the layout it was given, minus one
+    // widget. Before the reconciliation this answered 400 VALIDATION_ERROR,
+    // "Widget is smaller than the minimum size for its type", on both charts.
+    const getRes = await authedRequest('GET', '/api/dashboard/layout', cookie);
+    const { widgets } = (await getRes.json()) as { widgets: Array<{ type: string }> };
+    const next = widgets.filter((w) => w.type !== 'open-positions');
+
+    const res = await authedRequest('PUT', '/api/dashboard/layout', cookie, { widgets: next });
+    expect(res.status).toBe(200);
+
+    // And the write persisted the repaired geometry, so the row is no longer
+    // stale for the next reader.
+    const [row] = await db
+      .select({ widgets: dashboardLayouts.widgets })
+      .from(dashboardLayouts)
+      .where(eq(dashboardLayouts.userId, userId));
+    expect(row.widgets).toHaveLength(next.length);
+    for (const widget of row.widgets) {
+      expect(widget.h).toBeGreaterThanOrEqual(PerWidgetMinSize[widget.type].h);
+    }
+  });
+
   it('PUT empty body returns 400 ValidationError with required-field message', async () => {
     const { cookie } = await registerAndGetCookie();
     const res = await authedRequest('PUT', '/api/dashboard/layout', cookie, {});
@@ -425,7 +507,7 @@ describe('dashboard routes', () => {
         x: 0,
         y: 0,
         w: 12,
-        h: 2,
+        h: PerWidgetMinSize['stats-summary'].h,
       },
       {
         id: randomUUID(),

--- a/apps/docs/src/openapi/tradr-api.json
+++ b/apps/docs/src/openapi/tradr-api.json
@@ -2584,7 +2584,7 @@
     },
     "/api/dashboard/layout": {
       "get": {
-        "description": "Authed. Returns the user's widget placements on a 12-column grid, their theme, and when the layout was last saved. A user who has never customised the dashboard gets the default layout, not an empty one.\n",
+        "description": "Authed. Returns the user's widget placements on a 12-column grid, their theme, and when the layout was last saved. A user who has never customised the dashboard gets the default layout, not an empty one. A saved layout is reconciled against the current geometry before it is returned: a widget stored below its type's minimum size — which only happens when that minimum has been raised since the layout was saved — is given the current default size for its type, and the widgets below it move down so none overlap. The stored row is not rewritten; the next save persists the reconciled placements. The response is therefore always a body this endpoint will accept back on a PUT.\n",
         "responses": {
           "200": {
             "content": {

--- a/apps/web/src/features/dashboard/components/DashboardGrid.test.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardGrid.test.tsx
@@ -23,6 +23,11 @@ import { WIDGET_DRAG_CANCEL_CLASS, WIDGET_DRAG_HANDLE_CLASS } from './WidgetCard
  */
 const PERF_MIN_H = PerWidgetMinSize['performance-chart'].h;
 
+/** Stats Summary's minimum height, read for the same reason: it is derived too
+ * (from the tile grid the widget renders plus its chrome), so a literal goes
+ * stale and gridstack then clamps the fixture to geometry nobody wrote. */
+const STATS_MIN_H = PerWidgetMinSize['stats-summary'].h;
+
 const W = (over: Partial<WidgetPlacement>): WidgetPlacement =>
   ({
     id: '00000000-0000-4000-8000-000000000001',
@@ -132,12 +137,12 @@ describe('toGridWidgets', () => {
 describe('fromGridWidgets', () => {
   it('round-trips through toGridWidgets preserving type and config', () => {
     const widgets: WidgetPlacement[] = [
-      W({ id: 'a', type: 'stats-summary', x: 0, y: 0, w: 12, h: 2 }),
+      W({ id: 'a', type: 'stats-summary', x: 0, y: 0, w: 12, h: STATS_MIN_H }),
       W({
         id: 'b',
         type: 'performance-chart',
         x: 0,
-        y: 2,
+        y: STATS_MIN_H,
         w: 8,
         h: PERF_MIN_H,
         config: { timeframe: 'weekly' },
@@ -405,12 +410,12 @@ describe('DashboardGrid — gesture completion is the only write path', () => {
     installMatchMediaSpy({});
     const scheduleLayoutWrite = vi.fn();
     const widgets: WidgetPlacement[] = [
-      W({ id: 'a', type: 'stats-summary', x: 0, y: 0, w: 12, h: 2 }),
+      W({ id: 'a', type: 'stats-summary', x: 0, y: 0, w: 12, h: STATS_MIN_H }),
       W({
         id: 'b',
         type: 'performance-chart',
         x: 0,
-        y: 2,
+        y: STATS_MIN_H,
         w: 8,
         h: PERF_MIN_H,
         config: { timeframe: 'weekly' },
@@ -435,8 +440,8 @@ describe('DashboardGrid — gesture completion is the only write path', () => {
     // is unambiguous. The move alone must not write. (Geometry is passed whole:
     // `update` defaults any side it is not given rather than keeping it, so a
     // partial `{x, y}` would silently reset `w`/`h` to 1.)
-    const emptyRow = 2 + PERF_MIN_H;
-    grid.update(itemA, { x: 0, y: emptyRow, w: 12, h: 2 });
+    const emptyRow = STATS_MIN_H + PERF_MIN_H;
+    grid.update(itemA, { x: 0, y: emptyRow, w: 12, h: STATS_MIN_H });
     expect(scheduleLayoutWrite).not.toHaveBeenCalled();
 
     fireGesture(grid, 'dragstop', itemA);
@@ -446,8 +451,8 @@ describe('DashboardGrid — gesture completion is the only write path', () => {
     // `type` and `config` are not gridstack's to hold — they come back off the
     // widget the node matches.
     //
-    // `h: 2` also pins a gridstack gotcha: `save()` DELETES `h` from a node
-    // when it equals 1 or the item's own `minH`, and stats-summary's minH IS 2.
+    // Sitting stats-summary on its own minimum also pins a gridstack gotcha:
+    // `save()` DELETES `h` from a node when it equals 1 or the item's `minH`.
     // Taken at face value the placement would persist as 1 row tall.
     expect(dragged.find((widget) => widget.id === 'a')).toEqual({
       id: 'a',
@@ -455,13 +460,13 @@ describe('DashboardGrid — gesture completion is the only write path', () => {
       x: 0,
       y: emptyRow,
       w: 12,
-      h: 2,
+      h: STATS_MIN_H,
     });
     expect(dragged.find((widget) => widget.id === 'b')).toEqual({
       id: 'b',
       type: 'performance-chart',
       x: 0,
-      y: 2,
+      y: STATS_MIN_H,
       w: 8,
       h: PERF_MIN_H,
       config: { timeframe: 'weekly' },
@@ -469,7 +474,7 @@ describe('DashboardGrid — gesture completion is the only write path', () => {
 
     // Shrink to exactly PerWidgetMinSize['performance-chart'] — the other half
     // of the same gotcha, where `save()` would drop BOTH `w` and `h`.
-    grid.update(itemOf(grid, 'b'), { x: 0, y: 2, w: 4, h: PERF_MIN_H });
+    grid.update(itemOf(grid, 'b'), { x: 0, y: STATS_MIN_H, w: 4, h: PERF_MIN_H });
     fireGesture(grid, 'resizestop', itemOf(grid, 'b'));
     expect(scheduleLayoutWrite).toHaveBeenCalledTimes(2);
     const resized = scheduleLayoutWrite.mock.calls[1][0] as WidgetPlacement[];

--- a/apps/web/src/features/dashboard/widgets/StatsSummaryWidget.height.test.tsx
+++ b/apps/web/src/features/dashboard/widgets/StatsSummaryWidget.height.test.tsx
@@ -24,6 +24,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { PerformanceResponse } from '@tradr/shared';
 import { DEFAULT_WIDGETS } from '@tradr/shared/constants/dashboard-defaults';
+import { PerWidgetMinSize } from '@tradr/shared/schemas/dashboard';
 
 import { useDisplayCurrencyQuery } from '@/features/accounting/hooks/useDisplayCurrency';
 import { usePerformance } from '@/features/performance/hooks/usePerformance';
@@ -141,14 +142,21 @@ function mockPerformance({ clamped }: { clamped: boolean }): void {
   } as unknown as PerformanceResult);
 }
 
-/** The pinned default body height, in px — what `body.clientHeight` reports. */
+/**
+ * The body height a widget of `h` rows has, in px — what `body.clientHeight`
+ * reports. A widget spanning `h` rows is `40h` of canvas less the 16px
+ * gridstack takes out of the cell, and WidgetCard spends its border and header
+ * out of that before its scroll body sees a pixel. At h=6 this comes to 173.
+ */
+function bodyPxAt(h: number): number {
+  return GRID_ROW_HEIGHT_PX * h - GRID_GAP_PX - CARD_BORDER_PX - CARD_HEADER_PX;
+}
+
+/** The pinned default body height, in px. */
 function pinnedBodyPx(): { h: number; bodyPx: number } {
   const pinned = DEFAULT_WIDGETS.find((w) => w.type === 'stats-summary');
   const h = pinned?.h ?? 0;
-  // A widget spanning `h` rows is `40h` of canvas less the 16px gridstack takes
-  // out of the cell, and WidgetCard spends its border and header out of that
-  // before its scroll body sees a pixel. At h=6 this comes to 173.
-  return { h, bodyPx: GRID_ROW_HEIGHT_PX * h - GRID_GAP_PX - CARD_BORDER_PX - CARD_HEADER_PX };
+  return { h, bodyPx: bodyPxAt(h) };
 }
 
 beforeEach(() => {
@@ -216,5 +224,37 @@ describe('StatsSummaryWidget — the pinned default height fits the populated ti
         `${tiles} tiles, needing ${contentPx}px, but h=${h} gives the body ${bodyPx}px — ` +
         `the free-tier user sees a clipped widget`,
     ).toBeGreaterThanOrEqual(contentPx);
+  });
+
+  // THE MINIMUM IS LOAD-BEARING NOW, not just the default. A saved layout is
+  // reconciled against `PerWidgetMinSize` on read (`reconcileStoredLayout`), so
+  // the minimum is what decides whether a stored height counts as geometry a
+  // user chose or geometry left behind by an older bound. At h=2 — what this
+  // said while the row unit was 80px and one row was a widget — a layout saved
+  // at that height is indistinguishable from a deliberate one and keeps
+  // clipping 111px of figures forever.
+  it('the per-type minimum is the tightest height the tiles fit in', () => {
+    const { container, root } = mountPopulated();
+    const tiles = container.querySelectorAll('dl > div').length;
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+
+    const rows = Math.ceil(tiles / TILE_COLUMNS);
+    const contentPx = rows * TILE_PX + (rows - 1) * TILE_ROW_GAP_PX + BODY_PADDING_PX;
+    const min = PerWidgetMinSize['stats-summary'].h;
+
+    expect(
+      bodyPxAt(min),
+      `stats-summary may be resized to h=${min} (${bodyPxAt(min)}px of body) but its ` +
+        `${tiles} tiles need ${contentPx}px — raise the minimum in PerWidgetMinSize`,
+    ).toBeGreaterThanOrEqual(contentPx);
+    // Tight, not merely sufficient: one row lower does not fit, so the bound is
+    // the content's and not a number someone rounded up to.
+    expect(bodyPxAt(min - 1)).toBeLessThan(contentPx);
+    // The conditional free-tier notice is the default's headroom, not the
+    // minimum's — the same split the two chart widgets carry.
+    expect(pinnedBodyPx().h).toBeGreaterThan(min);
   });
 });

--- a/apps/web/src/features/performance/components/InvalidTimezoneBanner.tsx
+++ b/apps/web/src/features/performance/components/InvalidTimezoneBanner.tsx
@@ -40,12 +40,11 @@ export function __resetInvalidTimezoneBannerState(): void {
 
 export interface InvalidTimezoneBannerProps {
   /**
-   * `true` when the request that just failed is the SECOND INVALID_TIMEZONE
-   * encounter in this browser session (the retry-storm path was already
-   * consumed by `usePerformance`). Source of truth: the same session flag
-   * that `usePerformance.performanceRetry` writes — read it via
-   * `readInvalidTzSeen()` exposure or, more simply, pass `seenBefore` from
-   * the composition site which already knows.
+   * `true` when the request that just failed had already dropped `tz` — so it
+   * was the server's OWN default that was rejected, not the user's zone.
+   * Source of truth: `isTimezoneRejected(params.tz)`, the same predicate
+   * `usePerformance` uses to decide whether to send `tz`, so the banner cannot
+   * claim a fallback the request did not actually make.
    *
    * On first failure: dismissible, with "dates shown in UTC" copy.
    * On second failure: NOT dismissible (per Design §Component 7).
@@ -63,7 +62,11 @@ export interface InvalidTimezoneBannerProps {
  * informational and dismissible. Changing the preference under Settings →
  * Profile is the fix, but it does not rewrite the `tz` already in this page's
  * URL — the copy therefore says to re-enter Performance from the sidebar,
- * which is what re-seeds the destination from the new preference.
+ * which is what re-seeds the destination from the new preference. That
+ * instruction stands on the URL alone: the rejection is recorded against the
+ * OLD zone and cleared when the preference is written, so arriving with the
+ * new zone sends it whether the navigation was a router transition or a full
+ * page load.
  *
  * Second failure (same session): the retry omitted `tz` entirely, so the
  * server validated its own default of `UTC` (`PerformanceQuerySchema`) and
@@ -108,8 +111,8 @@ export function InvalidTimezoneBanner({ isSecondFailure, className }: InvalidTim
             </p>
           ) : (
             <p>
-              We could not resolve your reporting timezone, so dates are shown in UTC for this
-              session. Change it in{' '}
+              We could not resolve your reporting timezone, so dates are shown in UTC until it is
+              corrected. Change it in{' '}
               <a
                 href="/settings/profile"
                 data-testid="invalid-timezone-banner-settings-link"

--- a/apps/web/src/features/performance/components/PerformancePage.test.tsx
+++ b/apps/web/src/features/performance/components/PerformancePage.test.tsx
@@ -95,6 +95,7 @@ vi.mock('../hooks/usePerformance', async () => {
   };
 });
 
+import { __resetInvalidTimezoneState, recordRejectedTimezone } from '@/lib/invalidTimezone';
 import { captureClientEvent } from '@/lib/telemetry/posthog';
 
 import { ChartChunkStaleBanner } from './ChartChunkStaleBanner';
@@ -190,6 +191,7 @@ beforeEach(() => {
   useQueryMock.mockReset();
   vi.mocked(captureClientEvent).mockClear();
   sessionStorage.clear();
+  __resetInvalidTimezoneState();
   tierData.current = undefined;
 });
 
@@ -465,8 +467,10 @@ describe('PerformancePage — INVALID_TIMEZONE error path', () => {
     unmount(container, root);
   });
 
-  it('flips InvalidTimezoneBanner into second-failure mode when session flag is set', () => {
-    sessionStorage.setItem('perf.invalid_tz_seen', 'true');
+  it('flips into second-failure mode only when THIS zone is the rejected one', () => {
+    // The request that failed had already dropped `tz`, so it was the server's
+    // own default that was rejected — which is exactly what the copy claims.
+    recordRejectedTimezone(PARAMS.tz);
     useQueryMock.mockReturnValue({
       data: undefined,
       isLoading: false,
@@ -479,17 +483,39 @@ describe('PerformancePage — INVALID_TIMEZONE error path', () => {
     expect(banner?.getAttribute('data-second-failure')).toBe('true');
     unmount(container, root);
   });
+
+  it('keeps the settings remedy reachable when a DIFFERENT zone is the recorded one', () => {
+    // A rejection recorded against the zone the user has since left must not
+    // relabel a fresh failure as "the server rejected UTC as well" — this
+    // request still CARRIED the user's zone, so profile settings is the fix.
+    recordRejectedTimezone('Foo/Bar');
+    useQueryMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: { error: { code: 'INVALID_TIMEZONE' } },
+    });
+    const { container, root } = mountWith(
+      <PerformancePage params={{ ...PARAMS, tz: 'Europe/London' }} />,
+    );
+    const banner = container.querySelector('[data-testid="invalid-timezone-banner"]');
+    expect(banner?.getAttribute('data-second-failure')).toBeNull();
+    expect(
+      container.querySelector('[data-testid="invalid-timezone-banner-settings-link"]'),
+    ).not.toBeNull();
+    unmount(container, root);
+  });
 });
 
 describe('PerformancePage — UTC fallback success path (REQ-5.6)', () => {
   it('renders InvalidTimezoneBanner alongside data when the tz-omitted retry succeeded', async () => {
-    // The hook's retry policy wrote this flag before retrying with `tz` omitted.
-    sessionStorage.setItem('perf.invalid_tz_seen', 'true');
+    // The hook's retry policy recorded this zone before retrying with `tz` omitted.
+    const params: PerformanceQueryInput = { ...PARAMS, tz: 'Europe/London' };
+    recordRejectedTimezone(params.tz);
 
     // Request asked for a non-UTC tz; server resolved to UTC because the
     // retry omitted `tz`. Banner should render in first-failure mode (the
     // request succeeded, so the user sees the informational copy).
-    const params: PerformanceQueryInput = { ...PARAMS, tz: 'Europe/London' };
     useQueryMock.mockReturnValue({
       data: buildResponse({ resolvedTimezone: 'UTC' }),
       isLoading: false,
@@ -506,15 +532,47 @@ describe('PerformancePage — UTC fallback success path (REQ-5.6)', () => {
     expect(banner).not.toBeNull();
     // First-failure mode: dismissible, no `data-second-failure` attribute.
     expect(banner?.getAttribute('data-second-failure')).toBeNull();
+    // The remedy this whole banner state exists to carry.
+    expect(
+      container.querySelector('[data-testid="invalid-timezone-banner-settings-link"]'),
+    ).not.toBeNull();
     // Data still renders alongside the banner.
     expect(container.querySelector('[data-testid="stats-panel"]')).not.toBeNull();
     unmount(container, root);
   });
 
+  it('still reaches the settings remedy when sessionStorage reads throw (Safari private)', async () => {
+    const params: PerformanceQueryInput = { ...PARAMS, tz: 'Europe/London' };
+    recordRejectedTimezone(params.tz);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Reads throw, so only the in-memory fallback knows the zone was rejected.
+    // Reading through a different accessor than the request used is what made
+    // this banner unreachable in this mode.
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+    useQueryMock.mockReturnValue({
+      data: buildResponse({ resolvedTimezone: 'UTC' }),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    const { container, root } = mountWith(<PerformancePage params={params} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(
+      container.querySelector('[data-testid="invalid-timezone-banner-settings-link"]'),
+    ).not.toBeNull();
+    unmount(container, root);
+  });
+
   it('does NOT render InvalidTimezoneBanner when the requested tz matches resolved tz', async () => {
-    // Flag set but the request used the same tz the server resolved to —
+    // Zone recorded but the request used the same tz the server resolved to —
     // means the page recovered without the swap; no banner needed.
-    sessionStorage.setItem('perf.invalid_tz_seen', 'true');
+    recordRejectedTimezone(PARAMS.tz);
     useQueryMock.mockReturnValue({
       data: buildResponse({ resolvedTimezone: 'UTC' }),
       isLoading: false,
@@ -522,6 +580,27 @@ describe('PerformancePage — UTC fallback success path (REQ-5.6)', () => {
       error: null,
     });
     const { container, root } = mountWith(<PerformancePage params={PARAMS} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-testid="invalid-timezone-banner"]')).toBeNull();
+    unmount(container, root);
+  });
+
+  it('drops the banner once the rejection no longer names this zone', async () => {
+    // What the user sees after correcting the preference: the record was
+    // cleared, the sidebar re-seeded a new zone, and the UTC notice goes away
+    // instead of following them around for the rest of the tab session.
+    recordRejectedTimezone('Foo/Bar');
+    useQueryMock.mockReturnValue({
+      data: buildResponse({ resolvedTimezone: 'UTC' }),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    const { container, root } = mountWith(
+      <PerformancePage params={{ ...PARAMS, tz: 'Europe/London' }} />,
+    );
     await act(async () => {
       await Promise.resolve();
     });

--- a/apps/web/src/features/performance/components/PerformancePage.tsx
+++ b/apps/web/src/features/performance/components/PerformancePage.tsx
@@ -3,6 +3,7 @@ import { Component, lazy, Suspense, type ReactNode } from 'react';
 import type { Granularity, PerformanceQueryInput, PerformanceResponse } from '@tradr/shared';
 
 import { Skeleton } from '@/components/ui/skeleton';
+import { isTimezoneRejected } from '@/lib/invalidTimezone';
 
 import { isInvalidTimezoneError, usePerformance } from '../hooks/usePerformance';
 import type { PerformancePreset } from '../utils/derivePresetRange';
@@ -18,22 +19,6 @@ import { StatsPanel } from './StatsPanel';
 import { TierWindowNotice } from './TierWindowNotice';
 import { TimeframeSelector } from './TimeframeSelector';
 import { WeekStartChangedBanner } from './WeekStartChangedBanner';
-
-const INVALID_TZ_SEEN_KEY = 'perf.invalid_tz_seen';
-
-/**
- * Read the session flag set by `performanceRetry` when it retried with `tz`
- * omitted. Used at the populated path to detect "retry succeeded → fell back
- * to UTC" so the informational `InvalidTimezoneBanner` can render alongside
- * the data. Try/catch handles Safari private mode where storage throws.
- */
-function readInvalidTzSeenSafe(): boolean {
-  try {
-    return sessionStorage.getItem(INVALID_TZ_SEEN_KEY) === 'true';
-  } catch {
-    return false;
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Lazy chart import
@@ -218,17 +203,16 @@ export function PerformancePage({ params }: PerformancePageProps) {
   // The hook's retry policy already swapped to UTC on the first failure (and
   // the swap may itself succeed). We render the banner only when the request
   // ultimately failed with INVALID_TIMEZONE — signalling that even the UTC
-  // fallback did not resolve. `isSecondFailure` reflects the session flag the
-  // hook wrote on its first observation.
+  // fallback did not resolve.
+  //
+  // `isSecondFailure` asks the ONE question its copy claims: did the request
+  // that just failed omit `tz`? That is true exactly when this zone is the
+  // recorded rejected one — the same predicate the hook uses to decide whether
+  // to send `tz` — so the server was validating its own UTC default. A failure
+  // that still CARRIED the user's zone is a first failure, and gets the banner
+  // that names profile settings as the fix.
   if (isError && isInvalidTimezoneError(error)) {
-    let isSecondFailure = false;
-    try {
-      isSecondFailure = sessionStorage.getItem('perf.invalid_tz_seen') === 'true';
-    } catch {
-      // sessionStorage unavailable (Safari private mode) — treat as first
-      // failure; the banner is still informational.
-      isSecondFailure = false;
-    }
+    const isSecondFailure = isTimezoneRejected(params.tz);
     return (
       <div data-testid="performance-page" className="space-y-4">
         <InvalidTimezoneBanner isSecondFailure={isSecondFailure} />
@@ -260,10 +244,11 @@ export function PerformancePage({ params }: PerformancePageProps) {
 
   // REQ-5.6 — When the hook retried with `tz` omitted and the server fell
   // back to UTC, the request *succeeded* but the user's requested timezone
-  // was not honored. Detect that swap (session flag set AND server's
-  // resolved tz differs from the requested tz) so the populated/empty paths
-  // both render the informational banner.
-  const showUtcFallbackBanner = readInvalidTzSeenSafe() && params.tz !== resolvedTimezone;
+  // was not honored. Detect that swap (this zone is the recorded rejected one
+  // AND the server's resolved tz differs) so the populated/empty paths both
+  // render the informational banner — the one carrying the settings remedy.
+  // Once the zone is corrected the record clears, so the banner goes with it.
+  const showUtcFallbackBanner = isTimezoneRejected(params.tz) && params.tz !== resolvedTimezone;
 
   // The "in-timeframe-empty" branch only fires when global flags are
   // satisfied (the upstream branches own those cases) AND the active

--- a/apps/web/src/features/performance/hooks/usePerformance.test.ts
+++ b/apps/web/src/features/performance/hooks/usePerformance.test.ts
@@ -192,6 +192,24 @@ describe('rejected-timezone record — lifecycle', () => {
     expect(isTimezoneRejected(undefined)).toBe(false);
   });
 
+  it('clearRejectedTimezone wins when removeItem throws but reads still succeed', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    recordRejectedTimezone(BAD_TZ);
+    // Only the write side fails here. Reads keep working and prefer
+    // sessionStorage, which still holds the zone the clear could not remove —
+    // so without the staleness guard the clear is silently a no-op and the tab
+    // stays pinned to the tz-omitted fallback for the rest of the session.
+    vi.spyOn(storage, 'removeItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+
+    clearRejectedTimezone();
+
+    expect(storage.getItem('perf.invalid_tz')).toBe(BAD_TZ);
+    expect(readRejectedTimezone()).toBeNull();
+    expect(isTimezoneRejected(BAD_TZ)).toBe(false);
+  });
+
   it('clearRejectedTimezone survives a storage that throws on removeItem', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     recordRejectedTimezone(BAD_TZ);

--- a/apps/web/src/features/performance/hooks/usePerformance.test.ts
+++ b/apps/web/src/features/performance/hooks/usePerformance.test.ts
@@ -39,15 +39,26 @@ Object.defineProperty(globalThis, 'Storage', {
 });
 
 import {
+  __resetInvalidTimezoneState,
+  clearRejectedTimezone,
+  isTimezoneRejected,
+  readRejectedTimezone,
+  recordRejectedTimezone,
+} from '@/lib/invalidTimezone';
+
+import {
   __resetUsePerformanceModuleState,
   handlePerformanceQueryError,
   isInvalidTimezoneError,
   performanceRetry,
 } from './usePerformance';
 
+const BAD_TZ = 'Foo/Bar';
+
 beforeEach(() => {
   storage.clear();
   __resetUsePerformanceModuleState();
+  __resetInvalidTimezoneState();
 });
 
 afterEach(() => {
@@ -82,27 +93,44 @@ describe('isInvalidTimezoneError', () => {
   });
 });
 
-describe('performanceRetry — at-most-one INVALID_TIMEZONE retry per session', () => {
-  it('two INVALID_TIMEZONE failures in one session yield exactly ONE retry total', () => {
+describe('performanceRetry — at-most-one INVALID_TIMEZONE retry per rejected zone', () => {
+  it('two INVALID_TIMEZONE failures for the same zone yield exactly ONE retry total', () => {
     const err = { error: { code: 'INVALID_TIMEZONE' } };
 
-    // Failure #1: first time the session has seen INVALID_TIMEZONE → retry once.
-    expect(performanceRetry(0, err)).toBe(true);
-    expect(sessionStorage.getItem('perf.invalid_tz_seen')).toBe('true');
+    // Failure #1: this zone has not been rejected before → retry once.
+    expect(performanceRetry(0, err, BAD_TZ)).toBe(true);
+    expect(sessionStorage.getItem('perf.invalid_tz')).toBe(BAD_TZ);
 
     // The retried request fails again with INVALID_TIMEZONE: TanStack would
     // call the retry decision with failureCount=1. Either branch (>=1 OR
-    // session-flag) must refuse.
-    expect(performanceRetry(1, err)).toBe(false);
+    // already-rejected) must refuse.
+    expect(performanceRetry(1, err, BAD_TZ)).toBe(false);
 
-    // A *separate* mount in the same session also refuses (session flag).
-    expect(performanceRetry(0, err)).toBe(false);
+    // A *separate* mount asking for the same zone also refuses.
+    expect(performanceRetry(0, err, BAD_TZ)).toBe(false);
+  });
+
+  it('a DIFFERENT zone still gets its own retry — the record is not session-wide', () => {
+    const err = { error: { code: 'INVALID_TIMEZONE' } };
+    expect(performanceRetry(0, err, BAD_TZ)).toBe(true);
+
+    // The user corrected the preference and the new zone is also rejected: it
+    // must get its own single retry rather than inheriting the old zone's.
+    expect(performanceRetry(0, err, 'Baz/Qux')).toBe(true);
+    expect(readRejectedTimezone()).toBe('Baz/Qux');
+  });
+
+  it('refuses when the failing request carried no zone (the server rejected its own default)', () => {
+    const err = { error: { code: 'INVALID_TIMEZONE' } };
+    expect(performanceRetry(0, err, undefined)).toBe(false);
+    expect(performanceRetry(0, err, null)).toBe(false);
+    expect(readRejectedTimezone()).toBeNull();
   });
 
   it('does not retry non-INVALID_TIMEZONE errors', () => {
-    expect(performanceRetry(0, { error: { code: 'INTERNAL' } })).toBe(false);
-    expect(performanceRetry(0, { status: 500 })).toBe(false);
-    expect(performanceRetry(0, new Error('network down'))).toBe(false);
+    expect(performanceRetry(0, { error: { code: 'INTERNAL' } }, BAD_TZ)).toBe(false);
+    expect(performanceRetry(0, { status: 500 }, BAD_TZ)).toBe(false);
+    expect(performanceRetry(0, new Error('network down'), BAD_TZ)).toBe(false);
   });
 
   it('Safari private-mode: sessionStorage.setItem throws → fallback prevents retry storm', () => {
@@ -113,12 +141,12 @@ describe('performanceRetry — at-most-one INVALID_TIMEZONE retry per session', 
 
     const err = { error: { code: 'INVALID_TIMEZONE' } };
 
-    // First failure consumes the one allowed retry; flag set in module-local fallback.
-    expect(performanceRetry(0, err)).toBe(true);
+    // First failure consumes the one allowed retry; zone kept in the module-local fallback.
+    expect(performanceRetry(0, err, BAD_TZ)).toBe(true);
     // Subsequent failures must refuse — even though sessionStorage cannot
-    // record the flag, the in-memory fallback does.
-    expect(performanceRetry(0, err)).toBe(false);
-    expect(performanceRetry(0, err)).toBe(false);
+    // record the zone, the in-memory fallback does.
+    expect(performanceRetry(0, err, BAD_TZ)).toBe(false);
+    expect(performanceRetry(0, err, BAD_TZ)).toBe(false);
 
     expect(setItemSpy).toHaveBeenCalled();
     // Warned exactly once across the storm.
@@ -135,9 +163,48 @@ describe('performanceRetry — at-most-one INVALID_TIMEZONE retry per session', 
     });
 
     const err = { error: { code: 'INVALID_TIMEZONE' } };
-    expect(performanceRetry(0, err)).toBe(true);
-    expect(performanceRetry(0, err)).toBe(false);
+    expect(performanceRetry(0, err, BAD_TZ)).toBe(true);
+    expect(performanceRetry(0, err, BAD_TZ)).toBe(false);
+    // Reads and writes must AGREE in this mode, or the banner describes a
+    // fallback the request did not make.
+    expect(isTimezoneRejected(BAD_TZ)).toBe(true);
     expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe('rejected-timezone record — lifecycle', () => {
+  it('clearRejectedTimezone re-arms the retry for the zone that was rejected', () => {
+    const err = { error: { code: 'INVALID_TIMEZONE' } };
+    recordRejectedTimezone(BAD_TZ);
+    expect(performanceRetry(0, err, BAD_TZ)).toBe(false);
+
+    // What a reporting-timezone change does.
+    clearRejectedTimezone();
+    expect(readRejectedTimezone()).toBeNull();
+    expect(isTimezoneRejected(BAD_TZ)).toBe(false);
+    expect(performanceRetry(0, err, BAD_TZ)).toBe(true);
+  });
+
+  it('only the recorded zone is treated as rejected', () => {
+    recordRejectedTimezone(BAD_TZ);
+    expect(isTimezoneRejected(BAD_TZ)).toBe(true);
+    expect(isTimezoneRejected('Europe/London')).toBe(false);
+    expect(isTimezoneRejected(undefined)).toBe(false);
+  });
+
+  it('clearRejectedTimezone survives a storage that throws on removeItem', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    recordRejectedTimezone(BAD_TZ);
+    vi.spyOn(storage, 'removeItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+    clearRejectedTimezone();
+    // The in-memory fallback is what the Safari-private path reads, so it must
+    // be cleared even when the storage write cannot be.
+    vi.spyOn(storage, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+    expect(isTimezoneRejected(BAD_TZ)).toBe(false);
   });
 });
 

--- a/apps/web/src/features/performance/hooks/usePerformance.ts
+++ b/apps/web/src/features/performance/hooks/usePerformance.ts
@@ -3,42 +3,23 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { PerformanceQueryInput, PerformanceResponse } from '@tradr/shared';
 
 import { api, isUnauthorized } from '@/lib/api';
+import {
+  clearRejectedTimezone,
+  isTimezoneRejected,
+  recordRejectedTimezone,
+} from '@/lib/invalidTimezone';
 
 // ---- Storage keys ----
-const INVALID_TZ_KEY = 'perf.invalid_tz_seen';
 const RESOLVED_WEEK_START_KEY = 'perf.resolved_week_start';
 
 // ---- Module-local fallbacks (Safari private browsing throws on setItem) ----
 let storageWarned = false;
-let invalidTzSeenFallback = false;
 let resolvedWeekStartFallback: 0 | 1 | null = null;
 
 function warnStorageOnce(err: unknown) {
   if (storageWarned) return;
   storageWarned = true;
   console.warn('[usePerformance] sessionStorage unavailable; using in-memory fallback', err);
-}
-
-function readInvalidTzSeen(): boolean {
-  try {
-    if (sessionStorage.getItem(INVALID_TZ_KEY) === 'true') return true;
-  } catch (err) {
-    warnStorageOnce(err);
-  }
-  // Always also consult the in-memory fallback: when `setItem` throws (Safari
-  // private mode) `getItem` returns null even though we've already "seen" the
-  // INVALID_TIMEZONE error this page-load. Without this OR, two failures in
-  // one tab session would both retry → retry storm.
-  return invalidTzSeenFallback;
-}
-
-function writeInvalidTzSeen(): void {
-  try {
-    sessionStorage.setItem(INVALID_TZ_KEY, 'true');
-  } catch (err) {
-    warnStorageOnce(err);
-    invalidTzSeenFallback = true;
-  }
 }
 
 function readResolvedWeekStart(): 0 | 1 | null {
@@ -119,7 +100,6 @@ function emitWeekStartFlip(next: 0 | 1): void {
 // ---- Test seam: reset module-local state ----
 export function __resetUsePerformanceModuleState(): void {
   storageWarned = false;
-  invalidTzSeenFallback = false;
   resolvedWeekStartFallback = null;
   weekStartFlipListeners.clear();
 }
@@ -136,14 +116,27 @@ function buildPath(params: PerformanceQueryInput, omitTz: boolean): string {
 }
 
 /**
- * Custom retry policy. Returns true for at-most-one INVALID_TIMEZONE retry per session.
+ * Custom retry policy: at most ONE INVALID_TIMEZONE retry per rejected zone.
+ *
+ * The zone is the unit, not the session. Recording which zone was rejected is
+ * what stops the retry from being permanent — a request for any OTHER zone
+ * still carries its `tz`, so correcting the preference takes effect on the very
+ * next request instead of waiting for the tab to close.
+ *
  * Exported for tests; consumed by `usePerformance`.
  */
-export function performanceRetry(failureCount: number, error: unknown): boolean {
+export function performanceRetry(
+  failureCount: number,
+  error: unknown,
+  requestedTz: string | null | undefined,
+): boolean {
   if (failureCount >= 1) return false;
   if (!isInvalidTimezoneError(error)) return false;
-  if (readInvalidTzSeen()) return false;
-  writeInvalidTzSeen();
+  // No zone to blame (the request already omitted `tz`, so the server rejected
+  // its OWN default) or this zone already burnt its retry — either way, stop.
+  if (!requestedTz) return false;
+  if (isTimezoneRejected(requestedTz)) return false;
+  recordRejectedTimezone(requestedTz);
   return true;
 }
 
@@ -189,9 +182,9 @@ export function usePerformance(params: PerformanceQueryInput | null) {
       // `enabled` already guarantees this; the guard narrows the type locally
       // rather than asserting non-null.
       if (params === null) throw new Error('performance query ran without params');
-      // If the session has already seen INVALID_TIMEZONE, omit `tz` from
-      // subsequent requests so the server falls back to its default.
-      const omitTz = readInvalidTzSeen();
+      // Omit `tz` only for the exact zone the server rejected, so the server
+      // falls back to its own default. Any other zone is sent normally.
+      const omitTz = isTimezoneRejected(params.tz);
       const path = buildPath(params, omitTz);
       let data: PerformanceResponse;
       try {
@@ -200,6 +193,12 @@ export function usePerformance(params: PerformanceQueryInput | null) {
         handlePerformanceQueryError(err, queryClient);
         throw err;
       }
+
+      // A request that CARRIED a zone and succeeded proves nothing is rejected
+      // any more — drop the record so the tz-omitted fallback is temporary. A
+      // request that omitted `tz` proves nothing about the recorded zone, so it
+      // deliberately leaves the record alone.
+      if (!omitTz) clearRejectedTimezone();
 
       // Week-start-flip detection. Compare against last-seen value; on mismatch
       // invalidate the performance cache and emit a banner signal.
@@ -212,6 +211,6 @@ export function usePerformance(params: PerformanceQueryInput | null) {
 
       return data;
     },
-    retry: performanceRetry,
+    retry: (failureCount, error) => performanceRetry(failureCount, error, params?.tz),
   });
 }

--- a/apps/web/src/hooks/useUserTimezone.ts
+++ b/apps/web/src/hooks/useUserTimezone.ts
@@ -33,6 +33,7 @@ import { DEFAULT_REPORTING_TIMEZONE } from '@tradr/shared';
 
 import { api } from '@/lib/api';
 import { detectBrowserTimezone } from '@/lib/browserTimezone';
+import { clearRejectedTimezone } from '@/lib/invalidTimezone';
 
 export interface UserTimezoneResponse {
   timezone: string;
@@ -168,10 +169,13 @@ export function useReportingTimezoneBackfill(): void {
     void api
       .put<UserTimezoneResponse>('/users/me/timezone', { timezone: detected })
       .then(() => {
+        // Same reason as the mutation below: a stored zone is a new zone to
+        // ask for, so a rejection recorded against the old one must not keep
+        // stripping `tz` from performance requests.
+        clearRejectedTimezone();
         queryClient.invalidateQueries({ queryKey: ['users', 'me', 'timezone'] });
-        // Same reason as the mutation below: the bucketed figures carry the
-        // zone inside their key, so the entries cut in the substituted default
-        // have to go.
+        // The bucketed figures carry the zone inside their key, so the entries
+        // cut in the substituted default have to go.
         queryClient.invalidateQueries({ queryKey: ['performance'] });
       })
       .catch(() => {
@@ -200,6 +204,11 @@ export function useUserTimezoneMutation() {
     mutationFn: (timezone: string) =>
       api.put<UserTimezoneResponse>('/users/me/timezone', { timezone }),
     onSuccess: () => {
+      // Drop any recorded INVALID_TIMEZONE rejection first. The record is what
+      // makes performance requests omit `tz`; leaving a rejection for the zone
+      // the user just moved away from would strand the tab on UTC no matter
+      // how many times they corrected the preference.
+      clearRejectedTimezone();
       queryClient.invalidateQueries({ queryKey: ['users', 'me', 'timezone'] });
       queryClient.invalidateQueries({ queryKey: ['performance'] });
       toast.success('Reporting timezone updated');

--- a/apps/web/src/lib/invalidTimezone.test.tsx
+++ b/apps/web/src/lib/invalidTimezone.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+//
+// The rejected-timezone record has two owners — the performance query writes
+// and reads it, the reporting-timezone preference clears it — and the defect
+// this file guards against was that it had no lifecycle at all: once written it
+// was never cleared, so every later performance request dropped `tz` and the
+// tab stayed pinned to UTC for the rest of its session. These tests drive the
+// real hooks end-to-end and assert on the URLs that actually went out.
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, type ReactNode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { PerformanceQueryInput, PerformanceResponse } from '@tradr/shared';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const getMock = vi.fn();
+const putMock = vi.fn();
+vi.mock('@/lib/api', () => ({
+  api: {
+    get: (...args: unknown[]) => getMock(...args),
+    put: (...args: unknown[]) => putMock(...args),
+  },
+  isUnauthorized: () => false,
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), dismiss: vi.fn() },
+}));
+
+import { usePerformance } from '@/features/performance/hooks/usePerformance';
+import { useUserTimezoneMutation } from '@/hooks/useUserTimezone';
+
+import {
+  __resetInvalidTimezoneState,
+  readRejectedTimezone,
+  recordRejectedTimezone,
+} from './invalidTimezone';
+
+const BAD_TZ = 'Foo/Bar';
+
+const PARAMS: PerformanceQueryInput = {
+  granularity: 'month',
+  start: '2026-01-01T00:00:00.000Z',
+  end: '2027-01-01T00:00:00.000Z',
+  tz: BAD_TZ,
+  currency: 'USD',
+};
+
+const TZ_ERROR = { status: 400, error: { code: 'INVALID_TIMEZONE', message: 'Invalid timezone' } };
+
+function buildResponse(): PerformanceResponse {
+  return {
+    resolvedTimezone: 'UTC',
+    resolvedWeekStartDay: 0,
+    dataQuality: {
+      timeframeExcluded: { total: 0, unsupported: 0, mismatch: 0 },
+      historyExcluded: { total: 0, closed_at_null: 0 },
+    },
+    hasAnyAccounts: true,
+    hasAnyClosedPositions: true,
+    hasAnyClosedPositionsInSupportedCurrency: true,
+    defaultCurrency: 'USD',
+    currencies: [],
+  } as unknown as PerformanceResponse;
+}
+
+function makeClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retryDelay: 0, gcTime: 0, staleTime: 0 } },
+  });
+}
+
+function mount(ui: ReactNode, client: QueryClient) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+  });
+  return { container, root };
+}
+
+async function settle(rounds = 12): Promise<void> {
+  for (let i = 0; i < rounds; i += 1) {
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 5));
+    });
+  }
+}
+
+/** Every path `api.get` was called with, in order. */
+function requestedPaths(): string[] {
+  return getMock.mock.calls.map((c) => String(c[0]));
+}
+
+function Probe({ params }: { params: PerformanceQueryInput }) {
+  usePerformance(params);
+  return null;
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  __resetInvalidTimezoneState();
+  getMock.mockReset();
+  putMock.mockReset();
+  document.body.innerHTML = '';
+});
+
+describe('rejected-timezone record — cleared by a successful performance request', () => {
+  it('a later request for a DIFFERENT zone carries tz, and its success clears the record', async () => {
+    // First request carries the bad zone and is rejected; the one allowed
+    // retry goes out without `tz` and succeeds.
+    getMock.mockRejectedValueOnce(TZ_ERROR).mockResolvedValue(buildResponse());
+
+    const { root } = mount(<Probe params={PARAMS} />, makeClient());
+    await settle();
+
+    expect(requestedPaths()[0]).toContain(`tz=${encodeURIComponent(BAD_TZ)}`);
+    expect(requestedPaths()[1]).not.toContain('tz=');
+    // The zone that was actually rejected is what got recorded.
+    expect(readRejectedTimezone()).toBe(BAD_TZ);
+    act(() => root.unmount());
+
+    // The user corrects the preference and returns; the request must carry the
+    // NEW zone. Before the record had a lifecycle this dropped `tz` forever.
+    const before = requestedPaths().length;
+    const { root: root2 } = mount(
+      <Probe params={{ ...PARAMS, tz: 'Europe/London' }} />,
+      makeClient(),
+    );
+    await settle();
+
+    const later = requestedPaths().slice(before);
+    expect(later.length).toBeGreaterThan(0);
+    expect(later[0]).toContain('tz=Europe%2FLondon');
+    // That request carried a zone and succeeded, so nothing is rejected now.
+    expect(readRejectedTimezone()).toBeNull();
+    act(() => root2.unmount());
+  });
+
+  it('a successful request that OMITTED tz leaves the record alone', async () => {
+    // Success proves nothing about the recorded zone when the zone was never
+    // sent — clearing here would re-arm a request we already know fails.
+    recordRejectedTimezone(BAD_TZ);
+    getMock.mockResolvedValue(buildResponse());
+
+    const { root } = mount(<Probe params={PARAMS} />, makeClient());
+    await settle();
+
+    expect(requestedPaths()[0]).not.toContain('tz=');
+    expect(readRejectedTimezone()).toBe(BAD_TZ);
+    act(() => root.unmount());
+  });
+});
+
+describe('rejected-timezone record — cleared by a reporting-timezone change', () => {
+  it('useUserTimezoneMutation clears it on success, without any page reload', async () => {
+    recordRejectedTimezone(BAD_TZ);
+    putMock.mockResolvedValue({ timezone: 'Europe/London', stored: true });
+
+    let mutate: ((tz: string) => void) | null = null;
+    function MutationProbe() {
+      const m = useUserTimezoneMutation();
+      mutate = m.mutate;
+      return null;
+    }
+    const { root } = mount(<MutationProbe />, makeClient());
+    await act(async () => {
+      mutate?.('Europe/London');
+      await Promise.resolve();
+    });
+    await settle(4);
+
+    expect(putMock).toHaveBeenCalled();
+    expect(readRejectedTimezone()).toBeNull();
+    act(() => root.unmount());
+  });
+});

--- a/apps/web/src/lib/invalidTimezone.ts
+++ b/apps/web/src/lib/invalidTimezone.ts
@@ -15,10 +15,11 @@
 // A zone that is not the recorded one is always sent, so a corrected preference
 // takes effect on the next request — no page reload involved.
 //
-// It lives in `lib/` rather than inside the performance feature because two
-// unrelated callers need it: the performance query (which reads and writes it)
-// and the reporting-timezone preference (which clears it). A feature module
-// cannot own state a global preference hook has to reset.
+// It lives in `lib/` rather than inside the performance feature because three
+// unrelated callers need it: the performance query (which reads and writes it),
+// the route loader that prefetches that query (which reads it), and the
+// reporting-timezone preference (which clears it). A feature module cannot own
+// state a global preference hook has to reset.
 
 const REJECTED_TZ_KEY = 'perf.invalid_tz';
 
@@ -26,6 +27,13 @@ const REJECTED_TZ_KEY = 'perf.invalid_tz';
 // must agree in that mode or the UI disagrees with the request it is
 // describing, so BOTH sides consult this fallback.
 let rejectedTzFallback: string | null = null;
+// Reads prefer sessionStorage because it survives a reload, but that preference
+// is only safe while sessionStorage is in step with us. A write that throws
+// leaves the previous value behind — a failed `removeItem` in particular would
+// let reads keep returning the very zone the clear was meant to forget, which
+// is the session-sticky fallback this module exists to end. Once a write fails,
+// the in-memory record is the only truthful one.
+let rejectedTzStorageStale = false;
 let storageWarned = false;
 
 function warnStorageOnce(err: unknown): void {
@@ -36,11 +44,13 @@ function warnStorageOnce(err: unknown): void {
 
 /** The IANA zone the server most recently rejected, or `null`. */
 export function readRejectedTimezone(): string | null {
-  try {
-    const stored = sessionStorage.getItem(REJECTED_TZ_KEY);
-    if (stored) return stored;
-  } catch (err) {
-    warnStorageOnce(err);
+  if (!rejectedTzStorageStale) {
+    try {
+      const stored = sessionStorage.getItem(REJECTED_TZ_KEY);
+      if (stored) return stored;
+    } catch (err) {
+      warnStorageOnce(err);
+    }
   }
   return rejectedTzFallback;
 }
@@ -55,8 +65,10 @@ export function recordRejectedTimezone(tz: string): void {
   rejectedTzFallback = tz;
   try {
     sessionStorage.setItem(REJECTED_TZ_KEY, tz);
+    rejectedTzStorageStale = false;
   } catch (err) {
     warnStorageOnce(err);
+    rejectedTzStorageStale = true;
   }
 }
 
@@ -69,13 +81,16 @@ export function clearRejectedTimezone(): void {
   rejectedTzFallback = null;
   try {
     sessionStorage.removeItem(REJECTED_TZ_KEY);
+    rejectedTzStorageStale = false;
   } catch (err) {
     warnStorageOnce(err);
+    rejectedTzStorageStale = true;
   }
 }
 
 /** Test seam — clears the module-local fallback so test runs are isolated. */
 export function __resetInvalidTimezoneState(): void {
   rejectedTzFallback = null;
+  rejectedTzStorageStale = false;
   storageWarned = false;
 }

--- a/apps/web/src/lib/invalidTimezone.ts
+++ b/apps/web/src/lib/invalidTimezone.ts
@@ -1,0 +1,81 @@
+// The one record of "the server rejected this reporting timezone".
+//
+// It exists so a performance request that failed on an unrecognised IANA zone
+// can be retried ONCE with `tz` omitted (the server then uses its own default)
+// without that retry looping. Previously this was a bare "seen it" boolean that
+// was written once and never cleared, which pinned the whole tab to UTC for the
+// rest of its session: every later request kept dropping `tz`, so correcting the
+// preference changed nothing.
+//
+// So the record is keyed by the zone that was actually rejected, and it has a
+// lifecycle:
+//   - written when a request carrying that zone fails with INVALID_TIMEZONE;
+//   - cleared when a request that CARRIED a zone succeeds;
+//   - cleared when the user changes their reporting timezone.
+// A zone that is not the recorded one is always sent, so a corrected preference
+// takes effect on the next request — no page reload involved.
+//
+// It lives in `lib/` rather than inside the performance feature because two
+// unrelated callers need it: the performance query (which reads and writes it)
+// and the reporting-timezone preference (which clears it). A feature module
+// cannot own state a global preference hook has to reset.
+
+const REJECTED_TZ_KEY = 'perf.invalid_tz';
+
+// Safari private browsing throws on sessionStorage access. Reads and writes
+// must agree in that mode or the UI disagrees with the request it is
+// describing, so BOTH sides consult this fallback.
+let rejectedTzFallback: string | null = null;
+let storageWarned = false;
+
+function warnStorageOnce(err: unknown): void {
+  if (storageWarned) return;
+  storageWarned = true;
+  console.warn('[invalidTimezone] sessionStorage unavailable; using in-memory fallback', err);
+}
+
+/** The IANA zone the server most recently rejected, or `null`. */
+export function readRejectedTimezone(): string | null {
+  try {
+    const stored = sessionStorage.getItem(REJECTED_TZ_KEY);
+    if (stored) return stored;
+  } catch (err) {
+    warnStorageOnce(err);
+  }
+  return rejectedTzFallback;
+}
+
+/** True when `tz` is the zone the server rejected — so requests must omit it. */
+export function isTimezoneRejected(tz: string | null | undefined): boolean {
+  if (!tz) return false;
+  return readRejectedTimezone() === tz;
+}
+
+export function recordRejectedTimezone(tz: string): void {
+  rejectedTzFallback = tz;
+  try {
+    sessionStorage.setItem(REJECTED_TZ_KEY, tz);
+  } catch (err) {
+    warnStorageOnce(err);
+  }
+}
+
+/**
+ * Forget the rejected zone. Called on a successful performance request that
+ * carried a zone, and whenever the reporting timezone changes — both mean the
+ * recorded zone is no longer the one being asked for.
+ */
+export function clearRejectedTimezone(): void {
+  rejectedTzFallback = null;
+  try {
+    sessionStorage.removeItem(REJECTED_TZ_KEY);
+  } catch (err) {
+    warnStorageOnce(err);
+  }
+}
+
+/** Test seam — clears the module-local fallback so test runs are isolated. */
+export function __resetInvalidTimezoneState(): void {
+  rejectedTzFallback = null;
+  storageWarned = false;
+}

--- a/apps/web/src/routes/_auth.performance.test.tsx
+++ b/apps/web/src/routes/_auth.performance.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+//
+// The route loader prefetches the same query the component hook owns, so it
+// has to obey the same rejected-timezone record. When it did not, a user whose
+// reporting zone the server rejects burned the loader's full retry budget on
+// every single navigation to Performance — the hook-side fix was bypassed on
+// the primary navigation path.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { PerformanceQueryInput, PerformanceResponse } from '@tradr/shared';
+
+const getMock = vi.fn();
+vi.mock('@/lib/api', () => ({
+  api: { get: (...args: unknown[]) => getMock(...args) },
+  isUnauthorized: () => false,
+}));
+
+// The route module pulls in the whole performance page (charts, lazy chunks).
+// The loader is what is under test, so a stub component keeps the import cheap.
+vi.mock('@/features/performance/components/PerformancePage', () => ({
+  PerformancePage: () => null,
+}));
+
+import {
+  __resetInvalidTimezoneState,
+  readRejectedTimezone,
+  recordRejectedTimezone,
+} from '@/lib/invalidTimezone';
+import { queryClient } from '@/lib/queryClient';
+
+import { Route } from './_auth.performance';
+
+const BAD_TZ = 'Foo/Bar';
+
+const PARAMS: PerformanceQueryInput = {
+  granularity: 'month',
+  start: '2026-01-01T00:00:00.000Z',
+  end: '2027-01-01T00:00:00.000Z',
+  tz: BAD_TZ,
+  currency: 'USD',
+};
+
+const TZ_ERROR = { status: 400, error: { code: 'INVALID_TIMEZONE', message: 'Invalid timezone' } };
+
+function buildResponse(): PerformanceResponse {
+  return {
+    resolvedTimezone: 'UTC',
+    resolvedWeekStartDay: 0,
+    dataQuality: {
+      timeframeExcluded: { total: 0, unsupported: 0, mismatch: 0 },
+      historyExcluded: { total: 0, closed_at_null: 0 },
+    },
+    hasAnyAccounts: true,
+    hasAnyClosedPositions: true,
+    hasAnyClosedPositionsInSupportedCurrency: true,
+    defaultCurrency: 'USD',
+    currencies: [],
+  } as unknown as PerformanceResponse;
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const runLoader = (params: PerformanceQueryInput): Promise<unknown> =>
+  (Route.options as any).loader({ deps: { params } });
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/** Every path `api.get` was called with, in order. */
+function requestedPaths(): string[] {
+  return getMock.mock.calls.map((c) => String(c[0]));
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  __resetInvalidTimezoneState();
+  getMock.mockReset();
+  queryClient.clear();
+  // Keep the real retry COUNT (that is what is under test) but drop the
+  // exponential backoff so the failing path resolves inside the test timeout.
+  queryClient.setDefaultOptions({ queries: { retryDelay: 0, gcTime: 0, staleTime: 0 } });
+});
+
+afterEach(() => {
+  queryClient.clear();
+  queryClient.setDefaultOptions({});
+});
+
+describe('performance route loader — respects the rejected-timezone record', () => {
+  it('omits tz for the recorded zone instead of re-sending it on every navigation', async () => {
+    recordRejectedTimezone(BAD_TZ);
+    getMock.mockResolvedValue(buildResponse());
+
+    await runLoader(PARAMS);
+
+    expect(requestedPaths()).toHaveLength(1);
+    expect(requestedPaths()[0]).not.toContain('tz=');
+  });
+
+  it('costs exactly one request for a zone nothing has rejected yet', async () => {
+    getMock.mockRejectedValue(TZ_ERROR);
+
+    await runLoader(PARAMS);
+
+    // `ensureQueryData` -> `fetchQuery` forces `retry: false` when the caller
+    // sets none, so the prefetch never multiplies a rejected zone into a burst.
+    // The one tz-omitted retry, and the record it writes, belong to the hook —
+    // this asserts the loader does not grow a competing retry policy.
+    expect(requestedPaths()).toHaveLength(1);
+    expect(requestedPaths()[0]).toContain(`tz=${encodeURIComponent(BAD_TZ)}`);
+    expect(readRejectedTimezone()).toBeNull();
+  });
+
+  it('still carries tz for a zone that is not the recorded one', async () => {
+    recordRejectedTimezone(BAD_TZ);
+    getMock.mockResolvedValue(buildResponse());
+
+    await runLoader({ ...PARAMS, tz: 'Europe/London' });
+
+    expect(requestedPaths()).toHaveLength(1);
+    expect(requestedPaths()[0]).toContain('tz=Europe%2FLondon');
+  });
+});

--- a/apps/web/src/routes/_auth.performance.tsx
+++ b/apps/web/src/routes/_auth.performance.tsx
@@ -6,6 +6,7 @@ import { PerformanceQuerySchema } from '@tradr/shared/schemas/performance';
 
 import { PerformancePage } from '@/features/performance/components/PerformancePage';
 import { api } from '@/lib/api';
+import { isTimezoneRejected } from '@/lib/invalidTimezone';
 import { queryClient } from '@/lib/queryClient';
 
 // ---- Shared query options --------------------------------------------------
@@ -19,7 +20,12 @@ function buildPath(params: PerformanceQueryInput): string {
   q.set('granularity', params.granularity);
   q.set('start', params.start);
   q.set('end', params.end);
-  q.set('tz', params.tz);
+  // Same rejected-zone record the hook reads, via the same predicate — a second
+  // reader with its own idea of "rejected" is the bug this record was built to
+  // end. Without this the prefetch re-sends a zone the server has already
+  // refused, so every navigation to Performance opens with a request we know
+  // fails. Omitting `tz` lets the server fall back to its own default.
+  if (!isTimezoneRejected(params.tz)) q.set('tz', params.tz);
   if (params.currency) q.set('currency', params.currency);
   return `/performance?${q.toString()}`;
 }

--- a/e2e/tests/app-shell-fixture.spec.ts
+++ b/e2e/tests/app-shell-fixture.spec.ts
@@ -92,6 +92,18 @@ test.describe('mockAppShell', () => {
     await page.waitForURL(/\/login/, { timeout: 20_000 });
   });
 
+  test('refuses a second install on the same page', async ({ page }) => {
+    // Installing twice used to be a silent trap, which is the one thing this
+    // helper must not be. The second call's backstop is registered last, so
+    // Playwright reaches it FIRST — shadowing every route registered since the
+    // first call, the spec's own overrides included — and it swaps in a fresh
+    // record, losing whatever the first backstop had already seen. Nothing said
+    // so; the spec simply started failing on a stub it had definitely
+    // registered.
+    await mockAppShell(page);
+    await expect(mockAppShell(page)).rejects.toThrow(/already installed on this page/);
+  });
+
   test('fails the test when the unstubbed request comes after the last await', async ({ page }) => {
     // Also SUPPOSED to fail, and for a reason the test above cannot cover.
     //
@@ -105,9 +117,21 @@ test.describe('mockAppShell', () => {
     //
     // The body below is written to PASS in that world: it schedules one
     // unstubbed request for after it has returned and asserts nothing. What
-    // fails it now is teardown — the fixture settles, the request lands, the
-    // backstop records it, and the recorded list is asserted empty. Take either
-    // half away and this reports "Expected to fail, but passed".
+    // fails it now is teardown — the settle fixture holds the test open, the
+    // request lands, the backstop records it and throws, and the recorded list
+    // is asserted empty in a later fixture.
+    //
+    // Those two reports are belt and braces, NOT two halves of one check:
+    // measured by deleting each in turn, either alone still fails this test —
+    // with only the record the single error is the recorded-list assertion,
+    // with only the throw it is `unstubbed request GET
+    // /api/__unstubbed-after-last-await`.
+    //
+    // What is not redundant is WHERE the record is read. A backstop throw
+    // interrupts the step in flight, so while the settle and the assertion
+    // shared one fixture the throw cancelled the settle and the assertion never
+    // ran at all — inert, with the throw quietly doing all the work. The read
+    // has a fixture of its own now, which is what makes the second report real.
     test.fail();
 
     await mockAppShell(page);

--- a/e2e/tests/app-shell-fixture.spec.ts
+++ b/e2e/tests/app-shell-fixture.spec.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { expect, type Page } from '@playwright/test';
 
 import { mockAppShell, PERF_URL, SESSION_RESPONSE, test } from './fixtures/performance-fixtures';
@@ -24,6 +27,17 @@ const json = (body: unknown) => ({
 
 async function mockSession(page: Page) {
   await page.route('**/api/auth/me', (route) => route.fulfill(json(SESSION_RESPONSE)));
+}
+
+/** Every `.ts` file under the suite's own test root, recursively. */
+function suiteSources(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) found.push(...suiteSources(full));
+    else if (entry.name.endsWith('.ts')) found.push(full);
+  }
+  return found;
 }
 
 test.describe('mockAppShell', () => {
@@ -90,6 +104,75 @@ test.describe('mockAppShell', () => {
 
     await page.goto('/dashboard');
     await page.waitForURL(/\/login/, { timeout: 20_000 });
+  });
+
+  test('refuses a page the contract fixtures are not live for', async ({ context }) => {
+    // The backstop is only half the contract. The other half — catching a
+    // request the app makes after the spec's last await — is teardown on the
+    // `test` this file imports from the fixture module, so a spec that takes
+    // `test` from `@playwright/test` gets a weaker guarantee than the helper
+    // advertises, and nothing in that spec's diff looks wrong. Measured before
+    // this check existed: a stray request 200ms after the body returned passed
+    // green.
+    //
+    // A page opened by hand stands in for it here, because a spec cannot import
+    // two different `test`s. It is the same hole from the other side: these
+    // fixtures never saw this page, so nothing would ever read its violations.
+    const unfixtured = await context.newPage();
+    await expect(mockAppShell(unfixtured)).rejects.toThrow(/contract fixtures are not live/);
+    await unfixtured.close();
+  });
+
+  test('no spec reaches the real network via route.continue', () => {
+    // `continue()` abandons the handler chain and goes to the network, so a
+    // request nothing here answers takes a real 401 against the synthetic
+    // session and the api client bounces the whole app to /login — the failure
+    // the backstop exists to end, past the backstop entirely.
+    //
+    // Seven of them were removed from ledger-balances in one pass, and what
+    // stood between the next author and putting one back was a doc comment.
+    // That is not a guard, so the rule gets teeth here instead.
+    //
+    // A test rather than an ESLint rule on purpose. `no-restricted-syntax` is
+    // already blanket-disabled at the top of several specs in this directory
+    // for the `process.env` selector it carries, which would switch this off
+    // with it; and a selector matching `route.continue` would miss a handler
+    // whose parameter is named anything else. A grep for the call misses
+    // neither.
+    //
+    // Scoped to the test tree because that is where `page.route` handlers live;
+    // e2e/support holds Node stub servers, which have no Route to continue.
+    //
+    // This file is IN scope, which is why the title and the message below name
+    // the call without its parentheses: the check holds itself to the rule
+    // rather than carving out an exemption that a real call could hide in.
+    const testRoot = path.dirname(test.info().file);
+    const offenders: string[] = [];
+
+    for (const file of suiteSources(testRoot)) {
+      fs.readFileSync(file, 'utf8')
+        .split('\n')
+        .forEach((line, index) => {
+          // Comment lines are where the hazard is DESCRIBED — twice in this
+          // suite, deliberately. A real call never starts a line with any of
+          // these, so skipping them costs the check nothing.
+          const code = line.trim();
+          if (code.startsWith('*') || code.startsWith('//') || code.startsWith('/*')) return;
+          if (/\.continue\s*\(/.test(line)) {
+            offenders.push(`${path.relative(testRoot, file)}:${index + 1}`);
+          }
+        });
+    }
+
+    expect(
+      offenders,
+      'A route handler here calls continue(), which abandons the handler chain and goes ' +
+        'to the real network, so the request never reaches the mockAppShell backstop: it ' +
+        '401s against the mocked session and the app silently redirects to /login ' +
+        'mid-test, and the spec goes on asserting against the login page. Use ' +
+        'route.fallback() instead — it hands the request to the next matching handler, ' +
+        'and failing all of them, to the backstop that names it.',
+    ).toEqual([]);
   });
 
   test('refuses a second install on the same page', async ({ page }) => {

--- a/e2e/tests/app-shell-fixture.spec.ts
+++ b/e2e/tests/app-shell-fixture.spec.ts
@@ -1,6 +1,6 @@
-import { test, expect, type Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 
-import { mockAppShell, PERF_URL, SESSION_RESPONSE } from './fixtures/performance-fixtures';
+import { mockAppShell, PERF_URL, SESSION_RESPONSE, test } from './fixtures/performance-fixtures';
 
 /**
  * Coverage for `mockAppShell` itself (e2e/tests/fixtures/performance-fixtures.ts).
@@ -90,5 +90,39 @@ test.describe('mockAppShell', () => {
 
     await page.goto('/dashboard');
     await page.waitForURL(/\/login/, { timeout: 20_000 });
+  });
+
+  test('fails the test when the unstubbed request comes after the last await', async ({ page }) => {
+    // Also SUPPOSED to fail, and for a reason the test above cannot cover.
+    //
+    // The backstop's throw is only reported while the spec is awaiting
+    // something. A request the app fires after the spec's last await — a
+    // debounce, a widget fetching once its grid has mounted — used to throw
+    // into nothing: measured, teardown began 3ms after the body returned and a
+    // stray 50ms later was never even issued, so the suite stayed green with a
+    // missing stub. That is the same silent pass this file exists to prevent,
+    // reached by timing rather than by a missing stub.
+    //
+    // The body below is written to PASS in that world: it schedules one
+    // unstubbed request for after it has returned and asserts nothing. What
+    // fails it now is teardown — the fixture settles, the request lands, the
+    // backstop records it, and the recorded list is asserted empty. Take either
+    // half away and this reports "Expected to fail, but passed".
+    test.fail();
+
+    await mockAppShell(page);
+    await mockSession(page);
+
+    await page.goto('/dashboard');
+    await expect(page.getByTestId('drawer-topbar')).toBeVisible();
+
+    // Stands in for the endpoint the fixture does not know about yet, asked for
+    // late. `evaluate` returns as soon as the timer is set, so the request
+    // leaves the page after this test body has finished.
+    await page.evaluate(() => {
+      window.setTimeout(() => {
+        void fetch('/api/__unstubbed-after-last-await');
+      }, 200);
+    });
   });
 });

--- a/e2e/tests/app-shell-fixture.spec.ts
+++ b/e2e/tests/app-shell-fixture.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect, type Page } from '@playwright/test';
+
+import { mockAppShell, PERF_URL, SESSION_RESPONSE } from './fixtures/performance-fixtures';
+
+/**
+ * Coverage for `mockAppShell` itself (e2e/tests/fixtures/performance-fixtures.ts).
+ *
+ * Every other spec in this suite treats that helper as the authenticated app
+ * shell. Nothing checked that it actually WAS one. When a stub was missing the
+ * request 401'd, the api client redirected the whole app to /login, and the
+ * spec carried on asserting against the login page — green, and testing
+ * nothing. It happened four times on this branch before anyone noticed.
+ *
+ * So the contract gets its own tests: the shell is fully answered on the routes
+ * the mocked specs visit, and a request it does not answer fails the test
+ * instead of redirecting.
+ */
+
+const json = (body: unknown) => ({
+  status: 200,
+  contentType: 'application/json',
+  body: JSON.stringify(body),
+});
+
+async function mockSession(page: Page) {
+  await page.route('**/api/auth/me', (route) => route.fulfill(json(SESSION_RESPONSE)));
+}
+
+test.describe('mockAppShell', () => {
+  for (const [label, url] of [
+    ['/dashboard', '/dashboard'],
+    ['/performance', PERF_URL],
+  ] as const) {
+    test(`answers every request the shell makes on ${label}`, async ({ page }) => {
+      const unauthorized: string[] = [];
+      page.on('response', (response) => {
+        if (response.status() === 401) unauthorized.push(new URL(response.url()).pathname);
+      });
+
+      await mockAppShell(page);
+      await mockSession(page);
+
+      // A request the fixture does not answer never gets one: the backstop
+      // throws and this test fails naming the method and path. That is the
+      // assertion — no list of endpoints to keep in step with the app here,
+      // because the app itself decides what it asks for.
+      await page.goto(url);
+      await expect(page.getByTestId('drawer-topbar')).toBeVisible();
+      // The shell paints well before it has finished asking for things — the
+      // widgets fetch after their grid mounts. Without a wait the test can end
+      // while the last requests are still in flight, and a backstop throw after
+      // the body has returned is dropped: the missing stub goes unreported,
+      // which is the failure this whole file exists to prevent.
+      //
+      // A fixed window rather than `waitForLoadState('networkidle')`, because
+      // /dashboard is never idle: the grid re-persists its layout on a 300ms
+      // debounce, the layout stub echoes the same static body back, and the
+      // grid re-normalises and persists again, for as long as the page is open.
+      // Measured, every request the shell makes is issued within ~900ms of the
+      // navigation, and an unstubbed one throws the moment it is made.
+      await page.waitForTimeout(2_000);
+
+      // Belt and braces for the other way in: a stub that exists but answers
+      // 401 would redirect just as silently, and the backstop never sees it.
+      expect(unauthorized, 'the mocked session must not 401 anywhere').toEqual([]);
+      expect(page.url(), 'the shell must not have bounced the spec to /login').not.toContain(
+        '/login',
+      );
+    });
+  }
+
+  test('fails the test when a shell request is unstubbed', async ({ page }) => {
+    // This test is SUPPOSED to fail, and the backstop is the only thing that
+    // can fail it. The body is written to PASS in the fail-open world: it lets
+    // the missing stub 401, waits for the redirect a 401 produces, and asserts
+    // nothing whatsoever about the dashboard it was pointed at. That is the
+    // defect in one test — a spec quietly running against /login.
+    //
+    // With the backstop the request is never answered, so no redirect ever
+    // comes and the throw lands mid-wait: an expected failure, suite green.
+    // Take the backstop away and the body runs to the end and passes, which
+    // Playwright reports as "Expected to fail, but passed" — suite red.
+    test.fail();
+
+    await mockAppShell(page);
+    await mockSession(page);
+    // Drop one stub to stand in for the endpoint the fixture does not know
+    // about yet — the shape every one of the four regressions took.
+    await page.unroute('**/api/dashboard/totals');
+
+    await page.goto('/dashboard');
+    await page.waitForURL(/\/login/, { timeout: 20_000 });
+  });
+});

--- a/e2e/tests/dashboard-chart-height.spec.ts
+++ b/e2e/tests/dashboard-chart-height.spec.ts
@@ -1,6 +1,6 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 
-import { mockAppShell, SESSION_RESPONSE } from './fixtures/performance-fixtures';
+import { mockAppShell, SESSION_RESPONSE, test } from './fixtures/performance-fixtures';
 
 /**
  * Rendered height of the two dashboard chart widgets, on BOTH grid paths.

--- a/e2e/tests/fixtures/performance-fixtures.ts
+++ b/e2e/tests/fixtures/performance-fixtures.ts
@@ -177,15 +177,24 @@ export const SESSION_RESPONSE = {
  *
  * It FAILS CLOSED: anything under `/api/` that neither this helper nor the spec
  * answers hits the backstop registered below and fails the test by name. See
- * `failOnUnstubbedRequest`. Specs must import `test` from this module for that
- * to hold — the teardown half of the check is a fixture on it.
+ * `failOnUnstubbedRequest`.
  *
- * One way to defeat it, worth knowing: a spec handler that calls
- * `route.continue()` for the requests it does not want. `continue()` abandons
- * the handler chain and goes to the real network, so those requests never reach
- * the backstop and fail open to a 401 and the /login bounce all over again. Use
- * `route.fallback()`, which hands the request to the next matching handler —
- * this helper's stubs, and failing those, the backstop.
+ * Two things used to defeat it quietly, and both are now refused mechanically
+ * rather than by this comment:
+ *
+ *  1. Importing `test` from `@playwright/test` instead of from this module. The
+ *     backstop is installed by this function either way, but the teardown that
+ *     catches a request arriving after the spec's last await is a fixture on the
+ *     `test` exported below — a plain import silently drops it. So this function
+ *     now checks the fixture is live and throws if it is not; see
+ *     `contractedPages`.
+ *  2. A spec handler that calls `route.continue()` for the requests it does not
+ *     want. `continue()` abandons the handler chain and goes to the real
+ *     network, so those requests never reach the backstop and fail open to a 401
+ *     and the /login bounce all over again. Use `route.fallback()`, which hands
+ *     the request to the next matching handler — this helper's stubs, and
+ *     failing those, the backstop. `app-shell-fixture.spec.ts` greps the spec
+ *     tree and fails if a `continue()` call comes back.
  */
 /**
  * The default dashboard layout a freshly-registered user receives from the
@@ -199,7 +208,7 @@ export const SESSION_RESPONSE = {
  * file changes.
  *
  * It had already drifted: the copy below carried the pre-40px-unit values
- * (`stats-summary` at h:1, under the h:2 minimum its own type declares, and
+ * (`stats-summary` at h:1, far under the h:5 minimum its own type declares, and
  * six-column charts), so every spec leaning on the app shell rendered a layout
  * no user has ever been served.
  */
@@ -251,6 +260,26 @@ const DEFAULT_DASHBOARD_LAYOUT = {
 const unstubbedRequests = new WeakMap<Page, string[]>();
 
 /**
+ * Pages the contract fixtures below are live for. Stamped during fixture SETUP,
+ * so it is already true by the time any test body calls `mockAppShell`.
+ *
+ * This is what makes the guarantee compulsory rather than opt-in by import
+ * line. The backstop is installed by `mockAppShell` whichever `test` a spec
+ * imports, but the half that catches a request arriving AFTER the spec's last
+ * await is teardown on the `test` exported below. A spec importing `test` from
+ * `@playwright/test` therefore got the throw-while-awaiting half and nothing
+ * else — measured: a stray request fired 200ms after the body returned passed
+ * green, which is round 2's entire failure, re-opened by one import line. The
+ * cost lands on whoever writes the NEXT spec, so nothing in the diff that
+ * introduces it looks wrong.
+ *
+ * It also catches the other way to end up outside the fixtures: calling
+ * `mockAppShell` on a page the fixtures never saw (`context.newPage()`), whose
+ * violations no teardown reads.
+ */
+const contractedPages = new WeakSet<Page>();
+
+/**
  * The backstop that makes the list below a CONTRACT rather than a best effort.
  *
  * Registered first, so Playwright — which matches handlers in reverse
@@ -287,6 +316,22 @@ const unstubbedRequests = new WeakMap<Page, string[]>();
  *     EVERY unstubbed request rather than only the first.
  */
 async function failOnUnstubbedRequest(page: Page): Promise<void> {
+  // Half the contract lives in teardown on the `test` exported below, so refuse
+  // to install at all unless that `test` is the one running. Silently giving
+  // back a weaker guarantee than the doc comment promises is precisely the
+  // failure this helper exists to end.
+  if (!contractedPages.has(page)) {
+    throw new Error(
+      'mockAppShell: the app-shell contract fixtures are not live for this page.\n' +
+        'Without them the backstop still throws while the spec is awaiting something, ' +
+        'but a request the app makes AFTER the last await is never seen and the test ' +
+        'passes with a missing stub — the exact silent pass this helper exists to end.\n' +
+        "Fix: import `test` from './fixtures/performance-fixtures' (keep importing " +
+        '`expect` from `@playwright/test`), and call mockAppShell on the `page` fixture ' +
+        'rather than a page you opened yourself.',
+    );
+  }
+
   // A second install would register a second catch-all. Playwright matches in
   // reverse registration order, so it would shadow every route registered since
   // the first — including the spec's own overrides, which are registered after
@@ -381,6 +426,10 @@ const UNSTUBBED_SETTLE_MS = 500;
 export const test = base.extend<{ appShellContract: void; appShellSettle: void }>({
   appShellContract: [
     async ({ page }, use) => {
+      // Stamped in SETUP, so `mockAppShell` can refuse a page these fixtures
+      // are not live for — see `contractedPages`.
+      contractedPages.add(page);
+
       await use();
 
       // No record means the spec never installed the shell, so there is no

--- a/e2e/tests/fixtures/performance-fixtures.ts
+++ b/e2e/tests/fixtures/performance-fixtures.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import { test as base, expect, type Page } from '@playwright/test';
 
 /**
  * Static performance API fixtures used by the e2e specs. Kept in one place so
@@ -177,7 +177,15 @@ export const SESSION_RESPONSE = {
  *
  * It FAILS CLOSED: anything under `/api/` that neither this helper nor the spec
  * answers hits the backstop registered below and fails the test by name. See
- * `failOnUnstubbedRequest`.
+ * `failOnUnstubbedRequest`. Specs must import `test` from this module for that
+ * to hold — the teardown half of the check is a fixture on it.
+ *
+ * One way to defeat it, worth knowing: a spec handler that calls
+ * `route.continue()` for the requests it does not want. `continue()` abandons
+ * the handler chain and goes to the real network, so those requests never reach
+ * the backstop and fail open to a 401 and the /login bounce all over again. Use
+ * `route.fallback()`, which hands the request to the next matching handler —
+ * this helper's stubs, and failing those, the backstop.
  */
 /**
  * The default dashboard layout a freshly-registered user receives from the
@@ -237,13 +245,18 @@ const DEFAULT_DASHBOARD_LAYOUT = {
 };
 
 /**
+ * Every unstubbed request the backstop saw, per page. Read by the `test`
+ * exported below in teardown — see `failOnUnstubbedRequest`.
+ */
+const unstubbedRequests = new WeakMap<Page, string[]>();
+
+/**
  * The backstop that makes the list below a CONTRACT rather than a best effort.
  *
  * Registered first, so Playwright — which matches handlers in reverse
  * registration order — reaches it only when neither `mockAppShell` nor the spec
- * answered the request. It throws from inside the handler, which Playwright
- * reports as a test error naming the method and path, and the request is never
- * answered at all, so it cannot 401 and cannot trip the redirect to /login.
+ * answered the request. The request is never answered at all, so it cannot 401
+ * and cannot trip the redirect to /login.
  *
  * That inversion is the point. Unstubbed used to mean a 401, a global redirect,
  * and a spec that quietly went on testing the login page — an assertion about
@@ -254,13 +267,34 @@ const DEFAULT_DASHBOARD_LAYOUT = {
  * because the next author always reached a different endpoint. Failing closed
  * does: the cost of a missing stub is now one named error at the request that
  * needed it, paid by whoever mounts the new surface.
+ *
+ * The violation is reported TWICE, because one report alone is not enough:
+ *
+ *  1. It throws. Playwright surfaces a throw from a route handler as a test
+ *     error naming the method and path, which points straight at the missing
+ *     stub — but ONLY while the test is awaiting something. A request the app
+ *     fires after the spec's last await (a debounce, a deferred widget fetch)
+ *     throws into nothing and the test passes, silently, which is the very
+ *     failure this backstop exists to end. Measured: a stray request issued
+ *     50ms after the last await was dropped entirely.
+ *  2. It records the violation first. The `test` exported below waits out a
+ *     settle window and then asserts that record is empty, so the verdict does
+ *     not depend on anything having been awaited when the throw fired. The
+ *     throw names the request the moment it happens; the recorded list is what
+ *     survives if nothing was listening.
  */
 async function failOnUnstubbedRequest(page: Page): Promise<void> {
+  const seen: string[] = [];
+  unstubbedRequests.set(page, seen);
+
   await page.route('**/api/**', (route) => {
     const request = route.request();
     const { pathname, search } = new URL(request.url());
+    const violation = `${request.method()} ${pathname}${search}`;
+    // Record BEFORE throwing: the throw may go nowhere, this cannot.
+    seen.push(violation);
     throw new Error(
-      `mockAppShell: unstubbed request ${request.method()} ${pathname}${search}\n` +
+      `mockAppShell: unstubbed request ${violation}\n` +
         `Nothing answers it, so this test would otherwise have taken a 401 and been ` +
         `redirected to /login mid-run.\n` +
         `Fix: if the authenticated shell mounts this everywhere, add a stub to ` +
@@ -269,6 +303,60 @@ async function failOnUnstubbedRequest(page: Page): Promise<void> {
     );
   });
 }
+
+/**
+ * How long teardown lets the page keep talking before it reads the record.
+ *
+ * Teardown starts ~3ms after the test body's last await returns (measured), and
+ * the app does not stop asking for things when the spec stops looking: the
+ * dashboard grid re-persists its layout on a 300ms debounce, and a widget's
+ * fetch can leave well after the assertion that mounted it passed. Without a
+ * window, a stray request 50ms late was missed entirely — the test ended before
+ * the browser had issued it, so there was nothing to record and nothing to
+ * throw into either.
+ *
+ * 500ms clears the longest deferral the app shell has (the 300ms debounce) with
+ * margin, paid once per test that installs the shell. It is a bound, not a
+ * proof: a request the app defers longer than this is still beyond what a
+ * per-test teardown can see. Widen it if a shell surface starts asking later.
+ */
+const UNSTUBBED_SETTLE_MS = 500;
+
+/**
+ * `test` for every spec that uses `mockAppShell` — plain Playwright `test` plus
+ * an automatic teardown check that no request reached the backstop.
+ *
+ * It is a fixture rather than an `afterEach` each spec has to remember, because
+ * remembering is exactly what fails: the whole point of the backstop is that
+ * the NEXT author, mounting a surface nobody has thought of yet, gets told. A
+ * check they have to opt into is one they can leave out.
+ *
+ * Specs import `test` from here and keep importing `expect` from
+ * `@playwright/test`.
+ */
+export const test = base.extend<{ appShellContract: void }>({
+  appShellContract: [
+    async ({ page }, use) => {
+      await use();
+
+      // No record means the spec never installed the shell, so there is no
+      // contract to check and no settle to pay for.
+      const seen = unstubbedRequests.get(page);
+      if (!seen) return;
+
+      if (!page.isClosed()) await page.waitForTimeout(UNSTUBBED_SETTLE_MS);
+
+      expect(
+        seen,
+        'mockAppShell: the app made requests nothing stubbed. Each one would have ' +
+          '401d and bounced the spec to /login. Add a stub to mockAppShell ' +
+          '(e2e/tests/fixtures/performance-fixtures.ts) if the authenticated shell ' +
+          'mounts it everywhere, or register it in the spec AFTER the mockAppShell call.',
+      ).toEqual([]);
+    },
+    { auto: true },
+  ],
+});
 
 export async function mockAppShell(page: Page): Promise<void> {
   const json = (body: unknown) => ({

--- a/e2e/tests/fixtures/performance-fixtures.ts
+++ b/e2e/tests/fixtures/performance-fixtures.ts
@@ -174,6 +174,10 @@ export const SESSION_RESPONSE = {
  * takes precedence (Playwright matches routes in reverse registration order),
  * so a spec is free to override `/performance` (the boundary under test) or
  * `/users/me/display-currency` (ledger-balances) with its own handler.
+ *
+ * It FAILS CLOSED: anything under `/api/` that neither this helper nor the spec
+ * answers hits the backstop registered below and fails the test by name. See
+ * `failOnUnstubbedRequest`.
  */
 /**
  * The default dashboard layout a freshly-registered user receives from the
@@ -232,12 +236,49 @@ const DEFAULT_DASHBOARD_LAYOUT = {
   updatedAt: null,
 };
 
+/**
+ * The backstop that makes the list below a CONTRACT rather than a best effort.
+ *
+ * Registered first, so Playwright — which matches handlers in reverse
+ * registration order — reaches it only when neither `mockAppShell` nor the spec
+ * answered the request. It throws from inside the handler, which Playwright
+ * reports as a test error naming the method and path, and the request is never
+ * answered at all, so it cannot 401 and cannot trip the redirect to /login.
+ *
+ * That inversion is the point. Unstubbed used to mean a 401, a global redirect,
+ * and a spec that quietly went on testing the login page — an assertion about
+ * the PRESENCE of something still passes there, so the suite stayed green while
+ * testing nothing. Four separate debugging rounds on this branch started that
+ * way, each ending in one more stub; a fifth (`/api/symbols/quote-config`) was
+ * masked until the login bounce was removed. Adding stubs never fixed it,
+ * because the next author always reached a different endpoint. Failing closed
+ * does: the cost of a missing stub is now one named error at the request that
+ * needed it, paid by whoever mounts the new surface.
+ */
+async function failOnUnstubbedRequest(page: Page): Promise<void> {
+  await page.route('**/api/**', (route) => {
+    const request = route.request();
+    const { pathname, search } = new URL(request.url());
+    throw new Error(
+      `mockAppShell: unstubbed request ${request.method()} ${pathname}${search}\n` +
+        `Nothing answers it, so this test would otherwise have taken a 401 and been ` +
+        `redirected to /login mid-run.\n` +
+        `Fix: if the authenticated shell mounts this everywhere, add a stub to ` +
+        `mockAppShell (e2e/tests/fixtures/performance-fixtures.ts). If it belongs to the ` +
+        `route under test, register it in the spec AFTER the mockAppShell call.`,
+    );
+  });
+}
+
 export async function mockAppShell(page: Page): Promise<void> {
   const json = (body: unknown) => ({
     status: 200,
     contentType: 'application/json',
     body: JSON.stringify(body),
   });
+
+  // FIRST, so it is reached LAST — see the doc comment above.
+  await failOnUnstubbedRequest(page);
 
   await page.route('**/api/dashboard/layout', (route) =>
     route.fulfill(json(DEFAULT_DASHBOARD_LAYOUT)),
@@ -324,12 +365,7 @@ export async function mockAppShell(page: Page): Promise<void> {
   //
   // They are shell surface for the same reason the rest of this list is. Any
   // spec that navigates to /dashboard mounts all six widgets whether or not it
-  // is testing them, and one unmocked 401 does not merely blank a widget — the
-  // api client's global handler sends the whole app to /login, so the failure
-  // lands on some later assertion as "element not found" on a login form. That
-  // trap has now cost this branch four debugging rounds; the answer each time
-  // was another stub, and the stubs belong here rather than being rediscovered
-  // per spec.
+  // is testing them.
   //
   // Neutral answers: a zero total and no brokerages, so neither widget paints a
   // surface a spec was not written for.

--- a/e2e/tests/fixtures/performance-fixtures.ts
+++ b/e2e/tests/fixtures/performance-fixtures.ts
@@ -268,22 +268,42 @@ const unstubbedRequests = new WeakMap<Page, string[]>();
  * does: the cost of a missing stub is now one named error at the request that
  * needed it, paid by whoever mounts the new surface.
  *
- * The violation is reported TWICE, because one report alone is not enough:
+ * The violation is reported TWICE, and each report fails the test on its own —
+ * measured in both directions, by deleting each in turn (see
+ * app-shell-fixture.spec.ts). They are belt and braces, not two halves:
  *
  *  1. It throws. Playwright surfaces a throw from a route handler as a test
  *     error naming the method and path, which points straight at the missing
- *     stub — but ONLY while the test is awaiting something. A request the app
- *     fires after the spec's last await (a debounce, a deferred widget fetch)
- *     throws into nothing and the test passes, silently, which is the very
- *     failure this backstop exists to end. Measured: a stray request issued
- *     50ms after the last await was dropped entirely.
- *  2. It records the violation first. The `test` exported below waits out a
- *     settle window and then asserts that record is empty, so the verdict does
- *     not depend on anything having been awaited when the throw fired. The
- *     throw names the request the moment it happens; the recorded list is what
- *     survives if nothing was listening.
+ *     stub, and mid-body it cancels the await in flight so the failure lands
+ *     at the request rather than at the end of the test. It is attributed only
+ *     while the test is still live, though: a request the app fires after the
+ *     spec's last await (a debounce, a deferred widget fetch) used to throw
+ *     into nothing and the test passed, silently — measured, a stray issued
+ *     50ms late was dropped entirely. What holds the test open long enough for
+ *     one of those to land is the settle window in the `test` fixtures below.
+ *  2. It records the violation first. A throw also INTERRUPTS the step that is
+ *     running, which is why the read of that record lives in a step of its own
+ *     (again, the fixtures below) — it survives the interrupt, and it names
+ *     EVERY unstubbed request rather than only the first.
  */
 async function failOnUnstubbedRequest(page: Page): Promise<void> {
+  // A second install would register a second catch-all. Playwright matches in
+  // reverse registration order, so it would shadow every route registered since
+  // the first — including the spec's own overrides, which are registered after
+  // `mockAppShell` precisely so they win — and it would swap in a fresh record,
+  // dropping any violation already seen. Silent traps are what this whole
+  // backstop exists to end, so this one says so instead of being one.
+  if (unstubbedRequests.has(page)) {
+    throw new Error(
+      'mockAppShell: already installed on this page.\n' +
+        'A second call registers a second backstop that shadows every route ' +
+        'registered since the first (Playwright matches handlers in reverse ' +
+        'registration order), and replaces the record of what the first one saw.\n' +
+        'Fix: call it once, first, per page — in `beforeEach` or at the top of the ' +
+        'test, and register the spec-specific handlers after it.',
+    );
+  }
+
   const seen: string[] = [];
   unstubbedRequests.set(page, seen);
 
@@ -291,7 +311,9 @@ async function failOnUnstubbedRequest(page: Page): Promise<void> {
     const request = route.request();
     const { pathname, search } = new URL(request.url());
     const violation = `${request.method()} ${pathname}${search}`;
-    // Record BEFORE throwing: the throw may go nowhere, this cannot.
+    // Record BEFORE throwing. The throw fails the test AND interrupts whatever
+    // step is running, which is why the read of this list lives in a step of
+    // its own — see the `test` fixtures below.
     seen.push(violation);
     throw new Error(
       `mockAppShell: unstubbed request ${violation}\n` +
@@ -326,25 +348,45 @@ const UNSTUBBED_SETTLE_MS = 500;
  * `test` for every spec that uses `mockAppShell` — plain Playwright `test` plus
  * an automatic teardown check that no request reached the backstop.
  *
- * It is a fixture rather than an `afterEach` each spec has to remember, because
+ * It is fixtures rather than an `afterEach` each spec has to remember, because
  * remembering is exactly what fails: the whole point of the backstop is that
  * the NEXT author, mounting a surface nobody has thought of yet, gets told. A
  * check they have to opt into is one they can leave out.
  *
+ * TWO fixtures, and the split is load-bearing. A backstop throw does not merely
+ * fail the test, it INTERRUPTS whatever is running at that moment, and
+ * Playwright abandons that step's remaining code — so when the settle and the
+ * assertion lived in one fixture, a violation arriving during the settle
+ * cancelled the settle and the assertion below it never ran at all. Measured:
+ * the reported errors carried the throw and the cancellation, never the
+ * `expect`, and deleting the recorded list left the test exactly as red,
+ * because the throw was doing all the work by itself.
+ *
+ * An interrupt only reaches the step in flight, so the fix is to give the read
+ * a step of its own that awaits nothing:
+ *
+ *   - `appShellSettle` waits out the window. Interruptible, harmlessly — an
+ *     interrupt here means the violation it was waiting for has already been
+ *     recorded.
+ *   - `appShellContract` reads the record and asserts. It depends on nothing
+ *     that can be cancelled, so it runs whether or not the settle was cut
+ *     short, and reports EVERY violation rather than only the first.
+ *
+ * The dependency is what orders them: `appShellSettle` takes `appShellContract`
+ * as a fixture, so the contract is set up first and therefore torn down LAST.
+ *
  * Specs import `test` from here and keep importing `expect` from
  * `@playwright/test`.
  */
-export const test = base.extend<{ appShellContract: void }>({
+export const test = base.extend<{ appShellContract: void; appShellSettle: void }>({
   appShellContract: [
     async ({ page }, use) => {
       await use();
 
       // No record means the spec never installed the shell, so there is no
-      // contract to check and no settle to pay for.
+      // contract to check.
       const seen = unstubbedRequests.get(page);
       if (!seen) return;
-
-      if (!page.isClosed()) await page.waitForTimeout(UNSTUBBED_SETTLE_MS);
 
       expect(
         seen,
@@ -353,6 +395,21 @@ export const test = base.extend<{ appShellContract: void }>({
           '(e2e/tests/fixtures/performance-fixtures.ts) if the authenticated shell ' +
           'mounts it everywhere, or register it in the spec AFTER the mockAppShell call.',
       ).toEqual([]);
+    },
+    { auto: true },
+  ],
+  appShellSettle: [
+    async ({ page, appShellContract }, use) => {
+      void appShellContract; // ordering only — see the note above.
+      await use();
+
+      // Nothing installed the shell: no window to pay for.
+      if (!unstubbedRequests.has(page)) return;
+
+      // A plain timer, not `page.waitForTimeout`: a closed page turns that into
+      // a thrown error of its own, and this window is only ever a courtesy to
+      // the page, never an assertion about it.
+      await new Promise((resolve) => setTimeout(resolve, UNSTUBBED_SETTLE_MS));
     },
     { auto: true },
   ],

--- a/e2e/tests/ledger-balances.spec.ts
+++ b/e2e/tests/ledger-balances.spec.ts
@@ -1,6 +1,6 @@
-import { expect, test, type Page, type Route } from '@playwright/test';
+import { expect, type Page, type Route } from '@playwright/test';
 
-import { mockAppShell, SESSION_RESPONSE } from './fixtures/performance-fixtures';
+import { mockAppShell, SESSION_RESPONSE, test } from './fixtures/performance-fixtures';
 
 /**
  * Ledger-balances e2e suite (Task 24).
@@ -148,6 +148,15 @@ async function mockBrokerages(page: Page) {
  * Install the full set of accounting + accounts route handlers. The
  * `getState`/`setState` indirection lets each test customize the snapshot
  * without re-declaring every handler.
+ *
+ * The handlers below dispatch on method and hand anything they do not serve to
+ * `route.fallback()` — NOT `route.continue()`. `continue()` abandons the
+ * handler chain and goes to the real network, which for a request nothing here
+ * answers means a 401 against the synthetic session and the api client's global
+ * bounce to /login, mid-test: the exact failure `mockAppShell` fails closed to
+ * prevent, reintroduced one method at a time. `fallback()` hands the request to
+ * the next matching handler instead, so it lands on a `mockAppShell` stub or,
+ * failing that, its backstop, which names it.
  */
 async function installAccountingMocks(page: Page, getState: () => MockState) {
   // GET /accounts
@@ -166,13 +175,13 @@ async function installAccountingMocks(page: Page, getState: () => MockState) {
       await jsonResponse(route, created, 201);
       return;
     }
-    await route.continue();
+    await route.fallback();
   });
 
   // GET /accounts/:id (account detail page)
   await page.route(/\/api\/accounts\/[0-9a-f-]{36}$/i, async (route) => {
     if (route.request().method() !== 'GET') {
-      await route.continue();
+      await route.fallback();
       return;
     }
     const url = new URL(route.request().url());
@@ -192,7 +201,7 @@ async function installAccountingMocks(page: Page, getState: () => MockState) {
   // GET route so the more specific path is not shadowed.
   await page.route(/\/api\/ledger\/[0-9a-f-]{36}\/reconcile$/i, async (route) => {
     if (route.request().method() !== 'POST') {
-      await route.continue();
+      await route.fallback();
       return;
     }
     const url = new URL(route.request().url());
@@ -269,7 +278,7 @@ async function installAccountingMocks(page: Page, getState: () => MockState) {
       await jsonResponse(route, { currency: body.currency });
       return;
     }
-    await route.continue();
+    await route.fallback();
   });
 
   // GET/POST /exchange-rates and /exchange-rates/preview
@@ -299,12 +308,12 @@ async function installAccountingMocks(page: Page, getState: () => MockState) {
       await jsonResponse(route, created, 201);
       return;
     }
-    await route.continue();
+    await route.fallback();
   });
 
   await page.route('**/api/exchange-rates/preview', async (route) => {
     if (route.request().method() !== 'POST') {
-      await route.continue();
+      await route.fallback();
       return;
     }
     const body = route.request().postDataJSON() as
@@ -343,7 +352,7 @@ async function installAccountingMocks(page: Page, getState: () => MockState) {
   // DELETE /exchange-rates/:id
   await page.route(/\/api\/exchange-rates\/[0-9a-f-]{36}$/i, async (route) => {
     if (route.request().method() !== 'DELETE') {
-      await route.continue();
+      await route.fallback();
       return;
     }
     const url = new URL(route.request().url());

--- a/e2e/tests/ledger-balances.spec.ts
+++ b/e2e/tests/ledger-balances.spec.ts
@@ -157,6 +157,9 @@ async function mockBrokerages(page: Page) {
  * prevent, reintroduced one method at a time. `fallback()` hands the request to
  * the next matching handler instead, so it lands on a `mockAppShell` stub or,
  * failing that, its backstop, which names it.
+ *
+ * This paragraph is not what enforces it — `app-shell-fixture.spec.ts` greps the
+ * test tree and fails on any `continue()` call.
  */
 async function installAccountingMocks(page: Page, getState: () => MockState) {
   // GET /accounts

--- a/e2e/tests/performance-a11y.spec.ts
+++ b/e2e/tests/performance-a11y.spec.ts
@@ -96,9 +96,9 @@ test.describe('Performance page — keyboard accessibility', () => {
     page,
   }) => {
     // Co-display path: the populated response with `tz` differing from the
-    // sessionStorage flag is the engaged-banner case. We seed the session flag
-    // before navigating and request a non-UTC tz so the populated render shows
-    // the banner via `showUtcFallbackBanner`.
+    // recorded rejected zone is the engaged-banner case. We record the zone the
+    // server rejected before navigating and request that same zone, so the
+    // populated render shows the banner via `showUtcFallbackBanner`.
     const populatedWithTzMismatch = {
       ...POPULATED_RESPONSE,
       resolvedTimezone: 'UTC',
@@ -107,7 +107,7 @@ test.describe('Performance page — keyboard accessibility', () => {
 
     await page.addInitScript(() => {
       try {
-        sessionStorage.setItem('perf.invalid_tz_seen', 'true');
+        sessionStorage.setItem('perf.invalid_tz', 'America/New_York');
       } catch {
         /* Safari private mode — banner won't render via this path. */
       }
@@ -151,7 +151,7 @@ test.describe('Performance page — keyboard accessibility', () => {
 
     await page.addInitScript(() => {
       try {
-        sessionStorage.setItem('perf.invalid_tz_seen', 'true');
+        sessionStorage.setItem('perf.invalid_tz', 'America/New_York');
       } catch {
         /* noop */
       }

--- a/e2e/tests/performance-a11y.spec.ts
+++ b/e2e/tests/performance-a11y.spec.ts
@@ -1,10 +1,11 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 
 import {
   mockAppShell,
   PERF_URL,
   POPULATED_RESPONSE,
   SESSION_RESPONSE,
+  test,
 } from './fixtures/performance-fixtures';
 
 /**

--- a/e2e/tests/performance.spec.ts
+++ b/e2e/tests/performance.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 
 import {
   INVALID_TIMEZONE_RESPONSE,
@@ -7,6 +7,7 @@ import {
   PERF_URL,
   POPULATED_RESPONSE,
   SESSION_RESPONSE,
+  test,
 } from './fixtures/performance-fixtures';
 
 /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -279,3 +279,4 @@ export type { CanonicalPart, CanonicalMessage, ProviderModel } from './lib/advis
 export { uuidv5, uuidv5Batch, WIDGET_DEFAULT_NAMESPACE } from './utils/uuidv5';
 export { DEFAULT_WIDGETS, BODY_LIMIT_BYTES } from './constants/dashboard-defaults';
 export type { DefaultWidgetSpec } from './constants/dashboard-defaults';
+export { reconcileStoredLayout } from './utils/dashboard-layout';

--- a/packages/shared/src/schemas/dashboard.test.ts
+++ b/packages/shared/src/schemas/dashboard.test.ts
@@ -29,21 +29,22 @@ const UUID_G = '77777777-7777-4777-8777-777777777777';
 // derived, not chosen), so the heights here are read from that rather than
 // written out — otherwise this fixture goes stale the next time the chart's
 // chrome changes and every "accepts" case below fails for the wrong reason.
+const STATS_H = PerWidgetMinSize['stats-summary'].h;
 const PERF_H = PerWidgetMinSize['performance-chart'].h;
 const EQUITY_H = PerWidgetMinSize['equity-curve'].h;
 
 function canonicalWidgets() {
   return [
-    { id: UUID_A, type: 'stats-summary' as const, x: 0, y: 0, w: 12, h: 2 },
-    { id: UUID_B, type: 'performance-chart' as const, x: 0, y: 2, w: 6, h: PERF_H },
-    { id: UUID_C, type: 'equity-curve' as const, x: 0, y: 2 + PERF_H, w: 6, h: EQUITY_H },
-    { id: UUID_D, type: 'account-balances' as const, x: 6, y: 2, w: 6, h: 4 },
-    { id: UUID_E, type: 'position-sizing' as const, x: 6, y: 6, w: 6, h: 6 },
+    { id: UUID_A, type: 'stats-summary' as const, x: 0, y: 0, w: 12, h: STATS_H },
+    { id: UUID_B, type: 'performance-chart' as const, x: 0, y: STATS_H, w: 6, h: PERF_H },
+    { id: UUID_C, type: 'equity-curve' as const, x: 0, y: STATS_H + PERF_H, w: 6, h: EQUITY_H },
+    { id: UUID_D, type: 'account-balances' as const, x: 6, y: STATS_H, w: 6, h: 4 },
+    { id: UUID_E, type: 'position-sizing' as const, x: 6, y: STATS_H + 4, w: 6, h: 6 },
     {
       id: UUID_F,
       type: 'open-positions' as const,
       x: 0,
-      y: 2 + PERF_H + EQUITY_H,
+      y: STATS_H + PERF_H + EQUITY_H,
       w: 12,
       h: 4,
     },
@@ -241,7 +242,7 @@ describe('PutDashboardLayoutRequestSchema refinements', () => {
       x: 0,
       y: 0,
       w: 12,
-      h: 2,
+      h: STATS_H,
       config: {},
     });
     expect(result.success).toBe(true);

--- a/packages/shared/src/schemas/dashboard.ts
+++ b/packages/shared/src/schemas/dashboard.ts
@@ -41,7 +41,20 @@ export const GRID_MAX_ROWS = 24;
 // `chartWidgetMinRows` derives both from the same floor constant the charts
 // enforce for themselves, so the pair cannot drift.
 export const PerWidgetMinSize: Record<WidgetType, { w: number; h: number }> = {
-  'stats-summary': { w: 4, h: 2 },
+  // Same arithmetic as the charts, one widget over. Measured in chromium at
+  // 1440x900: five tiles on a 3-column track is two 44px rows and a 12px gap,
+  // 100px, plus 24px of body padding — 124px of content — and the widget's
+  // permanent chrome (49px header, 2px border, the 16px gridstack takes out of
+  // the cell) is 67px. 191px is 5 rows; h=4 gives the body 93px and clips 31px
+  // of figures. h=2, which this said until the tile grid was measured, gave it
+  // 13px and clipped 111px — a legal height at which the widget rendered blank.
+  //
+  // The free tier's clamped-window notice (24px plus a 12px gap) is NOT
+  // budgeted for here, exactly as it is not for the charts: the pinned default
+  // carries that headroom at h=6, and reserving a conditional row in the bound
+  // would put the minimum on the default and take vertical resizing away.
+  // `StatsSummaryWidget.height.test.tsx` pins both ends.
+  'stats-summary': { w: 4, h: 5 },
   'open-positions': { w: 4, h: 4 },
   // Pays for its timeframe strip and the gap under it out of the same body.
   'performance-chart': { w: 4, h: chartWidgetMinRows(TIMEFRAME_ROW_PX + STACK_GAP_PX) },

--- a/packages/shared/src/utils/dashboard-layout.test.ts
+++ b/packages/shared/src/utils/dashboard-layout.test.ts
@@ -38,6 +38,37 @@ function currentLayout(): WidgetPlacement[] {
   return DEFAULT_WIDGETS.map((widget, i) => ({ id: ID(i + 1), ...widget }));
 }
 
+/**
+ * A stale layout whose repair REORDERS it. Every width is at or above its
+ * minimum and nothing overlaps, so this is a layout that really could have been
+ * saved; only the chart's height is repaired. Growing it pushes `open-positions`
+ * down past `stats-summary`, which sits in a column band the chart never
+ * reaches and so is never touched.
+ */
+function displacedPairLayout(): WidgetPlacement[] {
+  return [
+    { id: ID(1), type: 'performance-chart', x: 0, y: 0, w: 8, h: 2 },
+    { id: ID(2), type: 'open-positions', x: 4, y: 2, w: 4, h: 4 },
+    { id: ID(3), type: 'stats-summary', x: 8, y: 6, w: 4, h: 5 },
+  ];
+}
+
+/** The same reordering between two widgets that DO share columns. */
+function sharedColumnLayout(): WidgetPlacement[] {
+  return [
+    { id: ID(1), type: 'performance-chart', x: 0, y: 0, w: 8, h: 2 },
+    { id: ID(2), type: 'open-positions', x: 0, y: 2, w: 12, h: 4 },
+    { id: ID(3), type: 'stats-summary', x: 8, y: 6, w: 4, h: 5 },
+  ];
+}
+
+const FIXTURES: Array<[string, () => WidgetPlacement[]]> = [
+  ['a stale layout', staleLayout],
+  ['a current layout', currentLayout],
+  ['a layout the repair reorders', displacedPairLayout],
+  ['a layout the repair reorders across shared columns', sharedColumnLayout],
+];
+
 function anyOverlap(widgets: WidgetPlacement[]): boolean {
   for (let i = 0; i < widgets.length; i++) {
     for (let j = i + 1; j < widgets.length; j++) {
@@ -92,12 +123,16 @@ describe('reconcileStoredLayout', () => {
     expect(anyOverlap(stale)).toBe(false);
     const out = reconcileStoredLayout(stale);
     expect(anyOverlap(out)).toBe(false);
-    // Stacking order survives, which is what makes the repaired layout still
-    // recognisably theirs. Not whole-page reading order — the two columns grow
-    // by different amounts (the charts are on the left, the short rail widgets
-    // on the right), so rows that used to align no longer do. What holds is the
-    // order of any two widgets that share columns: one was above the other and
-    // still is.
+    // On THIS layout stacking order survives, which is what makes the repaired
+    // default arrangement still recognisably theirs: not whole-page reading
+    // order — the two columns grow by different amounts (the charts on the
+    // left, the short rail widgets on the right), so rows that used to align no
+    // longer do — but the order of any two widgets that share columns.
+    //
+    // That is a property of this fixture, NOT an invariant of the function. See
+    // the two reordering tests below, where it does not hold, and the note in
+    // `reconcileStoredLayout` explaining why holding it in general costs more
+    // than the cosmetic reordering it would prevent.
     for (const a of stale) {
       for (const b of stale) {
         if (a.id === b.id) continue;
@@ -113,6 +148,58 @@ describe('reconcileStoredLayout', () => {
       const before = stale.find((w) => w.id === widget.id)!;
       expect({ x: widget.x, w: widget.w }).toEqual({ x: before.x, w: before.w });
     }
+  });
+
+  // The guarantees the function actually makes, checked against every fixture
+  // rather than pinned to one — the single-fixture version of this is what let
+  // an unheld stacking-order claim stand.
+  it.each(FIXTURES)('holds its guarantees on %s', (_name, fixture) => {
+    const stale = fixture();
+    const out = reconcileStoredLayout(stale);
+
+    // The output is writable, which is the whole point.
+    expect(PutDashboardLayoutRequestSchema.safeParse({ widgets: out }).success).toBe(true);
+    expect(anyOverlap(out)).toBe(false);
+    expect(out.map((w) => w.id)).toEqual(stale.map((w) => w.id));
+    for (const widget of out) {
+      const before = stale.find((w) => w.id === widget.id)!;
+      // Columns never move (no fixture here is under a minimum width), heights
+      // never shrink, and the re-flow only ever pushes a widget DOWN.
+      expect({ x: widget.x, w: widget.w }).toEqual({ x: before.x, w: before.w });
+      expect(widget.h).toBeGreaterThanOrEqual(before.h);
+      expect(widget.y).toBeGreaterThanOrEqual(before.y);
+    }
+  });
+
+  it('can reorder two widgets when only one of them is displaced', () => {
+    // The limitation, pinned as behaviour so nobody reads the re-flow as an
+    // order-preserving one: `open-positions` was above `stats-summary` and ends
+    // below it, because growing the chart displaces the first and not the
+    // second. Cosmetic — no overlap, and the guarantees above still hold — but
+    // it IS the user's arrangement being silently rearranged.
+    const stale = displacedPairLayout();
+    const out = reconcileStoredLayout(stale);
+    const y = (type: WidgetType, widgets: WidgetPlacement[]): number =>
+      widgets.find((w) => w.type === type)!.y;
+
+    expect(y('open-positions', stale)).toBeLessThan(y('stats-summary', stale));
+    expect(y('open-positions', out)).toBeGreaterThan(y('stats-summary', out));
+  });
+
+  it('can reorder two widgets that share columns', () => {
+    // And sharing columns does not save the pair: a widget pushed down carries
+    // nobody with it, so the same flip happens between two widgets that overlap
+    // horizontally — which is why the fixture above pins only its own order.
+    const stale = sharedColumnLayout();
+    const out = reconcileStoredLayout(stale);
+    const above = stale.find((w) => w.type === 'open-positions')!;
+    const below = stale.find((w) => w.type === 'stats-summary')!;
+
+    expect(above.x < below.x + below.w && below.x < above.x + above.w).toBe(true);
+    expect(above.y).toBeLessThan(below.y);
+    expect(out.find((w) => w.id === above.id)!.y).toBeGreaterThan(
+      out.find((w) => w.id === below.id)!.y,
+    );
   });
 
   it('returns the widgets in the order it was given', () => {

--- a/packages/shared/src/utils/dashboard-layout.test.ts
+++ b/packages/shared/src/utils/dashboard-layout.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_WIDGETS } from '../constants/dashboard-defaults';
+import {
+  PerWidgetMinSize,
+  PutDashboardLayoutRequestSchema,
+  type WidgetPlacement,
+  type WidgetType,
+} from '../schemas/dashboard';
+
+import { reconcileStoredLayout } from './dashboard-layout';
+
+const ID = (n: number): string => `00000000-0000-4000-8000-00000000000${n}`;
+
+function pinned(type: WidgetType): number {
+  return DEFAULT_WIDGETS.find((widget) => widget.type === type)!.h;
+}
+
+/**
+ * A layout as it sits in the database for anyone who arranged their dashboard
+ * before the geometry was fixed. Every height here was legal when it was
+ * written: `stats-summary` at h=1 and both charts at h=2 in the 80px era,
+ * doubled to 2 and 4 by migration 0021, with the charts landing exactly on the
+ * h=4 minimum they had before it was derived from the height a chart needs.
+ */
+function staleLayout(): WidgetPlacement[] {
+  return [
+    { id: ID(1), type: 'stats-summary', x: 0, y: 0, w: 12, h: 2 },
+    { id: ID(2), type: 'performance-chart', x: 0, y: 2, w: 8, h: 4 },
+    { id: ID(3), type: 'account-balances', x: 8, y: 2, w: 4, h: 4 },
+    { id: ID(4), type: 'equity-curve', x: 0, y: 6, w: 8, h: 4 },
+    { id: ID(5), type: 'position-sizing', x: 8, y: 6, w: 4, h: 6 },
+    { id: ID(6), type: 'open-positions', x: 0, y: 12, w: 12, h: 4 },
+  ];
+}
+
+function currentLayout(): WidgetPlacement[] {
+  return DEFAULT_WIDGETS.map((widget, i) => ({ id: ID(i + 1), ...widget }));
+}
+
+function anyOverlap(widgets: WidgetPlacement[]): boolean {
+  for (let i = 0; i < widgets.length; i++) {
+    for (let j = i + 1; j < widgets.length; j++) {
+      const a = widgets[i];
+      const b = widgets[j];
+      if (a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h) return true;
+    }
+  }
+  return false;
+}
+
+describe('reconcileStoredLayout', () => {
+  // THE WHOLE POINT, in one assertion: the geometry a stale row hands back is
+  // geometry the user can save. Every non-drag edit — add, remove, timeframe —
+  // PUTs the layout it was given, so a response that does not satisfy this is a
+  // 400 the user cannot clear (the Retry re-sends the same body).
+  it('produces a layout the write schema accepts, from one it rejects', () => {
+    const stale = staleLayout();
+    expect(PutDashboardLayoutRequestSchema.safeParse({ widgets: stale }).success).toBe(false);
+    expect(
+      PutDashboardLayoutRequestSchema.safeParse({ widgets: reconcileStoredLayout(stale) }).success,
+    ).toBe(true);
+  });
+
+  it('removing a widget from the reconciled layout still validates', () => {
+    // The add/remove path: the client filters the layout it was given and PUTs
+    // the rest. Nothing about dropping a widget can reintroduce a bad height,
+    // but this is the exact payload the defect 400d on.
+    const widgets = reconcileStoredLayout(staleLayout()).filter(
+      (widget) => widget.type !== 'open-positions',
+    );
+    expect(PutDashboardLayoutRequestSchema.safeParse({ widgets }).success).toBe(true);
+  });
+
+  it('gives a widget below its minimum the pinned default height, not the minimum', () => {
+    const out = reconcileStoredLayout(staleLayout());
+    const heightOf = (type: WidgetType): number => out.find((w) => w.type === type)!.h;
+
+    // The half a write-path clamp does not reach: `stats-summary` was saved at
+    // a height that is legal-looking but clips its figures, and only the pinned
+    // default fits what it renders in both tier states.
+    expect(heightOf('stats-summary')).toBe(pinned('stats-summary'));
+    expect(heightOf('performance-chart')).toBe(pinned('performance-chart'));
+    expect(heightOf('equity-curve')).toBe(pinned('equity-curve'));
+    // …and the default is above the minimum, so the repaired layout is not
+    // sitting on the bound it just failed.
+    expect(heightOf('performance-chart')).toBeGreaterThan(PerWidgetMinSize['performance-chart'].h);
+  });
+
+  it('re-flows y so growing a widget does not overlap its neighbour', () => {
+    const stale = staleLayout();
+    expect(anyOverlap(stale)).toBe(false);
+    const out = reconcileStoredLayout(stale);
+    expect(anyOverlap(out)).toBe(false);
+    // Stacking order survives, which is what makes the repaired layout still
+    // recognisably theirs. Not whole-page reading order — the two columns grow
+    // by different amounts (the charts are on the left, the short rail widgets
+    // on the right), so rows that used to align no longer do. What holds is the
+    // order of any two widgets that share columns: one was above the other and
+    // still is.
+    for (const a of stale) {
+      for (const b of stale) {
+        if (a.id === b.id) continue;
+        const sharesColumns = a.x < b.x + b.w && b.x < a.x + a.w;
+        if (!sharesColumns || a.y >= b.y) continue;
+        const outA = out.find((w) => w.id === a.id)!;
+        const outB = out.find((w) => w.id === b.id)!;
+        expect(outA.y).toBeLessThan(outB.y);
+      }
+    }
+    // And so does the horizontal axis — columns never moved.
+    for (const widget of out) {
+      const before = stale.find((w) => w.id === widget.id)!;
+      expect({ x: widget.x, w: widget.w }).toEqual({ x: before.x, w: before.w });
+    }
+  });
+
+  it('returns the widgets in the order it was given', () => {
+    const stale = staleLayout();
+    expect(reconcileStoredLayout(stale).map((w) => w.id)).toEqual(stale.map((w) => w.id));
+  });
+
+  it('leaves a current layout untouched', () => {
+    // Reconciliation runs on every read, so a layout that is already legal must
+    // come back byte-identical — otherwise it rearranges dashboards nobody
+    // asked it to.
+    const current = currentLayout();
+    expect(reconcileStoredLayout(current)).toEqual(current);
+  });
+
+  it('leaves a deliberately resized widget alone above its minimum', () => {
+    // A user who shrank Stats Summary to its minimum chose that. Only heights
+    // BELOW the minimum — which the UI cannot produce — are repaired.
+    const min = PerWidgetMinSize['stats-summary'].h;
+    const widgets: WidgetPlacement[] = [
+      { id: ID(1), type: 'stats-summary', x: 0, y: 0, w: 12, h: min },
+    ];
+    expect(reconcileStoredLayout(widgets)[0].h).toBe(min);
+  });
+
+  it('clamps a width below the minimum and shifts x back inside the grid', () => {
+    const widgets: WidgetPlacement[] = [
+      { id: ID(1), type: 'open-positions', x: 10, y: 0, w: 2, h: 4 },
+    ];
+    const [out] = reconcileStoredLayout(widgets);
+    expect(out.w).toBe(PerWidgetMinSize['open-positions'].w);
+    expect(out.x + out.w).toBeLessThanOrEqual(12);
+  });
+
+  it('keeps config and id on a repaired widget', () => {
+    const widgets: WidgetPlacement[] = [
+      {
+        id: ID(2),
+        type: 'performance-chart',
+        x: 0,
+        y: 0,
+        w: 8,
+        h: 4,
+        config: { timeframe: 'ytd' },
+      },
+    ];
+    const [out] = reconcileStoredLayout(widgets);
+    expect(out).toMatchObject({ id: ID(2), config: { timeframe: 'ytd' } });
+  });
+});

--- a/packages/shared/src/utils/dashboard-layout.ts
+++ b/packages/shared/src/utils/dashboard-layout.ts
@@ -1,0 +1,92 @@
+import { DEFAULT_WIDGETS } from '../constants/dashboard-defaults';
+import { GRID_MAX_ROWS, PerWidgetMinSize, type WidgetPlacement } from '../schemas/dashboard';
+
+/** The grid the schema validates against: `x <= 11`, `w <= 12`, `x + w <= 12`. */
+const GRID_COLUMNS = 12;
+
+const PinnedHeight = new Map(DEFAULT_WIDGETS.map((widget) => [widget.type, widget.h]));
+
+function overlaps(a: WidgetPlacement, b: WidgetPlacement): boolean {
+  return a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h;
+}
+
+/**
+ * Bring a STORED layout up to the geometry the app enforces today.
+ *
+ * A saved row is written once and read forever; nothing revisits it. So a
+ * widget-geometry fix — the row unit moving from 80px to 40px, the two chart
+ * minimums being derived from the height their chart needs, the Stats Summary
+ * tile grid being measured — lands in `DEFAULT_WIDGETS` and `PerWidgetMinSize`
+ * and reaches only the users who have never arranged their dashboard. Everyone
+ * else keeps geometry that was legal when they saved it and is not legal now:
+ * the layout still READS (nothing parses the GET response, and gridstack clamps
+ * on render), but the next write that does not come from a drag or a resize —
+ * an add, a remove, a timeframe change — sends that stale geometry back from
+ * React state, fails `WidgetPlacementSchema`, and 400s with a Retry that can
+ * only ever re-send the same body.
+ *
+ * This is the reconciliation, applied wherever a stored layout is read.
+ *
+ * A HEIGHT BELOW THE TYPE'S MINIMUM IS REPAIRED TO THE TYPE'S PINNED DEFAULT,
+ * not merely raised to the minimum. The minimum is the floor the UI itself
+ * enforces — gridstack carries it as `minH` and will not resize past it — so a
+ * stored height below it cannot be something a user chose. It can only be
+ * geometry from an older bound, and the honest repair for that is the height
+ * the widget would be given if it were placed today. Clamping to the minimum
+ * instead would leave a Stats Summary saved at h=2 clipping its figures for as
+ * long as the user never resized it, which is the half of this defect that a
+ * write-path fix alone does not reach.
+ *
+ * Widths are clamped rather than replaced, because the horizontal axis has
+ * never moved: a width below the minimum can only come from a hand-written API
+ * payload, and widening interacts with the 12-column bound, so the conservative
+ * repair (the minimum, shifted left only as far as it must be) is the right one.
+ *
+ * GROWING A WIDGET CAN PUSH IT INTO ITS NEIGHBOUR, and an overlapping layout
+ * fails `checkNoOverlap` — swapping one 400 for another. So the second pass
+ * re-flows `y` in reading order, moving a widget DOWN past anything it now
+ * collides with and never up. Relative order, columns and widths are preserved,
+ * which is what makes the repaired layout still recognisably the user's.
+ *
+ * A layout that is already current is returned unchanged: nothing is below a
+ * minimum, so nothing grows, so no widget collides with one already placed.
+ */
+export function reconcileStoredLayout(widgets: WidgetPlacement[]): WidgetPlacement[] {
+  const repaired = widgets.map((widget) => {
+    const min = PerWidgetMinSize[widget.type];
+    if (!min) return widget;
+
+    let { x, w, h } = widget;
+    if (h < min.h) {
+      h = Math.min(PinnedHeight.get(widget.type) ?? min.h, GRID_MAX_ROWS);
+    }
+    if (w < min.w) {
+      w = Math.min(min.w, GRID_COLUMNS);
+      x = Math.min(x, GRID_COLUMNS - w);
+    }
+    if (x === widget.x && w === widget.w && h === widget.h) return widget;
+    return { ...widget, x, w, h };
+  });
+
+  // Reading order, with the original index carried so the output keeps the
+  // order the caller gave — a read must not reshuffle the response.
+  const order = repaired
+    .map((widget, index) => ({ widget, index }))
+    .sort((a, b) => a.widget.y - b.widget.y || a.widget.x - b.widget.x || a.index - b.index);
+
+  const out: WidgetPlacement[] = new Array<WidgetPlacement>(repaired.length);
+  const placed: WidgetPlacement[] = [];
+  for (const { widget, index } of order) {
+    let candidate = widget;
+    // Each hit sits at or above `candidate`, so `hit.y + hit.h` is strictly
+    // below where it started: `y` only ever increases and the loop terminates.
+    for (;;) {
+      const hit = placed.find((other) => overlaps(other, candidate));
+      if (!hit) break;
+      candidate = { ...candidate, y: hit.y + hit.h };
+    }
+    placed.push(candidate);
+    out[index] = candidate;
+  }
+  return out;
+}

--- a/packages/shared/src/utils/dashboard-layout.ts
+++ b/packages/shared/src/utils/dashboard-layout.ts
@@ -28,14 +28,22 @@ function overlaps(a: WidgetPlacement, b: WidgetPlacement): boolean {
  * This is the reconciliation, applied wherever a stored layout is read.
  *
  * A HEIGHT BELOW THE TYPE'S MINIMUM IS REPAIRED TO THE TYPE'S PINNED DEFAULT,
- * not merely raised to the minimum. The minimum is the floor the UI itself
- * enforces — gridstack carries it as `minH` and will not resize past it — so a
- * stored height below it cannot be something a user chose. It can only be
- * geometry from an older bound, and the honest repair for that is the height
- * the widget would be given if it were placed today. Clamping to the minimum
- * instead would leave a Stats Summary saved at h=2 clipping its figures for as
- * long as the user never resized it, which is the half of this defect that a
- * write-path fix alone does not reach.
+ * not merely raised to the minimum — a deliberate trade, not something
+ * correctness forces. The heights being repaired were LEGAL CHOICES when they
+ * were saved: the chart minimum was h=4 and Stats Summary's was h=2 until the
+ * commit that added this derived them from what the widgets render, so a user
+ * really could have picked one and meant it. What changed is that the app no
+ * longer supports those heights — the widget cannot show its content at them,
+ * and gridstack now carries the raised minimum as `minH`, so the user cannot
+ * resize back to one either. Between preserving a height that is no longer
+ * usable and handing the widget the size it would be given if it were placed
+ * today, this prefers the usable widget. The cost is bounded and small: the
+ * pinned default is one row above the minimum for `stats-summary` and
+ * `performance-chart` and three above it for `equity-curve`, so a repaired
+ * widget is at most three rows taller than the bound alone would demand.
+ * Clamping to the minimum instead would leave a Stats Summary saved at h=2
+ * clipping its figures for as long as the user never resized it, which is the
+ * half of this defect that a write-path fix alone does not reach.
  *
  * Widths are clamped rather than replaced, because the horizontal axis has
  * never moved: a width below the minimum can only come from a hand-written API
@@ -45,8 +53,21 @@ function overlaps(a: WidgetPlacement, b: WidgetPlacement): boolean {
  * GROWING A WIDGET CAN PUSH IT INTO ITS NEIGHBOUR, and an overlapping layout
  * fails `checkNoOverlap` — swapping one 400 for another. So the second pass
  * re-flows `y` in reading order, moving a widget DOWN past anything it now
- * collides with and never up. Relative order, columns and widths are preserved,
- * which is what makes the repaired layout still recognisably the user's.
+ * collides with and never up. Columns and widths come through untouched, and no
+ * widget ends up higher than it was stored.
+ *
+ * RELATIVE STACKING ORDER IS NOT ONE OF THE GUARANTEES. A widget moves only
+ * when it actually collides, so a displaced widget can end up below one it used
+ * to sit above whenever that pair does not collide: grow a `performance-chart`
+ * at (x0,w8) from h=2 to h=12 and the `open-positions` beneath it at y=2 is
+ * pushed to y=12, while a `stats-summary` over at (x8,y6) is touched by neither
+ * and keeps y=6 — the two swap places. Sharing columns does not save it either;
+ * a widget that is pushed down carries nobody with it. Holding order in general
+ * would mean cascading a push onto widgets that do not collide, moving layouts
+ * that need no repair and opening gaps in them — more disruption than the
+ * reordering it prevents, which is cosmetic: the result still never overlaps and
+ * the write schema still accepts it. The tests pin the reordering as behaviour,
+ * across more than one layout, so nobody mistakes it for an invariant.
  *
  * A layout that is already current is returned unchanged: nothing is below a
  * minimum, so nothing grows, so no widget collides with one already placed.


### PR DESCRIPTION
Three user-facing defects and one test-fixture hole that had been hiding failures.

## A saved dashboard layout could no longer be saved

Raising the chart widgets' minimum heights left any layout stored under the old
minimums invalid. Reads were fine — the response is never parsed, and gridstack
clamps geometry on render, so the dashboard looked correct. Writes were not: any
layout write that did not come from a drag or resize (adding a widget, removing
one, changing timeframe) sent the stale height, took a 400, showed "Couldn't save
your last changes", rolled back, and retried the same rejected payload forever.

Stored layouts are now reconciled on read against current defaults and minimums.
Reconciling on read rather than clamping the outgoing payload is deliberate: a
clamp stops the 400 but can never deliver a *raised default* to someone who
already has a saved layout, and a migration would need rewriting for every future
geometry change.

Two honest limitations, both documented in the code and pinned by tests:

- Repair maps a below-minimum height to the widget's pinned default, not to its
  minimum. Those heights were legal, deliberate choices when they were saved, so
  this does override a real preference — bounded at +1 row for two widgets and +3
  for a third, and preferred over leaving a widget too short to show its content.
- The y-reflow does not universally preserve relative stacking order. A repaired
  widget can end up below one it used to sit above. No overlap is produced and the
  result validates; preserving order would need a cascade onto non-colliding
  widgets, which is a reflow redesign rather than a fix.

## An invalid reporting timezone pinned a tab to UTC for its whole session

The flag set when a performance request failed on an unrecognised timezone was
never cleared, so every later request in that tab silently dropped `tz`. It is now
a zone-keyed record with a real lifecycle: it clears on a successful request and on
a reporting-timezone change, and the route loader honours it instead of re-sending
a known-bad zone on every navigation.

Two things turned out to be different from how this was originally described, both
worth stating because they change what the fix had to do:

- The banner told users to change the timezone and reopen Performance. That was
  believed to work by accident, via a full page reload. It did not work at all —
  the flag lived in `sessionStorage`, which survives a reload. The copy now
  describes what the code actually does.
- The state carrying the settings link was believed to be near-unreachable because
  of when the flag was written. The real cause was a page/hook split: in Safari
  private mode the page read `sessionStorage` while the hook read an in-memory
  fallback, so each mode could only ever reach one of the two states. Both now go
  through one shared predicate.

## The e2e app-shell fixture failed open

`mockAppShell` did not stub every request the authenticated app shell makes. A
missing stub produced a 401, the global interceptor redirected, and the spec
silently landed on `/login` — testing the login page instead of the dashboard while
still passing any assertion about presence rather than content. This had already
bitten four times; each fix added the one missing stub, and each time the next
author hit a different endpoint.

The fixture is now fail-closed. An unstubbed `/api/**` request is never fulfilled,
so the silent redirect is structurally gone rather than patched. It throws naming
the offending URL, records the violation, and asserts in teardown so a stray
request firing after the last `await` still fails the test. `mockAppShell` refuses
to run on a page whose contract fixtures are not live, so the guarantee cannot be
opted out of by importing `test` from the wrong module, and a guard test fails the
suite if `route.continue()` — which bypasses the route chain to the real network —
is reintroduced.

One bound worth knowing: the teardown settle is 500ms, so a shell request deferred
longer than that past the last `await` goes unreported. It is still never answered,
so it cannot cause the login bounce this closes.

## Verification

Every fix was reproduced before being written and proved by deliberate breakage
afterwards — the coverage was reverted, watched to fail, and restored.

Full check suite run as CI runs it: lint, dependency-cruiser, migration check,
typecheck across 6 projects, web and docs builds, bundle-size/contrast/design-lint/
font gates, api 2045 tests, web 1615, shared 560, self-host parity 12/12, the full
e2e suite (122 passed, 0 unexpected failures across 3 projects), and docker-smoke
(all 13 assertions). Every generated artifact regenerates with zero diff.

The four `✘` lines in the e2e run are `test.fail()` contract tests behaving as
designed — they assert the new fixture fails when it should.
