### PR TITLE
fix(onboarding): always explain why the walkthrough stopped

### DIFF
--- a/apps/web/src/features/onboarding/hooks/useWalkthrough.test.ts
+++ b/apps/web/src/features/onboarding/hooks/useWalkthrough.test.ts
@@ -13,6 +13,7 @@ import { WALKTHROUGH_STEPS, type WalkthroughStep } from '../lib/steps';
 // engine's, on the same terms as everything else the hook calls.
 import {
   stop as endRealTour,
+  type TourBlock,
   type TourExitReason,
   type TourHandlers,
   type TourStep,
@@ -100,12 +101,13 @@ const engine = {
 /**
  * The double above, OR the real engine — see `withRealEngine`.
  *
- * A double cannot check the pairing of an exit reason with the step it names,
- * because the pairing is precisely what the test would be inventing. Only
- * `lib/tour-engine` knows that the step it gave up on for a missing target is
- * very often an action-gated one — every gated step in the position and close
- * sets also waits for its target — so the wording the user is shown has to be
- * pinned against a stop the real engine actually produced.
+ * A double cannot check which cause the engine assigns a stop, because the
+ * assignment is precisely what the test would be inventing. Only
+ * `lib/tour-engine` reads the live DOM at the moment it gives up, and only it
+ * knows that a step it gave up on is very often an action-gated one — every
+ * gated step in the position and close sets also waits for its target, and both
+ * of them live in dialogs the user can close. So the wording has to be pinned
+ * against a stop the real engine actually produced.
  */
 let realEngine = false;
 vi.mock('../lib/tour-engine', async (importOriginal) => {
@@ -151,17 +153,20 @@ function highlight(index: number) {
 }
 
 /**
- * The engine giving up, as `lib/tour-engine` does: it ends the tour and names
- * the step the user could not get past, or names none when there was none.
+ * The engine giving up, as `lib/tour-engine` does: it ends the tour and hands
+ * over its classification of why the user could not get past a step, or none
+ * when nobody was stuck.
  *
- * WHICH step that is belongs to the engine and is pinned there against the real
- * driver.js. What belongs here is what the user is left looking at afterwards.
+ * WHICH step it was and WHICH cause held them belong to the engine and are
+ * pinned there against the real driver.js. They arrive as one value, so a test
+ * here cannot pair a cause with a step the engine would never have paired it
+ * with. What belongs here is what the user is left looking at afterwards.
  */
-function endTour(reason: TourExitReason, blockedAt?: TourStep) {
+function endTour(reason: TourExitReason, blocked?: TourBlock) {
   act(() => {
     const session = started;
     started = null;
-    session?.handlers.onExit?.(reason, blockedAt);
+    session?.handlers.onExit?.(reason, blocked);
   });
 }
 
@@ -170,9 +175,31 @@ function withToaster() {
   render(createElement(Toaster));
 }
 
+/** Some other notice, raised only to prove a render happened — see below. */
+const A_MARKER = 'a notice raised by the test';
+
+/**
+ * NO NOTICE APPEARED, AND THIS CAN FAIL WHEN ONE DID.
+ *
+ * Querying straight after the tour ends proves nothing: sonner renders on its
+ * own schedule, so the toaster is still empty on that tick whether a notice was
+ * raised or not. Every "says nothing" test here read as green with the notice
+ * firing — checked by raising one deliberately and watching them pass.
+ *
+ * So the silence is measured against a notice that IS expected. Raising a marker
+ * and waiting for it puts the toaster through a render, and sonner renders its
+ * whole queue in one pass — so anything raised before the marker is on screen by
+ * the time the marker is. If the walkthrough spoke, this sees it.
+ */
+async function expectNoStopNotice(): Promise<void> {
+  toast.info(A_MARKER);
+  expect(await screen.findByText(A_MARKER)).toBeTruthy();
+  expect(screen.queryByText('The walkthrough stopped')).toBeNull();
+}
+
 /**
  * Drive the next tour with the REAL engine — driver.js, the real gate, the real
- * `blockedAt` — instead of the double.
+ * classification read off the live DOM — instead of the double.
  *
  * jsdom is enough, as it is for the engine's own tests: driver.js reads only
  * `getBoundingClientRect`, which returns zeroes here. Reduced motion keeps its
@@ -413,9 +440,9 @@ describe('useWalkthrough — the tour says why it stopped', () => {
     await start('position');
     const gated = aGatedStep();
 
-    // The decline: the user closed the tour on a step whose gate they could
-    // have opened, which is the only stop that is theirs to clear.
-    endTour('dismissed', gated);
+    // The decline: the user closed the tour on a step whose control was there
+    // and pressable, which is the only stop that is theirs to clear.
+    endTour('dismissed', { cause: 'action-required', step: gated });
 
     const notice = await screen.findByText('The walkthrough stopped');
     expect(notice).toBeTruthy();
@@ -430,7 +457,7 @@ describe('useWalkthrough — the tour says why it stopped', () => {
   });
 
   /**
-   * THE SAME STEP, THE OTHER REASON, AND IT MUST NOT READ THE SAME. Every gated
+   * THE SAME STEP, THE OTHER CAUSE, AND IT MUST NOT READ THE SAME. Every gated
    * step in these two sets also waits for its target, so a slow load or a
    * navigation that never happened stops the tour on one of them having shown
    * the user no control at all. Wording that keyed off the gate blamed them for
@@ -441,11 +468,11 @@ describe('useWalkthrough — the tour says why it stopped', () => {
     await start('close');
     const gated = aGatedStep();
 
-    endTour('target-missing', gated);
+    endTour('target-missing', { cause: 'target-missing', step: gated });
 
-    const why = await screen.findByText(/never appeared on screen/);
+    const why = await screen.findByText(/is not on screen/);
     expect(why.textContent).toContain(gated.title);
-    expect(why.textContent).toContain('the walkthrough could not show you that step');
+    expect(why.textContent).toContain('the walkthrough could not carry on from there');
     expect(screen.queryByText(/only moves on once you have actually done it/)).toBeNull();
   });
 
@@ -457,24 +484,18 @@ describe('useWalkthrough — the tour says why it stopped', () => {
     await start('position');
     const plain = started!.steps.find((s) => !s.advanceOnAction && s.target !== undefined)!;
 
-    endTour('target-missing', plain);
+    endTour('target-missing', { cause: 'target-missing', step: plain });
 
-    const why = await screen.findByText(/never appeared on screen/);
+    const why = await screen.findByText(/is not on screen/);
     expect(why.textContent).toContain(plain.title);
     expect(why.textContent).toContain('start it again from the setup checklist');
   });
 
-  // The fallback exists so that the one failure this is here to end cannot come
-  // back through a gap: a tour that gave up and named no step still says so.
-  it('still explains a tour that gave up without naming a step', async () => {
-    withToaster();
-    await start('position');
-
-    endTour('target-missing');
-
-    expect(await screen.findByText('The walkthrough stopped')).toBeTruthy();
-    expect(await screen.findByText(/It could not carry on from here/)).toBeTruthy();
-  });
+  // The fallback that used to sit here — a `target-missing` naming no step —
+  // has no test because it has no case: the engine hands over one value
+  // carrying both the cause and the step it happened on, so "gave up, said
+  // which reason, named no step" is not a thing that can be constructed. The
+  // engine's own tests pin that every give-up produces one.
 
   it('says nothing when the user simply closed the tour', async () => {
     withToaster();
@@ -482,8 +503,7 @@ describe('useWalkthrough — the tour says why it stopped', () => {
 
     endTour('dismissed');
 
-    await waitFor(() => expect(engine.startTour).toHaveBeenCalled());
-    expect(screen.queryByText('The walkthrough stopped')).toBeNull();
+    await expectNoStopNotice();
   });
 
   it('says nothing when the user finished it', async () => {
@@ -492,7 +512,7 @@ describe('useWalkthrough — the tour says why it stopped', () => {
 
     endTour('completed');
 
-    expect(screen.queryByText('The walkthrough stopped')).toBeNull();
+    await expectNoStopNotice();
   });
 
   // The session went away under the tour; the notice would land on the login
@@ -503,24 +523,24 @@ describe('useWalkthrough — the tour says why it stopped', () => {
 
     endTour('session-ended');
 
-    expect(screen.queryByText('The walkthrough stopped')).toBeNull();
+    await expectNoStopNotice();
   });
 });
 
 /**
  * THE SAME NOTICE, WITH NOTHING INVENTED IN BETWEEN.
  *
- * Everything above hands `onExit` a reason and a step chosen by the test, which
- * is how a notice came to name the wrong cause: the pairing was never checked
- * against an engine that produces it. These two run the REAL engine over the
- * REAL close set and read what is on screen at the end, so a reason that stops
- * matching its wording fails here rather than in front of a user.
+ * Everything above hands `onExit` a classification chosen by the test, which is
+ * how the wrong cause reached the screen twice: what the engine actually
+ * produces was never driven. These run the REAL engine over the REAL close set
+ * and read what is on screen at the end, so a classification that stops matching
+ * its wording fails here rather than in front of a user.
  *
- * The close set is the one that reaches both stops. Its first step is
+ * The close set is the one that reaches every stop. Its first step is
  * action-gated AND waits five seconds for a control on a route that has to load
- * first — so the same step ends the tour `dismissed` when the user declines it
- * and `target-missing` when the position never arrives, which is what a slow
- * load and a failed navigation both look like from here.
+ * first, so the SAME step produces all three endings: the user declining an
+ * action they could have taken, a control that never arrived, and a control that
+ * arrived and then went away under them.
  */
 describe('useWalkthrough — the real engine says why it stopped', () => {
   const gated = WALKTHROUGH_STEPS.close[0];
@@ -554,7 +574,7 @@ describe('useWalkthrough — the real engine says why it stopped', () => {
     });
     vi.useRealTimers();
 
-    const why = await screen.findByText(/never appeared on screen/);
+    const why = await screen.findByText(/is not on screen/);
     expect(why.textContent).toContain(gated.title);
     expect(screen.queryByText(/only moves on once you have actually done it/)).toBeNull();
   });
@@ -575,6 +595,35 @@ describe('useWalkthrough — the real engine says why it stopped', () => {
 
     const why = await screen.findByText(/only moves on once you have actually done it/);
     expect(why.textContent).toContain(gated.title);
+  });
+
+  /**
+   * THE CONTROL WENT AWAY UNDER THE STEP, AND THE USER DID NOT DECLINE ANYTHING.
+   *
+   * The third ending, and the one that read as the first: the engine recorded a
+   * gate for a step whose control had unmounted, so the tour told a user who had
+   * just cancelled a dialog that they had failed to do the thing inside it. It
+   * is the ordinary shape of every gated step in the product — `#symbol` and Add
+   * Fill both live in dialogs — which is why the classification is read from the
+   * live DOM at the moment the tour ends rather than from the step's own flag.
+   */
+  it('does not blame the user when the control was dismissed with its dialog', async () => {
+    withToaster();
+    withRealEngine();
+    mountTarget(gated);
+
+    await start('close');
+    expect(document.querySelector('.driver-popover-title')?.textContent).toBe(gated.title);
+
+    // The dialog the control lived in, cancelled; then the tour closed.
+    document.querySelector(gated.target!)!.remove();
+    act(() => {
+      document.querySelector<HTMLButtonElement>('.driver-popover-close-btn')?.click();
+    });
+
+    const why = await screen.findByText(/is not on screen/);
+    expect(why.textContent).toContain(gated.title);
+    expect(screen.queryByText(/only moves on once you have actually done it/)).toBeNull();
   });
 });
 

--- a/apps/web/src/features/onboarding/hooks/useWalkthrough.test.ts
+++ b/apps/web/src/features/onboarding/hooks/useWalkthrough.test.ts
@@ -1,7 +1,10 @@
 // @vitest-environment jsdom
-import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { act, cleanup, render, renderHook, screen, waitFor } from '@testing-library/react';
+import { createElement } from 'react';
+import { toast } from 'sonner';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { Toaster } from '@/components/ui/sonner';
 import { eventBus } from '@/stores/event-bus.store';
 
 import type { Checklist, ChecklistItemId } from '../lib/derive-checklist';
@@ -119,6 +122,33 @@ function highlight(index: number) {
   });
 }
 
+/**
+ * The engine giving up, as `lib/tour-engine` does: it ends the tour and names
+ * the step the user could not get past, or names none when there was none.
+ *
+ * WHICH step that is belongs to the engine and is pinned there against the real
+ * driver.js. What belongs here is what the user is left looking at afterwards.
+ */
+function endTour(reason: TourExitReason, blockedAt?: TourStep) {
+  act(() => {
+    const session = started;
+    started = null;
+    session?.handlers.onExit?.(reason, blockedAt);
+  });
+}
+
+/** Put the app's real toaster on screen, so a notice can be READ rather than counted. */
+function withToaster() {
+  render(createElement(Toaster));
+}
+
+/** The step in the running set that will only move on the real action. */
+function aGatedStep(): TourStep {
+  const step = started?.steps.find((s) => s.advanceOnAction);
+  if (!step) throw new Error('the set under test has no action-gated step');
+  return step;
+}
+
 function currentTargets(): (string | undefined)[] {
   return (started?.steps ?? []).map((s) => s.target);
 }
@@ -142,6 +172,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // sonner's queue is module-scoped like the session is, so a notice raised in
+  // one test would still be there for the next one's toaster to render.
+  toast.dismiss();
   // Unmount first: the store is module-scoped, so a hook still mounted from an
   // earlier test would re-render on the reset below — outside `act`, and
   // attributed to whichever test came next.
@@ -298,6 +331,110 @@ describe('useWalkthrough — start and exit', () => {
     await waitFor(() => expect(result.current.itemId).toBe('position'));
     expect(result.current.isRunning).toBe(true);
     expect(engine.startTour).toHaveBeenCalledTimes(2);
+  });
+});
+
+// --- a tour that cannot carry on -------------------------------------------
+
+/**
+ * A WALKTHROUGH THAT VANISHES WITH NOTHING ON SCREEN IS THIS AREA'S RECURRING
+ * DEFECT, and these are about what is left in front of the user, not about
+ * which function ran. They render the app's real toaster and read the words in
+ * it for that reason: "a handler was called" is exactly the evidence that would
+ * have passed while the screen stayed blank.
+ *
+ * The position and close sets each ask the user to do the real thing — create
+ * the position, record the exit fill — and replaying one still does. That is
+ * the walkthrough working as intended. What was broken was that a user who did
+ * not want to place another trade was shown nothing at all when it stopped.
+ */
+describe('useWalkthrough — the tour says why it stopped', () => {
+  it('tells the user an action-gated step needs them to actually do it', async () => {
+    withToaster();
+    await start('position');
+    const gated = aGatedStep();
+
+    endTour('target-missing', gated);
+
+    const notice = await screen.findByText('The walkthrough stopped');
+    expect(notice).toBeTruthy();
+
+    const why = await screen.findByText(/only moves on once you have actually done it/);
+    // The step it stopped at, named, so "which one?" is not left to the user.
+    expect(why.textContent).toContain(gated.title);
+    expect(why.textContent).toContain('the walkthrough cannot take that step for you');
+    // Both ways out, said plainly.
+    expect(why.textContent).toContain('carry on without it');
+    expect(why.textContent).toContain('start it again from the setup checklist');
+  });
+
+  it('says the same when the user closes the tour on that step rather than acting', async () => {
+    withToaster();
+    await start('close');
+    const gated = aGatedStep();
+
+    endTour('dismissed', gated);
+
+    expect(await screen.findByText('The walkthrough stopped')).toBeTruthy();
+    const why = await screen.findByText(/only moves on once you have actually done it/);
+    expect(why.textContent).toContain(gated.title);
+  });
+
+  // The general case, and the reason this is one path rather than a special
+  // case on the gate: the same silence has come from a set left on the wrong
+  // route and from a control that unmounted mid-tour.
+  it('explains an ordinary step that was never on screen', async () => {
+    withToaster();
+    await start('position');
+    const plain = started!.steps.find((s) => !s.advanceOnAction && s.target !== undefined)!;
+
+    endTour('target-missing', plain);
+
+    const why = await screen.findByText(/was not on screen/);
+    expect(why.textContent).toContain(plain.title);
+    expect(why.textContent).toContain('start it again from the setup checklist');
+  });
+
+  // The fallback exists so that the one failure this is here to end cannot come
+  // back through a gap: a tour that gave up and named no step still says so.
+  it('still explains a tour that gave up without naming a step', async () => {
+    withToaster();
+    await start('position');
+
+    endTour('target-missing');
+
+    expect(await screen.findByText('The walkthrough stopped')).toBeTruthy();
+    expect(await screen.findByText(/It could not carry on from here/)).toBeTruthy();
+  });
+
+  it('says nothing when the user simply closed the tour', async () => {
+    withToaster();
+    await start('position');
+
+    endTour('dismissed');
+
+    await waitFor(() => expect(engine.startTour).toHaveBeenCalled());
+    expect(screen.queryByText('The walkthrough stopped')).toBeNull();
+  });
+
+  it('says nothing when the user finished it', async () => {
+    withToaster();
+    await start('position');
+
+    endTour('completed');
+
+    expect(screen.queryByText('The walkthrough stopped')).toBeNull();
+  });
+
+  // The session went away under the tour; the notice would land on the login
+  // screen, addressed to nobody.
+  it('says nothing when the session ended under it', async () => {
+    withToaster();
+    await start('position');
+
+    endTour('session-ended');
+
+    expect(screen.queryByText('The walkthrough stopped')).toBeNull();
   });
 });
 

