### PR TITLE
fix(web): stop a logged-out 404 claiming the session expired

### DIFF
--- a/apps/web/src/hooks/useAuth.expiry.test.ts
+++ b/apps/web/src/hooks/useAuth.expiry.test.ts
@@ -20,7 +20,7 @@ import { queryClient } from '@/lib/queryClient';
 import { DRAWER_STORAGE_KEY, useDrawerStore } from '@/stores/drawer.store';
 import { eventBus } from '@/stores/event-bus.store';
 
-import { useAuth, useRegister } from './useAuth';
+import { useAuth, useRegister, useSessionPresence } from './useAuth';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -365,6 +365,39 @@ describe('a session expiring, and what the remounts afterwards may do', () => {
     // And the teardown still ran: this is a logout, announced as one.
     expect(onLogout).toHaveBeenCalledOnce();
     session.unmount();
+  });
+
+  // THE 404 PAGE'S QUESTION MUST NOT DISARM THE SESSION QUERY.
+  //
+  // `useSessionPresence` asks the same `GET /auth/me`, but with a 401 allowed as
+  // an answer. Asked under `['auth','me']` it did not merely READ that query, it
+  // owned it: a react-query observer writes its `queryFn` onto the cached query,
+  // so for as long as the not-found page was on screen the session query itself
+  // fetched permissively. An expiry landing in that window — the tab regaining
+  // focus, an invalidation, a refetch — answered 401 to a request that had opted
+  // out of the interception, and so redirected nowhere and announced nothing.
+  // The one guarantee the interception exists to make was suspended by being on
+  // a 404 page. The presence check asks under its own key for that reason.
+  it('does not disarm the session query while the not-found page is mounted', async () => {
+    const network = stubNetwork();
+    const session = await signIn();
+
+    // The unknown URL: __root's dispatcher mounts, and the authenticated surface
+    // that was on screen behind it goes.
+    const presence = renderHook(() => useSessionPresence(), { wrapper });
+    await act(async () => {});
+    session.unmount();
+
+    // The session ends while that page is up, and the session query goes back to
+    // the network — which is where the interception lives.
+    network.expire();
+    await act(async () => {
+      await queryClient.refetchQueries({ queryKey: ['auth', 'me'] });
+    });
+
+    expect(interceptNavigate).toHaveBeenCalledOnce();
+    expect(onLogout).toHaveBeenCalledOnce();
+    presence.unmount();
   });
 
   it('says nothing for the 401 a logged-out visitor gets', async () => {

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -30,12 +30,12 @@ import { clearClientSessionState } from '@/lib/sessionTeardown';
  * the latch on what comes back is what turned one expiry into a loop of them.
  * Only a login re-arms it.
  *
- * Both callers below share this, and the confirmation is why. `useSessionPresence`
- * hands its 200 straight on to a surface that navigates into the authenticated
- * app, where the cached user it just wrote means `useAuth`'s own query may never
- * reach the network. Were the confirmation to live only in `useAuth`, that
- * session would run with `hasSession` false and its eventual expiry would pass
- * unannounced.
+ * Both callers below share this, and the confirmation is why: a 200 is the same
+ * evidence whoever asked for it. `useSessionPresence` asks from an
+ * unauthenticated surface that then navigates into the authenticated app, and
+ * until `useAuth`'s own query answers there its 200 is the only thing that has
+ * said a session exists. Were the confirmation to live only in `useAuth`, a 401
+ * arriving in that window would find `hasSession` false and pass unannounced.
  */
 async function fetchMe(opts?: RequestOptions): Promise<User> {
   const me = await api.get<User>('/auth/me', opts);
@@ -135,14 +135,18 @@ export function useRegister() {
  * rather than a session ending. No redirect, no announcement, and the one-shot
  * latch survives for the next real expiry.
  *
- * It shares `['auth','me']` with `useAuth` deliberately: a signed-in user who
- * mistypes a URL mid-session is answered from the cache without a request, and
- * the identity a cold load fetches here is the one the authenticated app then
- * reads.
+ * IT ASKS UNDER ITS OWN KEY, not `['auth','me']`. A react-query observer does
+ * not merely read the query it names, it writes its own `queryFn` onto it — so
+ * sharing the key handed the permissive fetch to the SESSION query for as long
+ * as this page was mounted. An expiry landing in that window (the tab regaining
+ * focus, an invalidation, a refetch) then answered a 401 that had opted out of
+ * the interception: no redirect, no announcement. The one guarantee the
+ * interception makes must not be suspendable by being on a 404 page. The cost is
+ * one request a cache hit would have saved, on a page that is already an error.
  */
 export function useSessionPresence() {
   const { data: user, isLoading } = useQuery<User>({
-    queryKey: ['auth', 'me'],
+    queryKey: ['auth', 'session-presence'],
     queryFn: () => fetchMe({ allowUnauthenticated: true }),
     retry: false,
   });

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -9,8 +9,39 @@ import {
   markSessionEnded,
   markSessionStarted,
   setIsLoggingOut,
+  type RequestOptions,
 } from '@/lib/api';
 import { clearClientSessionState } from '@/lib/sessionTeardown';
+
+/**
+ * `GET /auth/me`, and the declaration that its answer licenses.
+ *
+ * `lib/api` intercepts 401s, and it cannot tell one that ENDED a session from
+ * the one a logged-out visitor's me-query returns. This request is what tells it
+ * apart, and the answer to it is the only honest evidence there is: the server
+ * has just named the user, so there is a session, right now. Declared HERE
+ * rather than from an effect over the cached user — an effect fires on every
+ * mount, including the ones that read a cached user belonging to a session that
+ * has already ended.
+ *
+ * CONFIRMED, not started: this answer says a session exists, not that one has
+ * just begun, and the difference is what the redirect latch turns on. An expiry
+ * clears the cache, which sends the me-query back to the network, and re-arming
+ * the latch on what comes back is what turned one expiry into a loop of them.
+ * Only a login re-arms it.
+ *
+ * Both callers below share this, and the confirmation is why. `useSessionPresence`
+ * hands its 200 straight on to a surface that navigates into the authenticated
+ * app, where the cached user it just wrote means `useAuth`'s own query may never
+ * reach the network. Were the confirmation to live only in `useAuth`, that
+ * session would run with `hasSession` false and its eventual expiry would pass
+ * unannounced.
+ */
+async function fetchMe(opts?: RequestOptions): Promise<User> {
+  const me = await api.get<User>('/auth/me', opts);
+  markSessionConfirmed();
+  return me;
+}
 
 /**
  * The login mutation ALONE, without the `['auth','me']` query `useAuth` mounts
@@ -86,30 +117,46 @@ export function useRegister() {
   });
 }
 
+/**
+ * Whether anyone is signed in — asked by a surface that is not itself
+ * authenticated, and must not become a session-expired notice when the answer
+ * is no.
+ *
+ * THE 404 PAGE IS THE CALLER, AND IT IS NOT A PUBLIC PAGE. /login and the other
+ * unauthenticated routes answer this by not asking: they are logged-out by
+ * definition, so they mount no me-query at all. The not-found page cannot do
+ * that, because it is a dispatcher — what an unknown URL should show genuinely
+ * differs for a signed-in user and an anonymous one, so it has to know. Asking
+ * through `useAuth` is what made a mistyped URL redirect a logged-out visitor to
+ * `/login?expired=true`: the me-query 401s, and the global interception reads
+ * every 401 as an expiry.
+ *
+ * So the question is asked, and `allowUnauthenticated` says a 401 is its answer
+ * rather than a session ending. No redirect, no announcement, and the one-shot
+ * latch survives for the next real expiry.
+ *
+ * It shares `['auth','me']` with `useAuth` deliberately: a signed-in user who
+ * mistypes a URL mid-session is answered from the cache without a request, and
+ * the identity a cold load fetches here is the one the authenticated app then
+ * reads.
+ */
+export function useSessionPresence() {
+  const { data: user, isLoading } = useQuery<User>({
+    queryKey: ['auth', 'me'],
+    queryFn: () => fetchMe({ allowUnauthenticated: true }),
+    retry: false,
+  });
+
+  return { isLoading, isAuthenticated: !!user };
+}
+
 export function useAuth() {
   const queryClient = useQueryClient();
   const router = useRouter();
 
   const { data: user, isLoading } = useQuery<User>({
     queryKey: ['auth', 'me'],
-    queryFn: async () => {
-      const me = await api.get<User>('/auth/me');
-      // `lib/api` intercepts 401s, and it cannot tell one that ENDED a session
-      // from the one a logged-out visitor's me-query returns on the login page.
-      // This request is what tells it apart, and the answer to it is the only
-      // honest evidence there is: the server has just named the user, so there
-      // is a session, right now. Declared HERE rather than from an effect over
-      // `user` — an effect fires on every mount, including the ones that read a
-      // cached user belonging to a session that has already ended.
-      //
-      // CONFIRMED, not started: this answer says a session exists, not that one
-      // has just begun, and the difference is what the redirect latch turns on.
-      // An expiry clears the cache, which sends this very query back to the
-      // network, and re-arming the latch on what comes back is what turned one
-      // expiry into a loop of them. The login below is the one that re-arms.
-      markSessionConfirmed();
-      return me;
-    },
+    queryFn: () => fetchMe(),
     retry: false,
   });
 

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -142,7 +142,10 @@ export function useRegister() {
  * focus, an invalidation, a refetch) then answered a 401 that had opted out of
  * the interception: no redirect, no announcement. The one guarantee the
  * interception makes must not be suspendable by being on a 404 page. The cost is
- * one request a cache hit would have saved, on a page that is already an error.
+ * a request a cache hit would have saved; on a cold load a signed-in user pays
+ * two — this presence check, then the authenticated layout's own — and sees the
+ * layout's loading state in between. That is the price of not sharing mutable
+ * query state, on a page that is already an error.
  */
 export function useSessionPresence() {
   const { data: user, isLoading } = useQuery<User>({

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -312,12 +312,20 @@ const SANCTIONED_ALLOW_UNAUTHENTICATED = [
   'lib/api.ts', // the declaration and the interception it opts out of
 ];
 
-/** Every `.ts`/`.tsx` file under `dir` whose text contains `needle`. */
+/**
+ * Every file under `dir` whose text contains `needle`.
+ *
+ * The extension set has to match everything the bundler will resolve, not just
+ * what the tree happens to contain today: a `.mts` or `.mjs` module is compiled
+ * and shipped like any other, so if it can carry a call site it has to be
+ * scanned for one. Narrowing this to `.ts`/`.tsx` would leave a guard that looks
+ * total and is not.
+ */
 function filesMentioning(needle: string, dir: string, base = dir): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     const full = join(dir, entry.name);
     if (entry.isDirectory()) return filesMentioning(needle, full, base);
-    if (!/\.tsx?$/.test(entry.name)) return [];
+    if (!/\.[mc]?[jt]sx?$/.test(entry.name)) return [];
     return readFileSync(full, 'utf8').includes(needle) ? [relative(base, full)] : [];
   });
 }

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -293,6 +294,41 @@ describe('runtime-config seam (C3 / Req 8.5)', () => {
     expect(tag).not.toMatch(/\btype\s*=\s*["']module["']/i);
     expect(tag).not.toMatch(/\basync\b/i);
     expect(tag).not.toMatch(/\bdefer\b/i);
+  });
+});
+
+// The interception's ONE sanctioned opt-out, and this list is what enforces it.
+//
+// `allowUnauthenticated` switches off the global 401 redirect for a single
+// request. It exists for one caller: the not-found page's presence check, whose
+// whole question is "is anyone signed in?" and for which a 401 is the answer
+// rather than a session ending. A second caller would be a request that
+// genuinely needs a session quietly losing the redirect a real expiry depends
+// on — and it would do so invisibly, because nothing about the request would
+// look wrong. A doc comment on the field cannot stop that; naming the sites can.
+const SANCTIONED_ALLOW_UNAUTHENTICATED = [
+  'hooks/useAuth.ts', // the presence check, the one legitimate caller
+  'lib/api.test.ts', // this guard, which has to spell the flag to look for it
+  'lib/api.ts', // the declaration and the interception it opts out of
+];
+
+/** Every `.ts`/`.tsx` file under `dir` whose text contains `needle`. */
+function filesMentioning(needle: string, dir: string, base = dir): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return filesMentioning(needle, full, base);
+    if (!/\.tsx?$/.test(entry.name)) return [];
+    return readFileSync(full, 'utf8').includes(needle) ? [relative(base, full)] : [];
+  });
+}
+
+describe('the 401 interception opt-out', () => {
+  it('is used at its sanctioned sites and nowhere else in apps/web/src', () => {
+    const src = fileURLToPath(new URL('..', import.meta.url));
+    expect(
+      filesMentioning('allowUnauthenticated', src).sort(),
+      'a new allowUnauthenticated call site opts a request out of the expiry redirect',
+    ).toEqual(SANCTIONED_ALLOW_UNAUTHENTICATED);
   });
 });
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -202,6 +202,24 @@ export function setRouter(r: any) {
 
 export interface RequestOptions {
   signal?: AbortSignal;
+  /**
+   * Ask a question a 401 is a legitimate ANSWER to, rather than a failure.
+   *
+   * The interception below treats every 401 as a session that has just ended,
+   * because for every authenticated surface that is what one means. It is not
+   * what one means to a caller whose whole question is "is anyone signed in?" —
+   * there, "no" is the answer, and turning it into `/login?expired=true` tells a
+   * visitor who never had a session that theirs ran out.
+   *
+   * Set this and the 401 falls through to the ordinary error path: no
+   * navigation, no `auth:logout`, and — the part that matters most — the
+   * one-shot latch is left unburnt, so the next REAL expiry still has its one
+   * announcement to make.
+   *
+   * It is not a way to opt an authenticated request out of the redirect. A
+   * request that needs a session must keep it.
+   */
+  allowUnauthenticated?: boolean;
 }
 
 async function request<T>(
@@ -228,7 +246,7 @@ async function request<T>(
 
   const response = await fetch(resolveApiUrl(path), options);
 
-  if (response.status === 401 && !isLoggingOut && !redirecting) {
+  if (response.status === 401 && !opts?.allowUnauthenticated && !isLoggingOut && !redirecting) {
     redirecting = true;
     // Before the navigation, so each owner tears its state down while the page
     // it belongs to is still on screen.

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,6 +1,7 @@
 import {
   createRootRoute,
   type ErrorComponentProps,
+  Link,
   Navigate,
   Outlet,
   useRouter,
@@ -11,7 +12,7 @@ import { Button } from '@/components/ui/button';
 import { Toaster } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { VersionBadge } from '@/components/VersionBadge';
-import { useAuth } from '@/hooks/useAuth';
+import { useSessionPresence } from '@/hooks/useAuth';
 import { captureClientException } from '@/lib/telemetry/posthog';
 
 function ErrorComponent({ error }: ErrorComponentProps) {
@@ -39,8 +40,26 @@ function ErrorComponent({ error }: ErrorComponentProps) {
   );
 }
 
+/**
+ * What an unknown URL shows, which is two different things.
+ *
+ * A SIGNED-IN USER IS LOST INSIDE THE APP; AN ANONYMOUS ONE MISTYPED SOMETHING.
+ * The first has somewhere to be put back, so they still go to the dashboard. The
+ * second used to be sent to /login as well — and getting there took a me-query,
+ * which 401s for a visitor with no session, which the api client's global
+ * interception answers by navigating to `/login?expired=true`. Mistype a URL, or
+ * follow a stale link from anywhere, and the app announced that your session had
+ * expired when you never had one.
+ *
+ * The two are told apart by `useSessionPresence`, which asks the same question
+ * `useAuth` does but treats a 401 as the answer "nobody" instead of as an expiry
+ * — see its note. Anonymous visitors then get the page below: a plain 404 that
+ * says the address is wrong, with a way to sign in for the case where it was
+ * only that they were signed out. Being lost and being signed out are different
+ * problems and this is where they stopped being the same message.
+ */
 function NotFoundComponent() {
-  const { isLoading, isAuthenticated } = useAuth();
+  const { isLoading, isAuthenticated } = useSessionPresence();
 
   if (isLoading) {
     return (
@@ -54,7 +73,20 @@ function NotFoundComponent() {
     return <Navigate to="/dashboard" />;
   }
 
-  return <Navigate to="/login" />;
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="max-w-sm text-center">
+        <h1 className="mb-2 text-2xl font-bold">Page not found</h1>
+        <p className="text-muted-foreground mb-6 text-sm">
+          We couldn&apos;t find that page. Check the address, or sign in to pick up where you left
+          off.
+        </p>
+        <Button asChild className="cursor-pointer">
+          <Link to="/login">Sign in</Link>
+        </Button>
+      </div>
+    </div>
+  );
 }
 
 export const Route = createRootRoute({

--- a/apps/web/src/routes/__tests__/not-found-anonymous.test.tsx
+++ b/apps/web/src/routes/__tests__/not-found-anonymous.test.tsx
@@ -1,0 +1,196 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from '@tanstack/react-router';
+import { render, screen, cleanup, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+
+import {
+  api,
+  markSessionConfirmed,
+  markSessionEnded,
+  markSessionStarted,
+  setRouter,
+} from '@/lib/api';
+
+import { Route as RootRoute } from '../__root';
+import { Route as LoginRoute } from '../login';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() }, Toaster: () => null }));
+
+// An unknown URL asks who you are, and a 401 is an ANSWER to that, not an expiry.
+//
+// __root's notFoundComponent is a dispatcher: what a 404 should show differs for
+// a signed-in user and an anonymous one, so unlike the public routes it cannot
+// avoid the question by not asking it. Asking it through `useAuth` meant the
+// me-query 401'd on a logged-out visitor and lib/api's global interception
+// navigated to `/login?expired=true` — a mistyped address, or any stale external
+// link, told people their session had expired when they never had one.
+//
+// The anonymous case below is the regression these tests exist for. The
+// signed-in case sits beside it so a later change cannot quietly collapse the
+// two back into one.
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// The REAL root, carrying the real notFoundComponent, so an unmatched path
+// renders what the app renders (the public-routes cold-load test's pattern).
+function buildRouter(initialPath: string) {
+  const rootOptions = RootRoute.options as any;
+  const rootRoute = createRootRoute({
+    component: rootOptions.component,
+    notFoundComponent: rootOptions.notFoundComponent,
+  });
+
+  const login = createRoute({
+    getParentRoute: () => rootRoute as any,
+    path: '/login',
+    component: (LoginRoute.options as any).component,
+  });
+  const dashboard = createRoute({
+    getParentRoute: () => rootRoute as any,
+    path: '/dashboard',
+    component: () => <div>dashboard-stub</div>,
+  });
+
+  const routeTree = rootRoute.addChildren([login, dashboard]);
+
+  return createRouter({
+    routeTree: routeTree as any,
+    history: createMemoryHistory({ initialEntries: [initialPath] }),
+  });
+}
+
+function renderAt(initialPath: string) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const router = buildRouter(initialPath);
+  // main.tsx hands the real router to lib/api, so the 401 interception navigates
+  // rather than assigning window.location. Same here, or the redirect these
+  // tests forbid would be invisible to them.
+  setRouter(router);
+  render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router as any} />
+    </QueryClientProvider>,
+  );
+  return { router };
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+// Two ticks: one for the me-query's answer, one for any navigation it provokes.
+async function settle() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+const UNKNOWN_PATH = '/this-route-does-not-exist';
+
+let fetchSpy: MockInstance;
+
+// Every request answers the same way, because the session is what is being
+// mocked, not one endpoint. The 404 page only ever calls `/auth/me`; the latch
+// case below deliberately calls something else.
+function mockSession(respond: () => Response) {
+  fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => respond());
+}
+
+beforeEach(() => {
+  // lib/api's redirect latch and session flag are module-scoped and a fresh page
+  // load is what normally resets them. This pair is that reset through the
+  // module's own exports: started re-arms the latch, ended clears the session.
+  markSessionStarted();
+  markSessionEnded();
+});
+
+afterEach(() => {
+  cleanup();
+  fetchSpy.mockRestore();
+  setRouter(null);
+});
+
+describe('an unknown URL while logged out', () => {
+  beforeEach(() => {
+    mockSession(
+      () =>
+        new Response(JSON.stringify({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+  });
+
+  it('renders a not-found page instead of redirecting to a session-expired login', async () => {
+    const { router } = renderAt(UNKNOWN_PATH);
+    await settle();
+
+    expect(screen.getByText('Page not found')).toBeTruthy();
+
+    // The address is still the one that was mistyped: no redirect happened, and
+    // in particular not the `expired` one the 401 interception used to perform.
+    expect(router.state.location.pathname).toBe(UNKNOWN_PATH);
+    expect(router.state.location.href).not.toContain('expired');
+    expect(screen.queryByText('Session expired. Please log in again.')).toBeNull();
+    expect(screen.queryByText('Log in', { selector: '[data-slot="card-title"]' })).toBeNull();
+  });
+
+  it('offers a way to sign in, so a wrong address is distinguishable from being signed out', async () => {
+    renderAt(UNKNOWN_PATH);
+    await settle();
+
+    const signIn = screen.getByRole('link', { name: 'Sign in' });
+    expect(signIn.getAttribute('href')).toBe('/login');
+  });
+
+  it('leaves the expiry redirect intact for the session that follows', async () => {
+    const { router } = renderAt(UNKNOWN_PATH);
+    await settle();
+
+    // The anonymous 404's own 401 must not consume lib/api's one-shot redirect
+    // latch, or the fix would trade a false expiry notice for a missing real
+    // one. `markSessionConfirmed` stands in for the session the visitor then
+    // signs into — it declares a session WITHOUT re-arming the latch, which is
+    // exactly what leaves a burnt latch visible here.
+    markSessionConfirmed();
+    await expect(api.get('/positions')).rejects.toThrow('Unauthorized');
+    await settle();
+
+    expect(router.state.location.pathname).toBe('/login');
+    expect(router.state.location.href).toContain('expired');
+  });
+});
+
+describe('an unknown URL while signed in', () => {
+  beforeEach(() => {
+    mockSession(
+      () =>
+        new Response(
+          JSON.stringify({
+            id: 'u1',
+            email: 'trader@example.com',
+            createdAt: new Date().toISOString(),
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    );
+  });
+
+  it('still dispatches to the dashboard rather than the anonymous page', async () => {
+    const { router } = renderAt(UNKNOWN_PATH);
+    await settle();
+
+    expect(router.state.location.pathname).toBe('/dashboard');
+    expect(screen.queryByText('Page not found')).toBeNull();
+  });
+});


### PR DESCRIPTION
Hitting an unknown URL while logged out told the user their session had expired.

`__root.tsx`'s not-found component consulted the session. That fired an authenticated
request, took a 401, and the global interceptor redirected to the login page with an
expiry notice — so a mistyped URL, or a stale link from outside the app, claimed a
session had ended that never existed.

An earlier change fixed the same false notice on the public routes by simply not
consulting the session there. That approach is wrong here: a not-found component is a
dispatcher, and what a 404 should render legitimately differs for a signed-in user and
an anonymous one. So the two cases are now each chosen deliberately:

- **Anonymous** — a "Page not found" page, on the URL the user actually typed, with a
  sign-in link. A wrong address is now distinguishable from "you need to sign in".
- **Signed in** — unchanged; still dispatches to the dashboard.

## The opt-out, and why it is guarded by a test rather than a comment

Asking "is anyone signed in?" needs a request whose 401 is an *answer* rather than a
session ending, so `RequestOptions.allowUnauthenticated` lets that one request skip the
global redirect, announcement, and one-shot latch.

That is a hole in the thing the interceptor exists to guarantee. A second caller would
be a request that genuinely needs a session quietly losing the redirect a real expiry
depends on — and it would do so invisibly, because nothing about the call would look
wrong. A doc comment cannot prevent that, so a test names the sanctioned files and fails
the suite if the flag appears anywhere else under `apps/web/src`.

The scan covers every extension the bundler resolves, not just the `.ts`/`.tsx` the tree
happens to contain today — a guard that looks total and is not is worse than none. A
computed property access still evades it; that is inherent to scanning text, and is
noted rather than papered over.

## The presence check asks under its own query key

A react-query observer does not merely read the query it names, it writes its own
`queryFn` onto it. Sharing `['auth','me']` therefore handed the permissive fetch to the
session query for as long as the 404 page was mounted, so an expiry landing in that
window — a tab regaining focus, an invalidation, a refetch — answered a 401 that had
opted out of the interception. No redirect, no announcement.

The guarantee the interception makes must not be suspendable by being on a 404 page, so
the presence check now uses its own key. Cost: on a cold load a signed-in user hitting a
404 pays two `/auth/me` requests — this check, then the authenticated layout's own — and
sees the layout's loading state in between. That is the price of not sharing mutable
query state, on a page that is already an error.

## Known adjacent issue, not addressed here

The expiry notice this change stops firing falsely does not currently fire *correctly*
either: the redirect writes its query parameter JSON-quoted (`expired=%22true%22`) while
the login page compares against the bare string, so a genuine expiry redirects with no
explanation. That is a separate defect on the genuine-expiry path, it predates this
change, and this change neither introduced nor touched it — the anonymous 404 simply no
longer reaches that redirect at all. Tracked separately.

## Verification

Reproduced before being written and proved by deliberate breakage afterwards. Reverting
the query-key split fails the expiry-during-404 regression test; dropping the flag check
fails three of the four not-found cases while the signed-in case still passes; adding a
rogue call site in a `.mts` module fails the scan guard.

781 scoped web tests pass after rebasing onto current main, typecheck clean across the
monorepo, eslint clean, prettier clean.
