### PR TITLE
fix(web): make the session-expired notice actually render

### DIFF
--- a/apps/web/src/hooks/useAuth.expiry.test.ts
+++ b/apps/web/src/hooks/useAuth.expiry.test.ts
@@ -201,7 +201,7 @@ describe('a session expiring, and what the remounts afterwards may do', () => {
     expect(interceptNavigate).toHaveBeenCalledTimes(1);
     expect(interceptNavigate).toHaveBeenCalledWith({
       to: '/login',
-      search: { expired: 'true' },
+      search: { expired: true },
       replace: true,
     });
   });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -252,7 +252,13 @@ async function request<T>(
     // it belongs to is still on screen.
     announceSessionExpired();
     if (router) {
-      router.navigate({ to: '/login', search: { expired: 'true' }, replace: true });
+      // A BOOLEAN, not the string 'true'. The router JSON-encodes any string
+      // value that is itself parseable JSON, so `'true'` reaches the address bar
+      // as `?expired=%22true%22` — quotes and all — and /login, which reads the
+      // raw query, matched none of it. A boolean is written through bare, so
+      // this navigation lands on the same `?expired=true` as the two hard
+      // navigations below and in the CSV preview's own 401 handling.
+      router.navigate({ to: '/login', search: { expired: true }, replace: true });
     } else {
       window.location.href = '/login?expired=true';
     }

--- a/apps/web/src/lib/telemetry/posthog.test.ts
+++ b/apps/web/src/lib/telemetry/posthog.test.ts
@@ -236,13 +236,13 @@ describe('scrubEvent', () => {
 
     const out = scrubEvent({
       properties: {
-        $current_url: 'https://app.tradr.io/login?expired=%22true%22',
+        $current_url: 'https://app.tradr.io/login?expired=true',
       } as Record<string, unknown>,
     });
 
     // Query strings carry real analytics signal and no route puts a secret in
     // one (REQ-3.9), so they are deliberately kept.
-    expect(out!.properties!.$current_url).toBe('https://app.tradr.io/login?expired=%22true%22');
+    expect(out!.properties!.$current_url).toBe('https://app.tradr.io/login?expired=true');
   });
 
   it('drops referrers even when no route has resolved', async () => {

--- a/apps/web/src/routes/__tests__/session-expiry-notice.test.tsx
+++ b/apps/web/src/routes/__tests__/session-expiry-notice.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  createBrowserHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from '@tanstack/react-router';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+
+import { api, markSessionEnded, markSessionStarted, setRouter } from '@/lib/api';
+
+import { Route as LoginRoute } from '../login';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const NOTICE = 'Session expired. Please log in again.';
+
+// THE WRITER AND THE READER, IN ONE PASS.
+//
+// The notice is a handshake between two files that never see each other:
+// lib/api's 401 interception writes the `expired` search param onto /login, and
+// login.tsx reads it back off the URL. Neither looks wrong alone, and the pair
+// was broken for its whole life — the router serializes a STRING value as JSON,
+// so `search: { expired: 'true' }` reached the address bar as
+// `?expired=%22true%22`, and the page's `=== 'true'` never matched. A user
+// thrown out mid-task got a bare login form and no explanation.
+//
+// So nothing here hands the login page a hand-written query string: the URL
+// under assertion is the one the real interception produces, and the notice
+// under assertion is what the real page makes of that URL. Break either side
+// and this fails.
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function buildRouter() {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> });
+
+  const login = createRoute({
+    getParentRoute: () => rootRoute as any,
+    path: '/login',
+    component: (LoginRoute.options as any).component,
+  });
+  // The login form links to both; they only need to exist for the links to build.
+  const register = createRoute({
+    getParentRoute: () => rootRoute as any,
+    path: '/register',
+    component: () => null,
+  });
+  const forgotPassword = createRoute({
+    getParentRoute: () => rootRoute as any,
+    path: '/forgot-password',
+    component: () => null,
+  });
+  const dashboard = createRoute({
+    getParentRoute: () => rootRoute as any,
+    path: '/dashboard',
+    component: () => <div>dashboard-stub</div>,
+  });
+
+  const routeTree = rootRoute.addChildren([login, register, forgotPassword, dashboard]);
+
+  // A BROWSER history, not a memory one: login.tsx reads window.location, and a
+  // memory history would leave it untouched — the page would then miss a notice
+  // it shows perfectly well in a browser, or show one for a URL the browser
+  // never had. main.tsx builds the real router this way too (the default).
+  return createRouter({ routeTree: routeTree as any, history: createBrowserHistory() });
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+let fetchSpy: MockInstance;
+
+beforeEach(() => {
+  window.history.replaceState(null, '', '/dashboard');
+
+  // lib/api's latch and session flag are module-scoped, and a fresh page load is
+  // what normally resets them; this pair is that reset through its own exports.
+  markSessionStarted();
+  markSessionEnded();
+
+  fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  fetchSpy.mockRestore();
+  setRouter(null);
+  markSessionEnded();
+  window.history.replaceState(null, '', '/');
+});
+
+describe('a session that expires says so on the login page', () => {
+  it('redirects to a URL the login page reads as expiry, and shows the notice', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const router = buildRouter();
+    // main.tsx hands the real router to lib/api; same here, or the interception
+    // would assign window.location instead of navigating.
+    setRouter(router);
+    render(
+      <QueryClientProvider client={qc}>
+        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+        <RouterProvider router={router as any} />
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByText('dashboard-stub')).toBeTruthy();
+
+    // A session the server has confirmed, then a request that finds it gone —
+    // the ordinary way an expiry is discovered.
+    markSessionStarted();
+    await act(async () => {
+      await api.get('/positions').catch(() => undefined);
+    });
+
+    // What the address bar actually holds. Written by the interception, and the
+    // only input the page gets.
+    expect(window.location.pathname).toBe('/login');
+    expect(window.location.search).toBe('?expired=true');
+
+    // And what the page makes of it.
+    expect(await screen.findByText(NOTICE)).toBeTruthy();
+  });
+
+  it('shows nothing on a /login the expiry did not send anyone to', async () => {
+    // The other half of the pair: the notice belongs to a session that ended,
+    // not to every visit to the login page.
+    window.history.replaceState(null, '', '/login');
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const router = buildRouter();
+    setRouter(router);
+    render(
+      <QueryClientProvider client={qc}>
+        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+        <RouterProvider router={router as any} />
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByText('Log in', { selector: '[data-slot="card-title"]' }),
+    ).toBeTruthy();
+    expect(screen.queryByText(NOTICE)).toBeNull();
+  });
+});


### PR DESCRIPTION
A user whose session actually expires is redirected to the login page and told nothing.

The 401 interception redirected with `router.navigate({ search: { expired: 'true' } })`.
The router serializes that value as a JSON string, so the URL came out
`/login?expired=%22true%22` — with literal quotes — while the login page compared the
parameter against the bare string `'true'`. The comparison could never be true, so the
notice explaining why someone had just been signed out never rendered.

The notice exists for exactly that moment: you are working, your session ends, and you
land on a login screen. As far as I can tell it had never fired.

## Why the writer was corrected rather than the reader

There are three writers of this parameter, not one:

- the router navigation in `api.ts`
- the routerless `window.location.href` fallback beside it, for when no router is available
- `useCsvPreview.ts`

Only the router navigation was producing the quoted form; both hard navigations already
emitted a bare `?expired=true`. Correcting the *reader* to accept `"true"` would
therefore have matched the router and broken the other two — and a cold page load from a
hard navigation delivers the value as a raw string, which could never parse as a
JSON-quoted one.

Passing a boolean instead survives the router's serializer untouched, so all three
writers now land on the same URL and the single reader stays correct for all of them.

## The coverage binds the two sides together

This bug survived because the writer and the reader live in different files and neither
looked wrong on its own. A test that hands the login page a hand-written query string and
checks the banner appears would have passed throughout — so that is deliberately not what
this adds.

The new test asserts the `window.location.search` the interception actually produces, then
asserts the notice the login page renders from exactly that URL. Nothing in it is
hand-written. Mutating only the writer fails it; mutating only the reader fails it. It
fails against the original bug, which is the test that matters.

## One fixture had enshrined the bug

A PostHog test fixture hardcoded `?expired=%22true%22` as its expected URL. The broken
output had been observed and copied in as truth, which is a good part of why this stayed
invisible for so long. Corrected here; nothing else in the tree encodes the quoted form.

## Known limitation

The two hard-navigation writers are still not bound by a test — a mutation there would go
uncaught. They are correct today and were correct before this change, so closing that gap
is left as separate work rather than widened into this one.

## Verification

Reproduced end to end first: a real 401 driven through the real interception into the real
login route put the address bar at `/login?expired=%22true%22` with no notice anywhere in
the DOM. It now reads `/login?expired=true` and renders "Session expired. Please log in
again."

564 web tests across routes, lib and hooks pass, plus 160 in csv-import; typecheck clean;
eslint clean.