--- a/apps/web/src/features/onboarding/hooks/useWalkthrough.test.ts
+++ b/apps/web/src/features/onboarding/hooks/useWalkthrough.test.ts
@@ -9,7 +9,14 @@ import { eventBus } from '@/stores/event-bus.store';
 
 import type { Checklist, ChecklistItemId } from '../lib/derive-checklist';
 import { WALKTHROUGH_STEPS, type WalkthroughStep } from '../lib/steps';
-import type { TourExitReason, TourHandlers, TourStep } from '../lib/tour-engine';
+// The module under `vi.mock` below: `stop()` here is the double's, or the real
+// engine's, on the same terms as everything else the hook calls.
+import {
+  stop as endRealTour,
+  type TourExitReason,
+  type TourHandlers,
+  type TourStep,
+} from '../lib/tour-engine';
 
 import {
   ACTION_SIGNALS,
@@ -89,7 +96,28 @@ const engine = {
   }),
   isActive: vi.fn(() => started !== null),
 };
-vi.mock('../lib/tour-engine', () => engine);
+
+/**
+ * The double above, OR the real engine — see `withRealEngine`.
+ *
+ * A double cannot check the pairing of an exit reason with the step it names,
+ * because the pairing is precisely what the test would be inventing. Only
+ * `lib/tour-engine` knows that the step it gave up on for a missing target is
+ * very often an action-gated one — every gated step in the position and close
+ * sets also waits for its target — so the wording the user is shown has to be
+ * pinned against a stop the real engine actually produced.
+ */
+let realEngine = false;
+vi.mock('../lib/tour-engine', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../lib/tour-engine')>();
+  return {
+    startTour: (steps: TourStep[], handlers?: TourHandlers) =>
+      realEngine ? real.startTour(steps, handlers) : engine.startTour(steps, handlers),
+    advance: () => (realEngine ? real.advance() : engine.advance()),
+    stop: (reason?: TourExitReason) => (realEngine ? real.stop(reason) : engine.stop(reason)),
+    isActive: () => (realEngine ? real.isActive() : engine.isActive()),
+  };
+});
 
 // --- helpers ----------------------------------------------------------------
 
@@ -140,6 +168,37 @@ function endTour(reason: TourExitReason, blockedAt?: TourStep) {
 /** Put the app's real toaster on screen, so a notice can be READ rather than counted. */
 function withToaster() {
   render(createElement(Toaster));
+}
+
+/**
+ * Drive the next tour with the REAL engine — driver.js, the real gate, the real
+ * `blockedAt` — instead of the double.
+ *
+ * jsdom is enough, as it is for the engine's own tests: driver.js reads only
+ * `getBoundingClientRect`, which returns zeroes here. Reduced motion keeps its
+ * rendering synchronous, so the popover is on screen the moment a tour starts.
+ */
+function withRealEngine() {
+  realEngine = true;
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    matches: query.includes('prefers-reduced-motion'),
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+/** Put the control a step anchors to on screen, so the real engine can find it. */
+function mountTarget(step: WalkthroughStep): void {
+  const attribute = /^\[([\w-]+)="([^"]+)"\]$/.exec(step.target ?? '');
+  if (!attribute) throw new Error(`the step under test has no attribute target: ${step.target}`);
+  const control = document.createElement('button');
+  control.setAttribute(attribute[1], attribute[2]);
+  document.body.appendChild(control);
 }
 
 /** The step in the running set that will only move on the real action. */
@@ -354,7 +413,9 @@ describe('useWalkthrough — the tour says why it stopped', () => {
     await start('position');
     const gated = aGatedStep();
 
-    endTour('target-missing', gated);
+    // The decline: the user closed the tour on a step whose gate they could
+    // have opened, which is the only stop that is theirs to clear.
+    endTour('dismissed', gated);
 
     const notice = await screen.findByText('The walkthrough stopped');
     expect(notice).toBeTruthy();
@@ -368,16 +429,24 @@ describe('useWalkthrough — the tour says why it stopped', () => {
     expect(why.textContent).toContain('start it again from the setup checklist');
   });
 
-  it('says the same when the user closes the tour on that step rather than acting', async () => {
+  /**
+   * THE SAME STEP, THE OTHER REASON, AND IT MUST NOT READ THE SAME. Every gated
+   * step in these two sets also waits for its target, so a slow load or a
+   * navigation that never happened stops the tour on one of them having shown
+   * the user no control at all. Wording that keyed off the gate blamed them for
+   * not pressing a button that was never there.
+   */
+  it('does not blame the user when a gated step was the one that never appeared', async () => {
     withToaster();
     await start('close');
     const gated = aGatedStep();
 
-    endTour('dismissed', gated);
+    endTour('target-missing', gated);
 
-    expect(await screen.findByText('The walkthrough stopped')).toBeTruthy();
-    const why = await screen.findByText(/only moves on once you have actually done it/);
+    const why = await screen.findByText(/never appeared on screen/);
     expect(why.textContent).toContain(gated.title);
+    expect(why.textContent).toContain('the walkthrough could not show you that step');
+    expect(screen.queryByText(/only moves on once you have actually done it/)).toBeNull();
   });
 
   // The general case, and the reason this is one path rather than a special
@@ -390,7 +459,7 @@ describe('useWalkthrough — the tour says why it stopped', () => {
 
     endTour('target-missing', plain);
 
-    const why = await screen.findByText(/was not on screen/);
+    const why = await screen.findByText(/never appeared on screen/);
     expect(why.textContent).toContain(plain.title);
     expect(why.textContent).toContain('start it again from the setup checklist');
   });
@@ -435,6 +504,77 @@ describe('useWalkthrough — the tour says why it stopped', () => {
     endTour('session-ended');
 
     expect(screen.queryByText('The walkthrough stopped')).toBeNull();
+  });
+});
+
+/**
+ * THE SAME NOTICE, WITH NOTHING INVENTED IN BETWEEN.
+ *
+ * Everything above hands `onExit` a reason and a step chosen by the test, which
+ * is how a notice came to name the wrong cause: the pairing was never checked
+ * against an engine that produces it. These two run the REAL engine over the
+ * REAL close set and read what is on screen at the end, so a reason that stops
+ * matching its wording fails here rather than in front of a user.
+ *
+ * The close set is the one that reaches both stops. Its first step is
+ * action-gated AND waits five seconds for a control on a route that has to load
+ * first — so the same step ends the tour `dismissed` when the user declines it
+ * and `target-missing` when the position never arrives, which is what a slow
+ * load and a failed navigation both look like from here.
+ */
+describe('useWalkthrough — the real engine says why it stopped', () => {
+  const gated = WALKTHROUGH_STEPS.close[0];
+
+  afterEach(() => {
+    // The engine's own module state, which the hook's reset does not reach.
+    // Runs before the file-wide teardown, so the toaster is still up for it.
+    endRealTour();
+    realEngine = false;
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+  });
+
+  it('blames the user for nothing when the control never rendered', async () => {
+    // The step really is gated — the pairing that used to pick the wording.
+    expect(gated.advanceOnAction).toBe(true);
+    expect(gated.waitForMs).toBeGreaterThan(0);
+    withToaster();
+    withRealEngine();
+    // Only `setTimeout`, so React and sonner keep their own scheduling: the
+    // wait for a target is a plain timer inside driver.js, and it is the only
+    // clock this test wants to move.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+
+    // Nothing is mounted, so the control never appears — the position page
+    // still loading, or a navigation that did not happen.
+    await start('close');
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(gated.waitForMs! + 100);
+    });
+    vi.useRealTimers();
+
+    const why = await screen.findByText(/never appeared on screen/);
+    expect(why.textContent).toContain(gated.title);
+    expect(screen.queryByText(/only moves on once you have actually done it/)).toBeNull();
+  });
+
+  it('says that same step needs them when they close the tour on it', async () => {
+    withToaster();
+    withRealEngine();
+    // The control is there and pressable, so the gate is really holding.
+    mountTarget(gated);
+
+    await start('close');
+    expect(document.querySelector('.driver-popover-title')?.textContent).toBe(gated.title);
+
+    // The close button is the only control that answers on a gated step.
+    act(() => {
+      document.querySelector<HTMLButtonElement>('.driver-popover-close-btn')?.click();
+    });
+
+    const why = await screen.findByText(/only moves on once you have actually done it/);
+    expect(why.textContent).toContain(gated.title);
   });
 });
 

--- a/apps/web/src/features/onboarding/hooks/useWalkthrough.ts
+++ b/apps/web/src/features/onboarding/hooks/useWalkthrough.ts
@@ -506,13 +506,27 @@ const STOP_NOTICE_MS = 12_000;
  * what the walkthrough teaches, so a user who does not want to place another
  * trade genuinely cannot go on. What was missing was never the gate; it was
  * anyone saying so.
+ *
+ * WHICH IS WHY THE WORDING FOLLOWS THE REASON AND NOT THE STEP. Being gated is
+ * not why a tour stopped — it is only why one of the two stops is the user's to
+ * clear. Every gated step in the position and close sets also carries a
+ * `waitForMs`, because each is entered cold on a route still loading, so a slow
+ * load or a navigation that did not happen ends those exact steps
+ * `target-missing`. Reading the gate flag instead of the reason told a user
+ * whose control never rendered that they had declined to press it, which is a
+ * confident lie about the one failure this notice exists to explain.
  */
-function explainStop(step: TourStep | undefined): string {
+function explainStop(reason: TourExitReason, step: TourStep | undefined): string {
   if (step === undefined) return 'It could not carry on from here.';
-  if (step.advanceOnAction === true) {
+  // The user turned the tour down where it stood, and the engine names a step
+  // here ONLY when its gate was one they could have opened (`recordGate`) — so
+  // this is the decline, and nothing else reaches it.
+  if (reason === 'dismissed') {
     return `“${step.title}” only moves on once you have actually done it, so the walkthrough cannot take that step for you.`;
   }
-  return `“${step.title}” was not on screen, so the walkthrough could not carry on.`;
+  // Everything else that names a step got it from the engine giving up on a
+  // target — gated or not, the control was never there to press.
+  return `“${step.title}” never appeared on screen, so the walkthrough could not show you that step.`;
 }
 
 function announceStop(reason: TourExitReason, blockedAt: TourStep | undefined): void {
@@ -525,7 +539,7 @@ function announceStop(reason: TourExitReason, blockedAt: TourStep | undefined): 
     // it was started from is still there. Exiting discards nothing — this
     // module writes no onboarding state at all — so "nothing was lost" is a
     // structural fact rather than a reassurance.
-    description: `${explainStop(blockedAt)} Nothing was lost — carry on without it, or start it again from the setup checklist whenever you want.`,
+    description: `${explainStop(reason, blockedAt)} Nothing was lost — carry on without it, or start it again from the setup checklist whenever you want.`,
   });
 }
 

--- a/apps/web/src/features/onboarding/hooks/useWalkthrough.ts
+++ b/apps/web/src/features/onboarding/hooks/useWalkthrough.ts
@@ -62,7 +62,7 @@ import type { EventName } from '@/stores/events.types';
 import { emitOnboardingEvent } from '../lib/analytics';
 import type { ChecklistItemId, Checklist } from '../lib/derive-checklist';
 import type { WalkthroughStep } from '../lib/steps';
-import type { TourExitReason, TourStep } from '../lib/tour-engine';
+import type { TourBlock } from '../lib/tour-engine';
 
 import { selectOwnRows, useOnboarding } from './useOnboarding';
 
@@ -496,10 +496,8 @@ const STOP_NOTICE_MS = 12_000;
  * WHAT IT DOES NOT COVER, DELIBERATELY. Completion needs no explanation, a
  * session that ended took the whole screen with it, and an ordinary dismissal
  * is the user saying they are done — telling someone who closed the tour that
- * the tour closed is nagging. The trigger is the engine's `blockedAt`: a step
- * the user could not get past. `target-missing` is reported even without one,
- * because a tour that vanished having named no step is precisely the failure
- * this exists to end, and silence would be the worst possible fallback.
+ * the tour closed is nagging. The trigger is the engine's `TourBlock`: a step
+ * the user could not get past, and which of the two things held them there.
  *
  * ACTION-GATED STEPS GET THE HONEST REASON. Replaying a set still requires the
  * real thing — creating the position, recording the exit fill — because that is
@@ -507,30 +505,32 @@ const STOP_NOTICE_MS = 12_000;
  * trade genuinely cannot go on. What was missing was never the gate; it was
  * anyone saying so.
  *
- * WHICH IS WHY THE WORDING FOLLOWS THE REASON AND NOT THE STEP. Being gated is
- * not why a tour stopped — it is only why one of the two stops is the user's to
- * clear. Every gated step in the position and close sets also carries a
- * `waitForMs`, because each is entered cold on a route still loading, so a slow
- * load or a navigation that did not happen ends those exact steps
- * `target-missing`. Reading the gate flag instead of the reason told a user
- * whose control never rendered that they had declined to press it, which is a
- * confident lie about the one failure this notice exists to explain.
+ * THE CLASSIFICATION IS THE ONLY INPUT, AND THAT IS THE FIX. This wording has
+ * twice been chosen from something standing next to the cause instead of the
+ * cause itself — first the step's own `advanceOnAction` flag, then the exit
+ * reason — and each time it told a user whose control had never rendered, or had
+ * gone, that they had declined to press it. Both readings were available because
+ * both were being reassembled here out of parts. They are not any more: the
+ * engine decides, from the live DOM at the moment it gives up, and this is a
+ * switch over that decision. The switch is exhaustive with no default, so a
+ * third cause is a type error here rather than a sentence about the wrong thing.
  */
-function explainStop(reason: TourExitReason, step: TourStep | undefined): string {
-  if (step === undefined) return 'It could not carry on from here.';
-  // The user turned the tour down where it stood, and the engine names a step
-  // here ONLY when its gate was one they could have opened (`recordGate`) — so
-  // this is the decline, and nothing else reaches it.
-  if (reason === 'dismissed') {
-    return `“${step.title}” only moves on once you have actually done it, so the walkthrough cannot take that step for you.`;
+function explainStop(blocked: TourBlock): string {
+  switch (blocked.cause) {
+    case 'action-required':
+      // The control was on screen and pressable and the user left anyway, which
+      // is the one stop that is theirs to clear.
+      return `“${blocked.step.title}” only moves on once you have actually done it, so the walkthrough cannot take that step for you.`;
+    case 'target-missing':
+      // Present tense, because it is true of both ways a control comes to be
+      // absent: one that never rendered, and one the user has since dismissed
+      // along with the dialog it lived in.
+      return `“${blocked.step.title}” is not on screen, so the walkthrough could not carry on from there.`;
   }
-  // Everything else that names a step got it from the engine giving up on a
-  // target — gated or not, the control was never there to press.
-  return `“${step.title}” never appeared on screen, so the walkthrough could not show you that step.`;
 }
 
-function announceStop(reason: TourExitReason, blockedAt: TourStep | undefined): void {
-  if (blockedAt === undefined && reason !== 'target-missing') return;
+function announceStop(blocked: TourBlock | undefined): void {
+  if (blocked === undefined) return;
 
   toast.info('The walkthrough stopped', {
     id: STOP_NOTICE_ID,
@@ -539,7 +539,7 @@ function announceStop(reason: TourExitReason, blockedAt: TourStep | undefined): 
     // it was started from is still there. Exiting discards nothing — this
     // module writes no onboarding state at all — so "nothing was lost" is a
     // structural fact rather than a reassurance.
-    description: `${explainStop(reason, blockedAt)} Nothing was lost — carry on without it, or start it again from the setup checklist whenever you want.`,
+    description: `${explainStop(blocked)} Nothing was lost — carry on without it, or start it again from the setup checklist whenever you want.`,
   });
 }
 
@@ -613,7 +613,7 @@ async function run(
     // appeared — and all three do the same thing to the user's data, because
     // none of them has any work to undo. They are told apart for the funnel,
     // and for whether the user is owed an explanation (`announceStop`).
-    onExit: (reason, blockedAt) => {
+    onExit: (reason, blocked) => {
       // THE STEP INDEX COMES FROM THE LIVE SESSION, AND IS READ BEFORE THE
       // TEARDOWN THAT CLEARS IT. Nothing stores a step index — resume
       // re-derives its position from the checklist instead, and adding a stored
@@ -639,7 +639,7 @@ async function run(
       });
       // After the teardown, so the screen the user is left with is the one the
       // notice is about.
-      announceStop(reason, blockedAt);
+      announceStop(blocked);
     },
   });
 }

--- a/apps/web/src/features/onboarding/hooks/useWalkthrough.ts
+++ b/apps/web/src/features/onboarding/hooks/useWalkthrough.ts
@@ -51,6 +51,7 @@
 
 import { useNavigate } from '@tanstack/react-router';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { toast } from 'sonner';
 import { create } from 'zustand';
 
 import { useAccounts } from '@/features/accounts/hooks/useAccounts';
@@ -61,6 +62,7 @@ import type { EventName } from '@/stores/events.types';
 import { emitOnboardingEvent } from '../lib/analytics';
 import type { ChecklistItemId, Checklist } from '../lib/derive-checklist';
 import type { WalkthroughStep } from '../lib/steps';
+import type { TourExitReason, TourStep } from '../lib/tour-engine';
 
 import { selectOwnRows, useOnboarding } from './useOnboarding';
 
@@ -466,6 +468,67 @@ function withOpeningParams(
   return { ...fallback, ...params };
 }
 
+/**
+ * One toast, reused. A user who stops twice gets the second explanation in
+ * place of the first rather than a stack of them.
+ */
+const STOP_NOTICE_ID = 'walkthrough-stopped';
+
+/**
+ * Long enough to read twice. The notice arrives at the moment an overlay the
+ * user was reading disappeared, so it has to survive the double-take that
+ * causes; it is still transient, so it carries no close button — the app's one
+ * permanent notice is the only one that needs a manual way out.
+ */
+const STOP_NOTICE_MS = 12_000;
+
+/**
+ * WHY THE TOUR STOPPED, IN WORDS, ON SCREEN.
+ *
+ * A walkthrough that ends without saying why is this area's recurring defect
+ * rather than an oversight in one step: it has now happened from three separate
+ * causes — a set left on the wrong route, a highlighted control that unmounted
+ * mid-tour, and a user declining the action a step waits for — and each time it
+ * looked identical from the user's seat, which is to say it looked like nothing
+ * at all. So the answer is one path for "the tour could not carry on", not a
+ * message bolted onto whichever cause was reported last.
+ *
+ * WHAT IT DOES NOT COVER, DELIBERATELY. Completion needs no explanation, a
+ * session that ended took the whole screen with it, and an ordinary dismissal
+ * is the user saying they are done — telling someone who closed the tour that
+ * the tour closed is nagging. The trigger is the engine's `blockedAt`: a step
+ * the user could not get past. `target-missing` is reported even without one,
+ * because a tour that vanished having named no step is precisely the failure
+ * this exists to end, and silence would be the worst possible fallback.
+ *
+ * ACTION-GATED STEPS GET THE HONEST REASON. Replaying a set still requires the
+ * real thing — creating the position, recording the exit fill — because that is
+ * what the walkthrough teaches, so a user who does not want to place another
+ * trade genuinely cannot go on. What was missing was never the gate; it was
+ * anyone saying so.
+ */
+function explainStop(step: TourStep | undefined): string {
+  if (step === undefined) return 'It could not carry on from here.';
+  if (step.advanceOnAction === true) {
+    return `“${step.title}” only moves on once you have actually done it, so the walkthrough cannot take that step for you.`;
+  }
+  return `“${step.title}” was not on screen, so the walkthrough could not carry on.`;
+}
+
+function announceStop(reason: TourExitReason, blockedAt: TourStep | undefined): void {
+  if (blockedAt === undefined && reason !== 'target-missing') return;
+
+  toast.info('The walkthrough stopped', {
+    id: STOP_NOTICE_ID,
+    duration: STOP_NOTICE_MS,
+    // Both ways out, named: nothing was riding on the tour, and the checklist
+    // it was started from is still there. Exiting discards nothing — this
+    // module writes no onboarding state at all — so "nothing was lost" is a
+    // structural fact rather than a reassurance.
+    description: `${explainStop(blockedAt)} Nothing was lost — carry on without it, or start it again from the setup checklist whenever you want.`,
+  });
+}
+
 async function run(
   itemId: ChecklistItemId,
   callerParams: Record<string, string> | undefined,
@@ -534,9 +597,9 @@ async function run(
     },
     // Every ending arrives here — completed, dismissed, or a target that never
     // appeared — and all three do the same thing to the user's data, because
-    // none of them has any work to undo. They are told apart only for the
-    // funnel.
-    onExit: (reason) => {
+    // none of them has any work to undo. They are told apart for the funnel,
+    // and for whether the user is owed an explanation (`announceStop`).
+    onExit: (reason, blockedAt) => {
       // THE STEP INDEX COMES FROM THE LIVE SESSION, AND IS READ BEFORE THE
       // TEARDOWN THAT CLEARS IT. Nothing stores a step index — resume
       // re-derives its position from the checklist instead, and adding a stored
@@ -560,6 +623,9 @@ async function run(
         stepCount,
         reason,
       });
+      // After the teardown, so the screen the user is left with is the one the
+      // notice is about.
+      announceStop(reason, blockedAt);
     },
   });
 }

--- a/apps/web/src/features/onboarding/lib/tour-engine.test.ts
+++ b/apps/web/src/features/onboarding/lib/tour-engine.test.ts
@@ -74,7 +74,7 @@ describe('startTour', () => {
 
     advance();
     expect(isActive()).toBe(false);
-    expect(onExit).toHaveBeenCalledExactlyOnceWith('completed');
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('completed', undefined);
     expect(document.querySelector('.driver-popover')).toBeNull();
   });
 
@@ -102,7 +102,7 @@ describe('startTour', () => {
 
     startTour([{ target: '#two', title: 'Only', description: 'Alone.' }]);
 
-    expect(firstExit).toHaveBeenCalledExactlyOnceWith('dismissed');
+    expect(firstExit).toHaveBeenCalledExactlyOnceWith('dismissed', undefined);
     expect(isActive()).toBe(true);
     expect(popoverTitle()).toBe('Only');
   });
@@ -233,7 +233,7 @@ describe('onBeforeAdvance', () => {
     clickPopoverButton('.driver-popover-next-btn');
 
     expect(onBeforeAdvance).not.toHaveBeenCalled();
-    expect(onExit).toHaveBeenCalledExactlyOnceWith('completed');
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('completed', undefined);
   });
 });
 
@@ -310,7 +310,7 @@ describe('exiting', () => {
 
     clickPopoverButton('.driver-popover-close-btn');
 
-    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed');
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', undefined);
     expect(isActive()).toBe(false);
   });
 
@@ -320,7 +320,7 @@ describe('exiting', () => {
 
     window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape', bubbles: true }));
 
-    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed');
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', undefined);
     expect(isActive()).toBe(false);
   });
 
@@ -331,8 +331,77 @@ describe('exiting', () => {
 
     clickPopoverButton('.driver-popover-next-btn');
 
-    expect(onExit).toHaveBeenCalledExactlyOnceWith('completed');
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('completed', undefined);
     expect(isActive()).toBe(false);
+  });
+});
+
+/**
+ * LEAVING A STEP THAT WOULD ONLY MOVE ON AN ACTION IS NOT AN ORDINARY EXIT, and
+ * the difference is the whole of this defect. On a gated step "Next" is inert,
+ * so the close button is the only control that answers the user at all —
+ * whereas on any other step it is one of three ways on that they chose not to
+ * take. Naming the step here is what lets the caller say why the tour stopped
+ * instead of leaving the screen bare, which is how this has failed three times.
+ */
+describe('the step the user could not get past', () => {
+  const gated: TourStep[] = [
+    { target: '#one', title: 'Do it', description: 'Create the thing.', advanceOnAction: true },
+    { target: '#two', title: 'Done', description: 'Here it is.' },
+  ];
+
+  it('is reported when the close button ends a gated step', () => {
+    const onExit = vi.fn();
+    startTour(gated, { onExit });
+
+    clickPopoverButton('.driver-popover-close-btn');
+
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', gated[0]);
+  });
+
+  it('is reported when Escape ends one', () => {
+    const onExit = vi.fn();
+    startTour(gated, { onExit });
+
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape', bubbles: true }));
+
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', gated[0]);
+  });
+
+  // The same test the gate itself is made of. A gated step whose control is
+  // disabled hands "Next" back, so the user leaving that one had a way on and
+  // declined it — there is nothing to explain, and explaining anyway would be
+  // an interruption for a user who simply closed the tour.
+  it('is not reported when the gate had already been released', () => {
+    document.querySelector<HTMLButtonElement>('#one')!.disabled = true;
+    const onExit = vi.fn();
+    startTour(gated, { onExit });
+
+    clickPopoverButton('.driver-popover-close-btn');
+
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', undefined);
+  });
+
+  it('is not reported for an ordinary step', () => {
+    const onExit = vi.fn();
+    startTour(TWO_STEPS, { onExit });
+
+    clickPopoverButton('.driver-popover-close-btn');
+
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', undefined);
+  });
+
+  // A tour the APP took away, not one the user got stuck in: `startTour` ends
+  // the previous tour through `stop()`, and so does the caller's own "end the
+  // walkthrough". Reporting those would put an explanation on screen at the
+  // moment the next tour starts.
+  it('is not reported when the caller ends the tour itself', () => {
+    const onExit = vi.fn();
+    startTour(gated, { onExit });
+
+    stop();
+
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', undefined);
   });
 });
 
@@ -361,11 +430,18 @@ describe('missing targets', () => {
 
   it('ends the tour cleanly when the target never appears', async () => {
     const onExit = vi.fn();
-    startTour([{ target: '#never', title: 'Nope', description: 'Absent.', waitForMs: 20 }], {
-      onExit,
-    });
+    const step: TourStep = {
+      target: '#never',
+      title: 'Nope',
+      description: 'Absent.',
+      waitForMs: 20,
+    };
+    startTour([step], { onExit });
 
-    await vi.waitFor(() => expect(onExit).toHaveBeenCalledExactlyOnceWith('target-missing'));
+    // The step it gave up on comes out with the reason, and this is the only
+    // moment anyone could know it: `onStepChange` never fired for it, so the
+    // caller's idea of the current step is still the one before.
+    await vi.waitFor(() => expect(onExit).toHaveBeenCalledExactlyOnceWith('target-missing', step));
 
     expect(isActive()).toBe(false);
     // No stuck overlay, and nothing was highlighted in its place.
@@ -374,11 +450,27 @@ describe('missing targets', () => {
     expect(document.body.classList.contains('driver-active')).toBe(false);
   });
 
+  it('names the step it gave up on, not the one it was showing', async () => {
+    const onExit = vi.fn();
+    const steps: TourStep[] = [
+      { target: '#one', title: 'First', description: 'Here.' },
+      { target: '#never', title: 'Unreachable', description: 'Absent.', waitForMs: 20 },
+    ];
+    startTour(steps, { onExit });
+
+    advance();
+
+    await vi.waitFor(() =>
+      expect(onExit).toHaveBeenCalledExactlyOnceWith('target-missing', steps[1]),
+    );
+  });
+
   it('gives up immediately when a step declares no wait', async () => {
     const onExit = vi.fn();
-    startTour([{ target: '#never', title: 'Nope', description: 'Absent.' }], { onExit });
+    const step: TourStep = { target: '#never', title: 'Nope', description: 'Absent.' };
+    startTour([step], { onExit });
 
-    await vi.waitFor(() => expect(onExit).toHaveBeenCalledExactlyOnceWith('target-missing'));
+    await vi.waitFor(() => expect(onExit).toHaveBeenCalledExactlyOnceWith('target-missing', step));
     expect(isActive()).toBe(false);
   });
 
@@ -428,7 +520,7 @@ describe('an ending the tour itself cannot see', () => {
 
     stop('session-ended');
 
-    expect(onExit).toHaveBeenCalledExactlyOnceWith('session-ended');
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('session-ended', undefined);
   });
 
   it('still reports the tracked reason when the caller names none', () => {
@@ -437,7 +529,7 @@ describe('an ending the tour itself cannot see', () => {
 
     clickPopoverButton('.driver-popover-close-btn');
 
-    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed');
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', undefined);
   });
 });
 

--- a/apps/web/src/features/onboarding/lib/tour-engine.test.ts
+++ b/apps/web/src/features/onboarding/lib/tour-engine.test.ts
@@ -373,6 +373,10 @@ describe('exiting', () => {
  * whereas on any other step it is one of three ways on that they chose not to
  * take. Naming the step here is what lets the caller say why the tour stopped
  * instead of leaving the screen bare, which is how this has failed three times.
+ *
+ * AND NAMING IT IS NOT ENOUGH: the engine says WHICH of the two things held the
+ * user, because the caller cannot tell from the step or from the reason, and
+ * both of those readings have already shipped as the wrong answer.
  */
 describe('the step the user could not get past', () => {
   const gated: TourStep[] = [
@@ -380,13 +384,15 @@ describe('the step the user could not get past', () => {
     { target: '#two', title: 'Done', description: 'Here it is.' },
   ];
 
+  const declined = { cause: 'action-required', step: gated[0] };
+
   it('is reported when the close button ends a gated step', () => {
     const onExit = vi.fn();
     startTour(gated, { onExit });
 
     clickPopoverButton('.driver-popover-close-btn');
 
-    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', gated[0]);
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', declined);
   });
 
   it('is reported when Escape ends one', () => {
@@ -395,7 +401,7 @@ describe('the step the user could not get past', () => {
 
     window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape', bubbles: true }));
 
-    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', gated[0]);
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', declined);
   });
 
   it('is reported when a click on the overlay ends one', async () => {
@@ -404,7 +410,7 @@ describe('the step the user could not get past', () => {
 
     await clickOverlay();
 
-    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', gated[0]);
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', declined);
   });
 
   // The overlay ends the tour through a different hook from the other two, and
@@ -422,7 +428,59 @@ describe('the step the user could not get past', () => {
 
     await clickOverlay();
 
-    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', secondIsGated[1]);
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', {
+      cause: 'action-required',
+      step: secondIsGated[1],
+    });
+  });
+
+  /**
+   * A CONTROL THAT HAS GONE IS NOT A USER WHO DECLINED, and reading it as one is
+   * the same mistake as the two before it, one level further down: the engine
+   * recorded the gate for a step whose control had unmounted, so the caller was
+   * handed "the user did not do it" for a button that was no longer there.
+   *
+   * Reachable in the product. `#symbol` is gated and lives in the new-position
+   * dialog: cancel the dialog, then close the tour, and this is the path.
+   */
+  it('classifies a gated step whose control has gone as a missing target', () => {
+    const onExit = vi.fn();
+    startTour(gated, { onExit });
+    // The dialog the control lived in, dismissed under the running tour.
+    document.querySelector('#one')!.remove();
+
+    clickPopoverButton('.driver-popover-close-btn');
+
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('target-missing', {
+      cause: 'target-missing',
+      step: gated[0],
+    });
+  });
+
+  it('classifies it the same way when Escape ends it', () => {
+    const onExit = vi.fn();
+    startTour(gated, { onExit });
+    document.querySelector('#one')!.remove();
+
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape', bubbles: true }));
+
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('target-missing', {
+      cause: 'target-missing',
+      step: gated[0],
+    });
+  });
+
+  // The gate itself is untouched by that classification, and must be: an absent
+  // control is no more pressable than a disabled one, but handing "Next" back
+  // here would advance a tour past a step the user was never shown. Only a
+  // control that is ON SCREEN and unusable releases it.
+  it('keeps the gate on a step whose control has gone', () => {
+    startTour(gated);
+    document.querySelector('#one')!.remove();
+
+    clickPopoverButton('.driver-popover-next-btn');
+
+    expect(popoverTitle()).toBe('Do it');
   });
 
   // The same test the gate itself is made of. A gated step whose control is
@@ -498,7 +556,12 @@ describe('missing targets', () => {
     // The step it gave up on comes out with the reason, and this is the only
     // moment anyone could know it: `onStepChange` never fired for it, so the
     // caller's idea of the current step is still the one before.
-    await vi.waitFor(() => expect(onExit).toHaveBeenCalledExactlyOnceWith('target-missing', step));
+    await vi.waitFor(() =>
+      expect(onExit).toHaveBeenCalledExactlyOnceWith('target-missing', {
+        cause: 'target-missing',
+        step,
+      }),
+    );
 
     expect(isActive()).toBe(false);
     // No stuck overlay, and nothing was highlighted in its place.
@@ -518,7 +581,10 @@ describe('missing targets', () => {
     advance();
 
     await vi.waitFor(() =>
-      expect(onExit).toHaveBeenCalledExactlyOnceWith('target-missing', steps[1]),
+      expect(onExit).toHaveBeenCalledExactlyOnceWith('target-missing', {
+        cause: 'target-missing',
+        step: steps[1],
+      }),
     );
   });
 
@@ -527,7 +593,12 @@ describe('missing targets', () => {
     const step: TourStep = { target: '#never', title: 'Nope', description: 'Absent.' };
     startTour([step], { onExit });
 
-    await vi.waitFor(() => expect(onExit).toHaveBeenCalledExactlyOnceWith('target-missing', step));
+    await vi.waitFor(() =>
+      expect(onExit).toHaveBeenCalledExactlyOnceWith('target-missing', {
+        cause: 'target-missing',
+        step,
+      }),
+    );
     expect(isActive()).toBe(false);
   });
 
@@ -587,6 +658,30 @@ describe('an ending the tour itself cannot see', () => {
     clickPopoverButton('.driver-popover-close-btn');
 
     expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', undefined);
+  });
+
+  /**
+   * An ending the caller named is not the user stuck on a step, so it carries no
+   * classification either — even when one has already been taken. Forwarding it
+   * would explain a walkthrough the session took away, to a user who is by then
+   * looking at the login screen.
+   *
+   * The window is real rather than theoretical: giving up on a target records
+   * the classification and defers the teardown by a tick, so a logout landing in
+   * between finds one waiting. The fake clock holds that tick open.
+   */
+  it('carries no classification for an ending the caller named', () => {
+    const onExit = vi.fn();
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      startTour([{ target: '#never', title: 'Nope', description: 'Absent.' }], { onExit });
+
+      stop('session-ended');
+
+      expect(onExit).toHaveBeenCalledExactlyOnceWith('session-ended', undefined);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/apps/web/src/features/onboarding/lib/tour-engine.test.ts
+++ b/apps/web/src/features/onboarding/lib/tour-engine.test.ts
@@ -37,6 +37,25 @@ function clickPopoverButton(selector: string): void {
   document.querySelector<HTMLButtonElement>(selector)?.click();
 }
 
+/**
+ * The third way out, and the one no test reached: clicking the dimmed page
+ * around the highlight.
+ *
+ * driver.js paints that dimming as a `<path>` inside its overlay `<svg>` and
+ * only treats a click as an overlay click when the path itself was the target,
+ * so the event has to come from there. It ends the tour through
+ * `onDestroyStarted` rather than through a popover button — a separate route
+ * into `stop()`, carrying its own step index.
+ *
+ * Awaited, unlike the popover: the overlay is painted from the animation frame
+ * that follows the highlight rather than during it, so it is the one part of a
+ * tour that is not on screen the moment `startTour` returns.
+ */
+async function clickOverlay(): Promise<void> {
+  const dimming = await vi.waitUntil(() => document.querySelector('.driver-overlay path'));
+  dimming.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+}
+
 const TWO_STEPS: TourStep[] = [
   { target: '#one', title: 'First', description: 'The first control.' },
   { target: '#two', title: 'Second', description: 'The second control.' },
@@ -314,6 +333,17 @@ describe('exiting', () => {
     expect(isActive()).toBe(false);
   });
 
+  it('reports a dismissal from a click on the overlay', async () => {
+    const onExit = vi.fn();
+    startTour(TWO_STEPS, { onExit });
+
+    await clickOverlay();
+
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', undefined);
+    expect(isActive()).toBe(false);
+    expect(document.querySelector('.driver-overlay')).toBeNull();
+  });
+
   it('reports a dismissal from Escape', () => {
     const onExit = vi.fn();
     startTour(TWO_STEPS, { onExit });
@@ -366,6 +396,33 @@ describe('the step the user could not get past', () => {
     window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape', bubbles: true }));
 
     expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', gated[0]);
+  });
+
+  it('is reported when a click on the overlay ends one', async () => {
+    const onExit = vi.fn();
+    startTour(gated, { onExit });
+
+    await clickOverlay();
+
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', gated[0]);
+  });
+
+  // The overlay ends the tour through a different hook from the other two, and
+  // that hook is handed its own step index — so this is the one place the index
+  // could be wrong without any other test noticing. Leaving the tour on step 1
+  // is what tells a read of `opts.index` apart from a hard-coded first step.
+  it('names the step the overlay click actually landed on', async () => {
+    const onExit = vi.fn();
+    const secondIsGated: TourStep[] = [
+      { target: '#one', title: 'First', description: 'The first control.' },
+      { target: '#two', title: 'Do it', description: 'Create the thing.', advanceOnAction: true },
+    ];
+    startTour(secondIsGated, { onExit });
+    advance();
+
+    await clickOverlay();
+
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', secondIsGated[1]);
   });
 
   // The same test the gate itself is made of. A gated step whose control is

--- a/apps/web/src/features/onboarding/lib/tour-engine.ts
+++ b/apps/web/src/features/onboarding/lib/tour-engine.ts
@@ -111,14 +111,35 @@ export interface TourHandlers {
    * and prepares before it calls.
    */
   onBeforeAdvance?: (index: number) => void;
-  /** Fires exactly once per tour, however it ended. */
-  onExit?: (reason: TourExitReason) => void;
+  /**
+   * Fires exactly once per tour, however it ended.
+   *
+   * `blockedAt` IS HOW THE TOUR SAYS WHY IT STOPPED, and it is the answer to a
+   * failure this walkthrough has now shipped three times: the tour vanishing
+   * with nothing on screen to explain it. It carries the step the user could
+   * not get past, and it is present only when there was one:
+   *
+   * - a step whose target never appeared, so the tour gave up on it; or
+   * - an action-gated step the user closed the tour on rather than perform,
+   *   where "Next" was inert and the close button was the only control that
+   *   answered them.
+   *
+   * Nobody outside this module can work either out. `onStepChange` never fires
+   * for a step that failed to resolve, so the caller's idea of "the current
+   * step" is the one BEFORE the failure; and whether a gate was really holding
+   * depends on whether the highlighted control was usable, which is read live
+   * here (`isGatedStep`). Absent means the tour ended without being stuck —
+   * completion, an ordinary dismissal, a session that went away.
+   */
+  onExit?: (reason: TourExitReason, blockedAt?: TourStep) => void;
 }
 
 let instance: Driver | null = null;
 let activeSteps: TourStep[] = [];
 let activeHandlers: TourHandlers = {};
 let exitReason: TourExitReason = 'dismissed';
+/** The step the tour could not get the user past — see `TourHandlers.onExit`. */
+let blockedAt: TourStep | undefined;
 let pendingStopTimer: number | undefined;
 
 function prefersReducedMotion(): boolean {
@@ -149,6 +170,7 @@ function clearState(): void {
   activeSteps = [];
   activeHandlers = {};
   exitReason = 'dismissed';
+  blockedAt = undefined;
 }
 
 /**
@@ -196,6 +218,27 @@ function isGatedStep(index: number): boolean {
 }
 
 /**
+ * Note that the user left from a step they could not move past, so the ending
+ * can be explained rather than merely happening.
+ *
+ * Called from the three paths a user turns the tour down by — Escape, the close
+ * button, the overlay — and from nowhere else. A PROGRAMMATIC `stop()` MUST NOT
+ * RECORD ONE: `startTour` ends the previous tour through it and so does the
+ * caller's own "end the walkthrough", and neither is the user failing to get
+ * past anything. Reporting those would put an explanation on screen for a tour
+ * the app itself took away, which is noise at exactly the moment the next one
+ * is starting.
+ *
+ * A gate the user could have opened is the only one worth reporting, which is
+ * why the test is `isGatedStep` rather than the step's `advanceOnAction` flag:
+ * a gated step whose control is disabled hands "Next" back, so a user leaving
+ * that one had a way on and chose not to take it.
+ */
+function recordGate(index: number): void {
+  if (isGatedStep(index)) blockedAt = activeSteps[index];
+}
+
+/**
  * THE WALKTHROUGH'S KEYBOARD CONTROLS ARE OURS, NOT DRIVER.JS'S, AND THAT IS A
  * BUG FIX.
  *
@@ -229,6 +272,7 @@ function handleKeyup(event: KeyboardEvent): void {
 
   if (event.key === 'Escape') {
     exitReason = 'dismissed';
+    recordGate(running.getActiveIndex() ?? -1);
     stop();
     return;
   }
@@ -255,6 +299,10 @@ const handleHighlightStarted: DriverHook = (element, _driveStep, opts) => {
   // rather than float a popover over nothing or drift onto a neighbour.
   if (step.target !== undefined && element === undefined) {
     exitReason = 'target-missing';
+    // The step we gave up on, kept for `onExit`: this is the ONLY moment anyone
+    // knows which one it was. `onStepChange` is not called below, so the
+    // caller's current step stays the one before this.
+    blockedAt = step;
     // Deferred by a tick on purpose: driver.js writes its own step state
     // immediately AFTER calling this hook, so tearing down from inside it would
     // resurrect the tour we just destroyed.
@@ -298,8 +346,9 @@ const handleDoneClick: DriverHook = () => {
   stop();
 };
 
-const handleCloseClick: DriverHook = () => {
+const handleCloseClick: DriverHook = (_element, _driveStep, opts) => {
   exitReason = 'dismissed';
+  recordGate(opts.index ?? -1);
   stop();
 };
 
@@ -310,7 +359,11 @@ const handleCloseClick: DriverHook = () => {
  * once per tour, whatever ended it. `stop()` uses `destroy()`, which bypasses
  * this hook, so there is no loop.
  */
-const handleDestroyStarted: DriverHook = () => {
+const handleDestroyStarted: DriverHook = (_element, _driveStep, opts) => {
+  // The overlay click reaches here and nothing else the user does, so it is a
+  // dismissal like the other two and is recorded the same way. `stop()`'s own
+  // `destroy()` bypasses this hook, so a programmatic ending never lands here.
+  recordGate(opts.index ?? -1);
   stop();
 };
 
@@ -384,12 +437,16 @@ export function stop(reason?: TourExitReason): void {
 
   const handlers = activeHandlers;
   const ending = reason ?? exitReason;
+  // Read before the teardown that clears it, for the same reason the caller
+  // reads its own step index there: this is session state, and the session is
+  // about to be gone.
+  const blocked = blockedAt;
   // Drop our state BEFORE tearing driver.js down: `instance` is null from here
   // on, so anything re-entering through a driver.js hook is a no-op rather than
   // a second exit.
   clearState();
   running.destroy();
-  handlers.onExit?.(ending);
+  handlers.onExit?.(ending, blocked);
 }
 
 /** Whether a tour is currently running. */

--- a/apps/web/src/features/onboarding/lib/tour-engine.ts
+++ b/apps/web/src/features/onboarding/lib/tour-engine.ts
@@ -82,19 +82,59 @@ export type TourExitReason =
   | 'completed'
   /**
    * The user turned the walkthrough down where it stood — close button, overlay
-   * click, or Escape. It means they did not want the tour, which is why it does
-   * NOT cover a tour that ended because the session did: the funnel exists to
-   * find where users stop, and "declined the walkthrough" and "left the app"
-   * are different answers to that question.
+   * click, or Escape — WITH A WAY ON AVAILABLE. It means they did not want the
+   * tour, which is why it does not cover a tour that ended because the session
+   * did, and why it does not cover leaving a step whose control was not on
+   * screen: the funnel exists to find where users stop, and "declined the
+   * walkthrough", "left the app" and "we pointed at nothing" are different
+   * answers to that question.
    */
   | 'dismissed'
-  /** A step's target never appeared within its `waitForMs`. */
+  /**
+   * The tour was pointing at a control that is not on screen — one that never
+   * appeared within its `waitForMs`, or one that has gone since. Both are the
+   * same thing to the user, and neither is anything they did.
+   */
   | 'target-missing'
   /**
    * The session ended under the tour — a logout, or an expiry — and took it
    * down with it. Not a judgement on the walkthrough: the user was still in it.
    */
   | 'session-ended';
+
+/**
+ * WHY THE USER COULD NOT GET PAST A STEP — the engine's own classification, and
+ * the ONLY thing a caller should explain a stop from.
+ *
+ * There are exactly two answers, and they are not interchangeable: either the
+ * control the step asks for was there and the user chose not to use it, or it
+ * was not there at all. Telling someone the first when it was the second blames
+ * them for a control that had vanished, which is this area's recurring defect
+ * one level down from where it kept being fixed.
+ *
+ * The classification carries its own step, so "which step?" cannot be answered
+ * from a different source than "why?", and a cause without a step is
+ * unrepresentable rather than merely unlikely.
+ */
+export type TourBlockCause =
+  /**
+   * The step only moves on the real action, and the control was on screen and
+   * usable — so the user had the means and did not take it.
+   */
+  | 'action-required'
+  /**
+   * The step's control is not on screen. It never resolved within `waitForMs`,
+   * or it was there when the step opened and has since unmounted — a dialog the
+   * user closed, a row that went away. Nothing was asked of the user that they
+   * could have done.
+   */
+  | 'target-missing';
+
+export interface TourBlock {
+  cause: TourBlockCause;
+  /** The step the tour could not carry the user past. */
+  step: TourStep;
+}
 
 export interface TourHandlers {
   /** Fires as each step is highlighted, before any animation. */
@@ -114,32 +154,34 @@ export interface TourHandlers {
   /**
    * Fires exactly once per tour, however it ended.
    *
-   * `blockedAt` IS HOW THE TOUR SAYS WHY IT STOPPED, and it is the answer to a
+   * `blocked` IS HOW THE TOUR SAYS WHY IT STOPPED, and it is the answer to a
    * failure this walkthrough has now shipped three times: the tour vanishing
-   * with nothing on screen to explain it. It carries the step the user could
-   * not get past, and it is present only when there was one:
+   * with nothing on screen to explain it. It names the step the user could not
+   * get past AND which of the two things held them there, together, and it is
+   * present only when there was such a step.
    *
-   * - a step whose target never appeared, so the tour gave up on it; or
-   * - an action-gated step the user closed the tour on rather than perform,
-   *   where "Next" was inert and the close button was the only control that
-   *   answered them.
+   * NOBODY OUTSIDE THIS MODULE CAN WORK EITHER OUT, WHICH IS WHY THEY ARE
+   * DECIDED HERE AND NOT RE-DERIVED THERE. `onStepChange` never fires for a step
+   * that failed to resolve, so the caller's idea of "the current step" is the
+   * one BEFORE the failure; and whether the user was really being asked for an
+   * action depends on whether the highlighted control was on screen and usable,
+   * which is read live here (`blockOn`). A caller that reconstructed the cause
+   * from the step's own `advanceOnAction` flag, or from `reason`, would be
+   * guessing at exactly the moment it must not.
    *
-   * Nobody outside this module can work either out. `onStepChange` never fires
-   * for a step that failed to resolve, so the caller's idea of "the current
-   * step" is the one BEFORE the failure; and whether a gate was really holding
-   * depends on whether the highlighted control was usable, which is read live
-   * here (`isGatedStep`). Absent means the tour ended without being stuck —
-   * completion, an ordinary dismissal, a session that went away.
+   * Absent means the tour ended without anyone being stuck — completion, an
+   * ordinary dismissal, a session that went away, an ending the app itself
+   * asked for.
    */
-  onExit?: (reason: TourExitReason, blockedAt?: TourStep) => void;
+  onExit?: (reason: TourExitReason, blocked?: TourBlock) => void;
 }
 
 let instance: Driver | null = null;
 let activeSteps: TourStep[] = [];
 let activeHandlers: TourHandlers = {};
 let exitReason: TourExitReason = 'dismissed';
-/** The step the tour could not get the user past — see `TourHandlers.onExit`. */
-let blockedAt: TourStep | undefined;
+/** Why the tour could not carry on, if it could not — see `TourHandlers.onExit`. */
+let blocked: TourBlock | undefined;
 let pendingStopTimer: number | undefined;
 
 function prefersReducedMotion(): boolean {
@@ -170,56 +212,77 @@ function clearState(): void {
   activeSteps = [];
   activeHandlers = {};
   exitReason = 'dismissed';
-  blockedAt = undefined;
+  blocked = undefined;
 }
 
 /**
- * Whether the control a step points at can be used at all right now.
+ * WHAT IS HOLDING THE USER ON THIS STEP, AND WHICH OF THE TWO THINGS IT IS —
+ * decided in ONE place, from the live DOM, so that "does 'Next' advance?" and
+ * "what do we tell the user?" can never be answers to differently-asked
+ * questions. Every previous fix in this area corrected one of those readings and
+ * left the other looking somewhere else.
  *
  * Read live rather than remembered from the highlight, because the answer
  * changes under the step: the control a user is being asked to press is often
- * disabled until they have done something else, and that something else may
- * happen while the popover is on screen.
+ * disabled until they have done something else, and it may be enabled — or gone
+ * — while the popover is still on screen.
+ *
+ * The states a gated step can be in, and nothing else:
+ *
+ * - NO CONTROL NAMED — `action-required`. A centred step gated on an action has
+ *   nothing that could be missing, so the only thing holding the user is the
+ *   action itself, which the caller reports when it lands.
+ * - NAMED BUT NOT THERE — `target-missing`. The user is not declining anything;
+ *   there is nothing on screen to decline. It is decided here rather than only
+ *   in `handleHighlightStarted` because a control can go away AFTER it resolved:
+ *   `#symbol` lives in the new-position dialog, so cancelling that dialog
+ *   unmounts the control the step is pointing at while the tour still runs on it.
+ * - THERE BUT UNUSABLE — nothing. A GATE THE USER CANNOT OPEN IS NOT A GATE, IT
+ *   IS A TRAP: the rest of the page is `pointer-events: none` under a running
+ *   tour, so a gated step whose control is disabled would leave Escape as the
+ *   only way out, and Escape ends the walkthrough rather than continuing it.
+ *   The close set reaches exactly that state — "It closes itself" highlights
+ *   Close Position, disabled until the whole entered quantity has been exited,
+ *   and the step before it advances on any exit fill, so a user who records the
+ *   PARTIAL exit it invites arrives at a control they cannot press. Returning
+ *   nothing hands them "Next", and there is then nothing to explain either: they
+ *   had a way on.
+ * - THERE AND USABLE — `action-required`. The gate holds, which is the whole
+ *   point of an action step, and a user who leaves anyway declined something
+ *   they could have done.
+ *
+ * A step with no `advanceOnAction` is never blocking: "Next" moves it, so
+ * whatever the user did, they had a way on.
  */
-function isTargetUnusable(target: string | undefined): boolean {
-  if (target === undefined) return false;
-  const element = document.querySelector(target);
-  // A target that is not there at all is `handleHighlightStarted`'s to deal
-  // with — it ends the tour. Not knowing is not the same as knowing it is dead,
-  // so the gate stands.
-  if (element === null) return false;
-  return element.matches(':disabled, [aria-disabled="true"], [data-disabled]');
+function blockOn(index: number): TourBlock | undefined {
+  const step = activeSteps[index];
+  if (step?.advanceOnAction !== true) return undefined;
+  if (step.target === undefined) return { cause: 'action-required', step };
+
+  const element = document.querySelector(step.target);
+  if (element === null) return { cause: 'target-missing', step };
+  if (element.matches(':disabled, [aria-disabled="true"], [data-disabled]')) return undefined;
+  return { cause: 'action-required', step };
 }
 
 /**
- * The one step state that decides whether "Next" (or its key) advances.
+ * Whether "Next" (or its key) is suppressed on this step.
  *
- * A GATE THE USER CANNOT OPEN IS NOT A GATE, IT IS A TRAP. Suppressing "Next"
- * is only safe while the highlighted control is one the user can actually
- * press: the rest of the page is `pointer-events: none` under a running tour,
- * so a gated step whose control is disabled leaves Escape as the only way out —
- * and Escape ends the walkthrough rather than continuing it.
- *
- * The close set reaches exactly that state. "It closes itself" highlights Close
- * Position, which is disabled until the whole entered quantity has been exited
- * ("Exit the full quantity first"), and the step before it advances on any exit
- * fill — so a user who records a PARTIAL exit, which the step before explicitly
- * invites, arrives at a control they cannot press waiting for a `closed` event
- * that will not come. Releasing the gate here hands them "Next" instead, which
- * is what a step whose action is unavailable owes them.
- *
- * It costs the happy path nothing: an enabled control keeps its gate, so the
- * step still ignores "Next" for every user who can do the thing it asks.
+ * Being blocked at all is the test, NOT which cause it is: a control that has
+ * gone is no more pressable than one that never worked, and handing "Next" back
+ * there would advance a tour whose step the user was never shown. The gate is
+ * released by exactly one state — a control that is on screen and unusable —
+ * which is `blockOn`'s to decide, so the gate and the explanation cannot come
+ * apart. It costs the happy path nothing: an enabled control keeps its gate, so
+ * the step still ignores "Next" for every user who can do the thing it asks.
  */
 function isGatedStep(index: number): boolean {
-  const step = activeSteps[index];
-  if (step?.advanceOnAction !== true) return false;
-  return !isTargetUnusable(step.target);
+  return blockOn(index) !== undefined;
 }
 
 /**
- * Note that the user left from a step they could not move past, so the ending
- * can be explained rather than merely happening.
+ * Classify the step the user left from, so the ending can be explained rather
+ * than merely happening.
  *
  * Called from the three paths a user turns the tour down by — Escape, the close
  * button, the overlay — and from nowhere else. A PROGRAMMATIC `stop()` MUST NOT
@@ -228,14 +291,9 @@ function isGatedStep(index: number): boolean {
  * past anything. Reporting those would put an explanation on screen for a tour
  * the app itself took away, which is noise at exactly the moment the next one
  * is starting.
- *
- * A gate the user could have opened is the only one worth reporting, which is
- * why the test is `isGatedStep` rather than the step's `advanceOnAction` flag:
- * a gated step whose control is disabled hands "Next" back, so a user leaving
- * that one had a way on and chose not to take it.
  */
-function recordGate(index: number): void {
-  if (isGatedStep(index)) blockedAt = activeSteps[index];
+function recordBlock(index: number): void {
+  blocked = blockOn(index);
 }
 
 /**
@@ -272,7 +330,7 @@ function handleKeyup(event: KeyboardEvent): void {
 
   if (event.key === 'Escape') {
     exitReason = 'dismissed';
-    recordGate(running.getActiveIndex() ?? -1);
+    recordBlock(running.getActiveIndex() ?? -1);
     stop();
     return;
   }
@@ -298,11 +356,12 @@ const handleHighlightStarted: DriverHook = (element, _driveStep, opts) => {
   // target that means the `waitForElement` window expired, so end the tour
   // rather than float a popover over nothing or drift onto a neighbour.
   if (step.target !== undefined && element === undefined) {
-    exitReason = 'target-missing';
-    // The step we gave up on, kept for `onExit`: this is the ONLY moment anyone
-    // knows which one it was. `onStepChange` is not called below, so the
-    // caller's current step stays the one before this.
-    blockedAt = step;
+    // The step we gave up on and why, kept for `onExit`: this is the ONLY moment
+    // anyone knows which one it was. `onStepChange` is not called below, so the
+    // caller's current step stays the one before this. The reason reported to
+    // the caller is derived from this in `stop()` rather than set beside it —
+    // one value, so the two cannot disagree.
+    blocked = { cause: 'target-missing', step };
     // Deferred by a tick on purpose: driver.js writes its own step state
     // immediately AFTER calling this hook, so tearing down from inside it would
     // resurrect the tour we just destroyed.
@@ -348,7 +407,7 @@ const handleDoneClick: DriverHook = () => {
 
 const handleCloseClick: DriverHook = (_element, _driveStep, opts) => {
   exitReason = 'dismissed';
-  recordGate(opts.index ?? -1);
+  recordBlock(opts.index ?? -1);
   stop();
 };
 
@@ -363,7 +422,7 @@ const handleDestroyStarted: DriverHook = (_element, _driveStep, opts) => {
   // The overlay click reaches here and nothing else the user does, so it is a
   // dismissal like the other two and is recorded the same way. `stop()`'s own
   // `destroy()` bypasses this hook, so a programmatic ending never lands here.
-  recordGate(opts.index ?? -1);
+  recordBlock(opts.index ?? -1);
   stop();
 };
 
@@ -378,6 +437,7 @@ export function startTour(steps: TourStep[], handlers: TourHandlers = {}): void 
   activeSteps = steps;
   activeHandlers = handlers;
   exitReason = 'dismissed';
+  blocked = undefined;
 
   instance = driver({
     steps: steps.map(toDriveStep),
@@ -436,17 +496,25 @@ export function stop(reason?: TourExitReason): void {
   if (!running) return;
 
   const handlers = activeHandlers;
-  const ending = reason ?? exitReason;
-  // Read before the teardown that clears it, for the same reason the caller
-  // reads its own step index there: this is session state, and the session is
-  // about to be gone.
-  const blocked = blockedAt;
+  // A CALLER-NAMED ENDING CARRIES NO CLASSIFICATION. The tour did not stop
+  // because the user was stuck on a step — the session went away under it, or
+  // the app took it down — so there is nothing for the caller to explain and no
+  // step to name. Forwarding one would put "you did not do this" on screen for a
+  // user who was logged out mid-step.
+  const block = reason === undefined ? blocked : undefined;
+  // ONE VALUE ANSWERS BOTH QUESTIONS, WHICH IS WHY THE REASON IS DERIVED HERE
+  // AND NOT TRACKED BESIDE THE CLASSIFICATION. A tour that stopped because the
+  // control it was pointing at was not on screen ended on the missing target,
+  // whichever way the user got out of it — reporting that as a dismissal is what
+  // let the caller call an absent control a decision the user made. Read before
+  // the teardown that clears it, like the caller's own step index.
+  const ending = reason ?? (block?.cause === 'target-missing' ? 'target-missing' : exitReason);
   // Drop our state BEFORE tearing driver.js down: `instance` is null from here
   // on, so anything re-entering through a driver.js hook is a no-op rather than
   // a second exit.
   clearState();
   running.destroy();
-  handlers.onExit?.(ending, blocked);
+  handlers.onExit?.(ending, block);
 }
 
 /** Whether a tour is currently running. */


### PR DESCRIPTION
The walkthrough could stop and say nothing.

The position and close step sets each contain a step that only advances when the user
performs the real action — creating a position, or recording an exit fill. Someone
replaying such a set from the activation checklist who did not want to place another
trade would back out, and the tour simply vanished: popover and overlay gone, no
explanation, nothing on screen.

That silent stop had already shipped from two other causes — a set leaving the user on
the wrong route, and a control unmounting mid-tour. The recurrence was the real problem:
the tour had no general answer for "I cannot continue", so every new cause produced the
same silent disappearance.

Replaying a set still requires the real action. The tour teaches by doing, and that is
deliberate. What changes is that stopping is always explained.

## What it looks like now

The engine classifies why it could not continue and names the step it could not get past.
Two causes, two honest messages:

- **The step needs you to do the thing** — `"Record the exit" only moves on once you have
  actually done it, so the walkthrough cannot take that step for you.`
- **The step's control is not there** — `"Record the exit" is not on screen, so the
  walkthrough could not carry on from there.`

An ordinary dismissal, a completed tour, and a session ending all stay silent, as before.

## Two rounds of getting this wrong, and what finally fixed it

Worth recording, because both mistakes were the same shape and neither was visible from
reading the code.

The first attempt chose its wording from whether the step was action-gated, ignoring the
reason it already had. So a step whose control never appeared told the user they had
failed to do something — blaming a person for a UI failure. Reachable in practice: a set
entered cold exits before the position has loaded.

The second attempt branched on the reason instead. But the reason itself was wrong: the
check for an unusable target returned false for an element that was simply *absent*, so
an unmounted control still reported as a user dismissal and produced the same false
blame. Reachable by cancelling the New Position dialog and then closing the tour.

Each round corrected one input to the message and left another wrong. What closed it was
making the bad state unrepresentable rather than fixing a third instance: cause and step
are now a single value, decided in one place from one live-DOM read, so "which step"
cannot come from a different source than "why". The wording is an exhaustive switch over
that value with no default — a new cause is a compile error, not a wrong message.

## Coverage

The tests that mattered here are the ones that drive the real engine rather than a
double, because every defect above survived tests that used a double.

Also fixed: three "no notice appears" assertions queried synchronously and passed even
when a notice *was* raised — they asserted nothing. They now fail when a notice is
raised, verified by raising one on each silent path. A silence test that cannot fail is
worse than no test.

Every change was proved by deliberate breakage — reverted, watched to fail, restored.
476 onboarding tests pass after rebasing onto current main; typecheck and lint clean.
