### PR TITLE
feat(onboarding): keep the walkthrough reachable after onboarding ends

### DIFF
--- a/apps/web/src/features/accounts/components/AccountList.tsx
+++ b/apps/web/src/features/accounts/components/AccountList.tsx
@@ -94,7 +94,13 @@ export function AccountList() {
     <>
       <div className="mb-4 flex items-center justify-between">
         <h1 className="text-2xl font-bold">Accounts</h1>
-        <Button className="cursor-pointer" onClick={beginCreate}>
+        {/* The walkthrough's account set opens here, so this button is its first
+            step's anchor — the same `data-tour` contract the positions list and
+            the account dialog already use. It is the one control that starts a
+            second account, and unlike the dashboard's welcome screen it is on
+            this page for every user, which is what lets that set run more than
+            once. */}
+        <Button className="cursor-pointer" data-tour="account-new" onClick={beginCreate}>
           New Account
         </Button>
       </div>

--- a/apps/web/src/features/accounts/hooks/useAccounts.ts
+++ b/apps/web/src/features/accounts/hooks/useAccounts.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 import type {
@@ -28,14 +28,28 @@ export function getAccountErrorCode(err: unknown): string | undefined {
 }
 
 /**
+ * The list as a query DEFINITION rather than a subscription.
+ *
+ * `useAccounts` is built on it, so a caller that needs the list ONCE — in
+ * response to a click, without mounting a hook that would fetch on render —
+ * reads the same cache entry through the same fetcher rather than a second copy
+ * of the key that could drift from this one.
+ */
+export function accountsListQuery() {
+  return queryOptions({
+    queryKey: ['accounts', 'list'],
+    queryFn: () => api.get<Account[]>('/accounts'),
+  });
+}
+
+/**
  * `options.enabled` lets a caller that may not need the list at all skip the
  * request entirely; omitted, it fetches as before. A disabled query reports
  * `data: undefined`, `isLoading: false` and `isError: false`.
  */
 export function useAccounts(options?: { enabled?: boolean }) {
-  return useQuery<Account[]>({
-    queryKey: ['accounts', 'list'],
-    queryFn: () => api.get<Account[]>('/accounts'),
+  return useQuery({
+    ...accountsListQuery(),
     enabled: options?.enabled,
   });
 }

--- a/apps/web/src/features/onboarding/components/WalkthroughLauncher.test.tsx
+++ b/apps/web/src/features/onboarding/components/WalkthroughLauncher.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+//
+// THE CLAIM UNDER TEST IS "PERMANENT". The activation checklist retires when
+// all four items are complete, and it must — the `status: 'done'` write it makes
+// is what switches the two expensive onboarding reads off. This card is what a
+// user has left afterwards, so the tests below are written from the seat of a
+// user whose checklist has already gone: all four sets are still offered, they
+// still start, and reaching them costs the server nothing and changes nothing.
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { OnboardingState } from '@tradr/shared';
+
+import { api } from '@/lib/api';
+
+import { __resetWalkthroughForTests, useWalkthroughStore } from '../hooks/useWalkthrough';
+import { WALKTHROUGH_STEPS, type WalkthroughStep } from '../lib/steps';
+import type { TourHandlers } from '../lib/tour-engine';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const navigate = vi.fn();
+vi.mock('@tanstack/react-router', () => ({ useNavigate: () => navigate }));
+
+// Only the one call that would put an overlay on screen is a double; the rest of
+// the engine is real, so the launcher is driving the same runtime the checklist
+// drives.
+const startTour = vi.fn();
+vi.mock('../lib/tour-engine', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../lib/tour-engine')>();
+  return {
+    ...real,
+    startTour: (steps: WalkthroughStep[], handlers?: TourHandlers) => startTour(steps, handlers),
+  };
+});
+
+import { WalkthroughLauncher } from './WalkthroughLauncher';
+
+/**
+ * A retired user, as the server would report them. Nothing below should ever
+ * ask for it — that is the point of case 2 — but a spy that answers correctly is
+ * the honest way to prove the question was never put.
+ */
+const RETIRED: OnboardingState = { status: 'done', coachMarksSeen: [] };
+
+function renderLauncher() {
+  const get = vi.spyOn(api, 'get').mockImplementation((path: string) => {
+    if (path === '/users/me/onboarding') return Promise.resolve(RETIRED) as never;
+    if (path === '/accounts' || path === '/positions') return Promise.resolve([]) as never;
+    return Promise.reject(new Error(`unexpected GET ${path}`)) as never;
+  });
+  const patch = vi.spyOn(api, 'patch').mockResolvedValue(RETIRED as never);
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={qc}>
+      <WalkthroughLauncher />
+    </QueryClientProvider>,
+  );
+  return { get, patch };
+}
+
+afterEach(() => {
+  cleanup();
+  __resetWalkthroughForTests();
+  vi.restoreAllMocks();
+  navigate.mockReset();
+  startTour.mockReset();
+});
+
+describe('WalkthroughLauncher — the entry point that outlives the checklist', () => {
+  it('offers all four sets, in the checklist order, to a user who has retired', () => {
+    renderLauncher();
+
+    const rows = [...document.querySelectorAll('[data-walkthrough-set]')];
+    expect(rows.map((el) => el.getAttribute('data-walkthrough-set'))).toEqual([
+      'account',
+      'calculator',
+      'position',
+      'close',
+    ]);
+    // Named, not just present: four buttons all reading "Start" would be four
+    // unnamed controls to a screen reader.
+    expect(screen.getByRole('button', { name: 'Start walkthrough: Log a position' })).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'Start walkthrough: Close it and see the stats' }),
+    ).toBeTruthy();
+  });
+
+  it('asks the server nothing — the retired user’s read gate stays shut', async () => {
+    const { get, patch } = renderLauncher();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Start walkthrough: Size a trade in the calculator' }),
+    );
+    await waitFor(() => expect(startTour).toHaveBeenCalled());
+
+    // Not "no expensive read" but no read AT ALL, including the cheap
+    // preference one. The card offers every set to everybody, so it has no
+    // question to put — and a version of it built on a hook that reads
+    // onboarding state would fail here, which is exactly what this pins.
+    expect(get).not.toHaveBeenCalled();
+    // And no write. The other two doors into the walkthrough record the opt-in
+    // with `status: 'active'`; doing that here would un-retire the user — both
+    // gated reads back on, and the checklist back on their dashboard — for
+    // asking to see a walkthrough again.
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it('starts the set that was asked for, and navigates to where it opens', async () => {
+    renderLauncher();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Start walkthrough: Log a position' }),
+    );
+
+    await waitFor(() => expect(startTour).toHaveBeenCalledTimes(1));
+    const [steps] = startTour.mock.calls[0] as [WalkthroughStep[]];
+    expect(steps.map((step) => step.title)).toEqual(
+      WALKTHROUGH_STEPS.position.map((step) => step.title),
+    );
+    expect(useWalkthroughStore.getState().itemId).toBe('position');
+    // The position set opens on `/positions`, and the user pressed this from
+    // Settings — so the launcher is what has to get them there.
+    expect(navigate).toHaveBeenCalledWith({ to: '/positions' });
+  });
+
+  it('offers the two action-gated sets on the same terms as the rest', async () => {
+    renderLauncher();
+
+    // `close` is the set the checklist withholds unless the user has an open
+    // position of their own, because it opens on one. This card cannot know
+    // that and does not ask: it starts the set, and a set that then cannot
+    // carry on says so itself.
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Start walkthrough: Close it and see the stats' }),
+    );
+
+    await waitFor(() => expect(startTour).toHaveBeenCalledTimes(1));
+    expect(useWalkthroughStore.getState().itemId).toBe('close');
+  });
+
+  it('withdraws the buttons, with a reason, when the tour runtime will not load', () => {
+    useWalkthroughStore.setState({ isUnavailable: true });
+    renderLauncher();
+
+    for (const button of screen.getAllByRole('button')) {
+      expect((button as HTMLButtonElement).disabled).toBe(true);
+    }
+    expect(screen.getByTestId('walkthrough-launcher-unavailable')).toBeTruthy();
+  });
+});

--- a/apps/web/src/features/onboarding/components/WalkthroughLauncher.test.tsx
+++ b/apps/web/src/features/onboarding/components/WalkthroughLauncher.test.tsx
@@ -4,15 +4,18 @@
 // all four items are complete, and it must — the `status: 'done'` write it makes
 // is what switches the two expensive onboarding reads off. This card is what a
 // user has left afterwards, so the tests below are written from the seat of a
-// user whose checklist has already gone: all four sets are still offered, they
-// still start, and reaching them costs the server nothing and changes nothing.
+// user whose checklist has already gone: all four sets are still offered, the
+// ones that can run do, the ones that cannot say so, and rendering the card
+// costs the server nothing and changes nothing.
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { toast } from 'sonner';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { OnboardingState } from '@tradr/shared';
 
+import { Toaster } from '@/components/ui/sonner';
 import { api } from '@/lib/api';
 
 import { __resetWalkthroughForTests, useWalkthroughStore } from '../hooks/useWalkthrough';
@@ -40,15 +43,30 @@ import { WalkthroughLauncher } from './WalkthroughLauncher';
 
 /**
  * A retired user, as the server would report them. Nothing below should ever
- * ask for it — that is the point of case 2 — but a spy that answers correctly is
- * the honest way to prove the question was never put.
+ * ask for it — that is the point of the read-gate case — but a spy that answers
+ * correctly is the honest way to prove the question was never put.
  */
 const RETIRED: OnboardingState = { status: 'done', coachMarksSeen: [] };
 
-function renderLauncher() {
+/** An account the user made, and one open position booked against it. */
+const OWN_ACCOUNT = { id: 'acct-own', isDemo: false };
+const OWN_OPEN = { id: 'pos-own', accountId: 'acct-own', status: 'open' };
+
+/**
+ * The card, with the two lists the server would answer with. They are supplied
+ * per test because what the user HAS is the whole question three of these sets
+ * turn on.
+ */
+function renderLauncher(
+  data: { accounts?: unknown[]; positions?: unknown[] } = {
+    accounts: [OWN_ACCOUNT],
+    positions: [OWN_OPEN],
+  },
+) {
   const get = vi.spyOn(api, 'get').mockImplementation((path: string) => {
     if (path === '/users/me/onboarding') return Promise.resolve(RETIRED) as never;
-    if (path === '/accounts' || path === '/positions') return Promise.resolve([]) as never;
+    if (path === '/accounts') return Promise.resolve(data.accounts ?? []) as never;
+    if (path === '/positions') return Promise.resolve(data.positions ?? []) as never;
     return Promise.reject(new Error(`unexpected GET ${path}`)) as never;
   });
   const patch = vi.spyOn(api, 'patch').mockResolvedValue(RETIRED as never);
@@ -58,12 +76,20 @@ function renderLauncher() {
   render(
     <QueryClientProvider client={qc}>
       <WalkthroughLauncher />
+      <Toaster />
     </QueryClientProvider>,
   );
   return { get, patch };
 }
 
+function startSet(label: string) {
+  return userEvent.click(screen.getByRole('button', { name: `Start walkthrough: ${label}` }));
+}
+
 afterEach(() => {
+  // sonner's queue is module-scoped, so a notice raised in one test would still
+  // be there for the next one's toaster to render.
+  toast.dismiss();
   cleanup();
   __resetWalkthroughForTests();
   vi.restoreAllMocks();
@@ -90,18 +116,14 @@ describe('WalkthroughLauncher — the entry point that outlives the checklist', 
     ).toBeTruthy();
   });
 
-  it('asks the server nothing — the retired user’s read gate stays shut', async () => {
+  it('asks the server nothing to render — the retired user’s read gate stays shut', async () => {
     const { get, patch } = renderLauncher();
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Start walkthrough: Size a trade in the calculator' }),
-    );
-    await waitFor(() => expect(startTour).toHaveBeenCalled());
-
-    // Not "no expensive read" but no read AT ALL, including the cheap
-    // preference one. The card offers every set to everybody, so it has no
-    // question to put — and a version of it built on a hook that reads
-    // onboarding state would fail here, which is exactly what this pins.
+    // Not "no expensive read" but no read AT ALL, including the cheap preference
+    // one. Mounting the card puts no question to the server, which is what lets
+    // it live on an ordinary settings screen; a version built on a hook that
+    // reads onboarding state would fail here.
+    await waitFor(() => expect(screen.getByTestId('walkthrough-launcher')).toBeTruthy());
     expect(get).not.toHaveBeenCalled();
     // And no write. The other two doors into the walkthrough record the opt-in
     // with `status: 'active'`; doing that here would un-retire the user — both
@@ -113,9 +135,7 @@ describe('WalkthroughLauncher — the entry point that outlives the checklist', 
   it('starts the set that was asked for, and navigates to where it opens', async () => {
     renderLauncher();
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Start walkthrough: Log a position' }),
-    );
+    await startSet('Log a position');
 
     await waitFor(() => expect(startTour).toHaveBeenCalledTimes(1));
     const [steps] = startTour.mock.calls[0] as [WalkthroughStep[]];
@@ -128,19 +148,89 @@ describe('WalkthroughLauncher — the entry point that outlives the checklist', 
     expect(navigate).toHaveBeenCalledWith({ to: '/positions' });
   });
 
-  it('offers the two action-gated sets on the same terms as the rest', async () => {
+  /**
+   * THE SET THAT OPENS ON A POSITION GETS ONE, WHICH IS THE WHOLE OF THIS FIX.
+   *
+   * `close` starts on `/positions/$positionId`, and nobody pressing a button in
+   * Settings can name that row. Without an id the set navigated nowhere, waited
+   * out its first step against a screen that has none of its controls, and
+   * disappeared — a button that did nothing. The checklist path had already
+   * solved this by falling back to the user's own most recently touched open
+   * position; this reads the same lists to answer the same question, only from
+   * the click rather than from a mounted hook.
+   */
+  it('opens the close set on the user’s own open position', async () => {
     renderLauncher();
 
-    // `close` is the set the checklist withholds unless the user has an open
-    // position of their own, because it opens on one. This card cannot know
-    // that and does not ask: it starts the set, and a set that then cannot
-    // carry on says so itself.
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Start walkthrough: Close it and see the stats' }),
-    );
+    await startSet('Close it and see the stats');
 
     await waitFor(() => expect(startTour).toHaveBeenCalledTimes(1));
     expect(useWalkthroughStore.getState().itemId).toBe('close');
+    expect(navigate).toHaveBeenCalledWith({
+      to: '/positions/$positionId',
+      params: { positionId: OWN_OPEN.id },
+    });
+  });
+
+  /**
+   * The sample account's rows are not the user's, on the checklist's own terms —
+   * `selectOwnRows`. Closing one of the fixture's positions would teach the right
+   * gesture and tick nothing, so the set is refused rather than run over data the
+   * user did not create.
+   */
+  it('will not open the close set on the sample account’s position', async () => {
+    renderLauncher({
+      accounts: [{ id: 'acct-demo', isDemo: true }],
+      positions: [{ id: 'pos-demo', accountId: 'acct-demo', status: 'open' }],
+    });
+
+    await startSet('Close it and see the stats');
+
+    expect(await screen.findByText('That walkthrough cannot start yet')).toBeTruthy();
+    expect(startTour).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  /**
+   * A SET THAT CANNOT BEGIN SAYS SO, AND SAYS SOMETHING TRUE.
+   *
+   * The account set is a tour of the zero-state, which the dashboard renders only
+   * while the user has no accounts — so for the retired user this card exists for
+   * it has no first step to show. It used to navigate them off Settings to a
+   * dashboard that showed nothing and then tell them to go back to the setup
+   * checklist, the one surface that has certainly retired.
+   */
+  it('explains the account set instead of walking a settled user into nothing', async () => {
+    renderLauncher();
+
+    await startSet('Create a brokerage account');
+
+    const notice = await screen.findByText('That walkthrough cannot start yet');
+    expect(notice).toBeTruthy();
+    const why = await screen.findByText(/tour of the welcome screen/);
+    expect(why.textContent).toContain('Accounts in the sidebar');
+    // The remedy names somewhere that still exists for this user.
+    expect(why.textContent).not.toContain('checklist');
+    // Nothing started, and — the other half of the complaint — the user is still
+    // where they pressed the button.
+    expect(startTour).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The click may read the two lists, because the user asked for a walkthrough
+   * and one of the sets opens on a row only those lists can name. It must not
+   * reach for the onboarding PREFERENCE: that is the value the retirement gate is
+   * keyed on, and this card must never have an opinion about it.
+   */
+  it('reads only the two lists when a set is started, and never the preference', async () => {
+    const { get, patch } = renderLauncher();
+
+    await startSet('Size a trade in the calculator');
+    await waitFor(() => expect(startTour).toHaveBeenCalled());
+
+    expect(get.mock.calls.map(([path]) => path).sort()).toEqual(['/accounts', '/positions']);
+    expect(patch).not.toHaveBeenCalled();
   });
 
   it('withdraws the buttons, with a reason, when the tour runtime will not load', () => {

--- a/apps/web/src/features/onboarding/components/WalkthroughLauncher.test.tsx
+++ b/apps/web/src/features/onboarding/components/WalkthroughLauncher.test.tsx
@@ -51,17 +51,26 @@ const RETIRED: OnboardingState = { status: 'done', coachMarksSeen: [] };
 /** An account the user made, and one open position booked against it. */
 const OWN_ACCOUNT = { id: 'acct-own', isDemo: false };
 const OWN_OPEN = { id: 'pos-own', accountId: 'acct-own', status: 'open' };
+const OWN_CLOSED = { id: 'pos-done', accountId: 'acct-own', status: 'closed' };
 
 /**
- * The card, with the two lists the server would answer with. They are supplied
- * per test because what the user HAS is the whole question three of these sets
- * turn on.
+ * The card, with the two lists the server would answer with. `data` is read on
+ * every request rather than captured, so a test can change what the server says
+ * BETWEEN clicks — which is the only way to ask whether the second click looked.
+ *
+ * `gcTime` is a parameter for the same reason. Zero — drop a query the moment
+ * nothing is observing it — is the convenient default for a test, but it is not
+ * the app's (`lib/queryClient.ts` takes the library's five minutes), and it
+ * would quietly hide the defect the stale-read test exists to catch: an entry
+ * that has been collected has to be fetched again by anyone, however they ask
+ * for it.
  */
 function renderLauncher(
   data: { accounts?: unknown[]; positions?: unknown[] } = {
     accounts: [OWN_ACCOUNT],
     positions: [OWN_OPEN],
   },
+  { gcTime = 0 }: { gcTime?: number } = {},
 ) {
   const get = vi.spyOn(api, 'get').mockImplementation((path: string) => {
     if (path === '/users/me/onboarding') return Promise.resolve(RETIRED) as never;
@@ -71,7 +80,7 @@ function renderLauncher(
   });
   const patch = vi.spyOn(api, 'patch').mockResolvedValue(RETIRED as never);
   const qc = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    defaultOptions: { queries: { retry: false, gcTime }, mutations: { retry: false } },
   });
   render(
     <QueryClientProvider client={qc}>
@@ -79,7 +88,7 @@ function renderLauncher(
       <Toaster />
     </QueryClientProvider>,
   );
-  return { get, patch };
+  return { get, patch, qc };
 }
 
 function startSet(label: string) {
@@ -192,29 +201,30 @@ describe('WalkthroughLauncher — the entry point that outlives the checklist', 
   });
 
   /**
-   * A SET THAT CANNOT BEGIN SAYS SO, AND SAYS SOMETHING TRUE.
+   * THE FOURTH SET RUNS, WHICH IS THE POINT OF A CARD THAT OFFERS FOUR.
    *
-   * The account set is a tour of the zero-state, which the dashboard renders only
-   * while the user has no accounts — so for the retired user this card exists for
-   * it has no first step to show. It used to navigate them off Settings to a
-   * dashboard that showed nothing and then tell them to go back to the setup
-   * checklist, the one surface that has certainly retired.
+   * The account set used to be a tour of the dashboard's welcome screen — a
+   * screen the retired user this card exists for passed months ago — so from
+   * here it could only ever explain why it would not start. It now opens on the
+   * Accounts page's "New Account", which is on that page for every user and is
+   * where a second account is genuinely made, so the walkthrough about creating
+   * an account can be watched by someone who has already created one.
    */
-  it('explains the account set instead of walking a settled user into nothing', async () => {
+  it('runs the account set for a user who already has accounts', async () => {
     renderLauncher();
 
     await startSet('Create a brokerage account');
 
-    const notice = await screen.findByText('That walkthrough cannot start yet');
-    expect(notice).toBeTruthy();
-    const why = await screen.findByText(/tour of the welcome screen/);
-    expect(why.textContent).toContain('Accounts in the sidebar');
-    // The remedy names somewhere that still exists for this user.
-    expect(why.textContent).not.toContain('checklist');
-    // Nothing started, and — the other half of the complaint — the user is still
-    // where they pressed the button.
-    expect(startTour).not.toHaveBeenCalled();
-    expect(navigate).not.toHaveBeenCalled();
+    await waitFor(() => expect(startTour).toHaveBeenCalledTimes(1));
+    const [steps] = startTour.mock.calls[0] as [WalkthroughStep[]];
+    expect(steps.map((step) => step.title)).toEqual(
+      WALKTHROUGH_STEPS.account.map((step) => step.title),
+    );
+    expect(useWalkthroughStore.getState().itemId).toBe('account');
+    // And the user is taken to the screen it opens on, from Settings.
+    expect(navigate).toHaveBeenCalledWith({ to: '/accounts' });
+    // No apology, because there is nothing to apologise for any more.
+    expect(screen.queryByText('That walkthrough cannot start yet')).toBeNull();
   });
 
   /**
@@ -226,11 +236,92 @@ describe('WalkthroughLauncher — the entry point that outlives the checklist', 
   it('reads only the two lists when a set is started, and never the preference', async () => {
     const { get, patch } = renderLauncher();
 
-    await startSet('Size a trade in the calculator');
+    await startSet('Close it and see the stats');
     await waitFor(() => expect(startTour).toHaveBeenCalled());
 
     expect(get.mock.calls.map(([path]) => path).sort()).toEqual(['/accounts', '/positions']);
     expect(patch).not.toHaveBeenCalled();
+  });
+
+  /**
+   * AND ONLY WHERE THE ANSWER DEPENDS ON THEM. The calculator set opens on
+   * fields `/calculator` renders for everybody and needs no route values, so
+   * there is nothing a read could come back with that would change what happens
+   * next — and a request whose answer is ignored is one the user's browser
+   * should not make.
+   */
+  it('reads nothing at all for the set that starts from anywhere', async () => {
+    const { get } = renderLauncher();
+
+    await startSet('Size a trade in the calculator');
+    await waitFor(() => expect(startTour).toHaveBeenCalledTimes(1));
+
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  /**
+   * THE SAMPLE STATE IS THE ONE THE ACCOUNT SET IS WITHHELD IN, because it is
+   * the one the PRODUCT withholds account creation in: "New Account" asks to
+   * remove the sample data before it opens the form, and the server refuses the
+   * create until it is gone. Driven live, a walkthrough started here put its own
+   * overlay over that confirmation and the click that reached for it ended the
+   * walkthrough where it stood, without a word — so the set is refused in
+   * advance instead, in the same voice as the other two.
+   */
+  it('refuses the account set while the sample data is what would be replaced', async () => {
+    renderLauncher({
+      accounts: [{ id: 'acct-demo', isDemo: true }],
+      positions: [],
+    });
+
+    await startSet('Create a brokerage account');
+
+    expect(await screen.findByText('That walkthrough cannot start yet')).toBeTruthy();
+    const why = await screen.findByText(/sample account cannot both exist/);
+    // A remedy the reader can act on, and one that still exists for them.
+    expect(why.textContent).toContain('Remove the sample data first');
+    expect(why.textContent).not.toContain('checklist');
+    expect(startTour).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  /**
+   * THE REFUSAL'S OWN REMEDY HAS TO WORK, WHICH MEANS THE SECOND CLICK HAS TO
+   * LOOK AGAIN.
+   *
+   * The notice tells a user with nothing open to go and log a position. Nothing
+   * keeps this card's copy of the positions list up to date while they do —
+   * `['positions', 'list', undefined]` is subscribed to only by the checklist and
+   * `useWalkthrough`, both switched off for a retired user, so the invalidation
+   * the create publishes marks the entry stale and no observer refetches it. A
+   * click-time read that accepts cached data therefore answers the second
+   * attempt out of the first attempt's snapshot: refused again, in the same
+   * words, with no request sent, and only a full page reload gets the user
+   * anywhere. Being told to do something that does not help is worse than being
+   * told nothing.
+   */
+  it('answers the second attempt from the data as it is then, not as it was', async () => {
+    // Nothing open: the set is refused, and the notice says to go and log one.
+    const data = { accounts: [OWN_ACCOUNT], positions: [OWN_CLOSED] };
+    const { qc } = renderLauncher(data, { gcTime: 5 * 60_000 });
+
+    await startSet('Close it and see the stats');
+    expect(await screen.findByText('That walkthrough cannot start yet')).toBeTruthy();
+    expect(startTour).not.toHaveBeenCalled();
+
+    // The user does exactly that. This is what reaches the cache when they do:
+    // `useCreatePosition` invalidates the whole `['positions']` key, and no
+    // mounted observer answers for the unfiltered entry.
+    data.positions = [OWN_OPEN];
+    await qc.invalidateQueries({ queryKey: ['positions'] });
+
+    await startSet('Close it and see the stats');
+
+    await waitFor(() => expect(startTour).toHaveBeenCalledTimes(1));
+    expect(navigate).toHaveBeenCalledWith({
+      to: '/positions/$positionId',
+      params: { positionId: OWN_OPEN.id },
+    });
   });
 
   it('withdraws the buttons, with a reason, when the tour runtime will not load', () => {

--- a/apps/web/src/features/onboarding/components/WalkthroughLauncher.tsx
+++ b/apps/web/src/features/onboarding/components/WalkthroughLauncher.tsx
@@ -1,0 +1,96 @@
+// WalkthroughLauncher — the walkthrough's permanent door, in Settings › Help.
+//
+// WHY IT EXISTS. Every other way into the walkthrough is temporary. The
+// zero-state goes the moment the user creates their first account, and the
+// activation checklist — which carries a "Start" on every row, completed ones
+// included, precisely so the later sets stay reachable — RETIRES when all four
+// items are complete. Retirement is required behaviour and must stay: the
+// `status: 'done'` write it makes is what switches `useOnboarding`'s two
+// expensive reads off for a user who can never see a checklist again. But it
+// left a user who had finished onboarding with no route back to the guided tour
+// from anywhere in the product, which is the same dead end the checklist's play
+// buttons were added to fix, reached from the other side.
+//
+// SO IT OFFERS ALL FOUR SETS TO EVERYONE, UNCONDITIONALLY, and that is what
+// makes it permanent rather than merely long-lived. It asks no question about
+// the user's progress, so there is no answer that could take a control away:
+// not `canStart` (which withholds a set whose opening screen is not the one the
+// user is on, and would hide three of the four from exactly the retired user
+// this is for), and not the checklist (which for that user is `null`). Nothing
+// here reads or writes onboarding state at all — see `useWalkthroughLauncher`,
+// which is the hook that property lives in.
+//
+// TWO OF THE SETS NEED THE USER TO ACT, AND ONE NEEDS A POSITION. The position
+// and close sets contain steps that only move on once the real thing has been
+// done, and the close set opens on a position this component has no way to
+// name. Neither is special-cased: a set that cannot carry on stops and says so,
+// which is the tour's own behaviour everywhere else it happens.
+
+import { Play } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { useWalkthroughLauncher } from '../hooks/useWalkthrough';
+import { CHECKLIST_ITEMS } from '../lib/derive-checklist';
+
+export function WalkthroughLauncher() {
+  const { start, isUnavailable } = useWalkthroughLauncher();
+
+  return (
+    <Card data-testid="walkthrough-launcher" className="gap-4 py-4">
+      <CardHeader className="px-4">
+        <CardTitle className="text-base">Guided walkthrough</CardTitle>
+        <CardDescription>
+          Take any part of the tour, as many times as you like. It only points at the screen it is
+          talking about — nothing is changed and nothing is recorded.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="px-4">
+        {/* Ordered, because these are the four setup steps in the order the
+            checklist presents them — not because one gates the next. */}
+        <ol className="flex flex-col">
+          {CHECKLIST_ITEMS.map((item) => (
+            <li
+              key={item.id}
+              data-walkthrough-set={item.id}
+              className="flex min-h-9 items-center gap-3 py-1"
+            >
+              <span className="min-w-0 flex-1 text-sm">{item.label}</span>
+              {/* A named button rather than the checklist's bare play triangle:
+                  this card is a list of four things to start and nothing else,
+                  so the action is the point of the row rather than an extra on
+                  the end of it. The label goes in the accessible name too —
+                  four buttons all reading "Start" name nothing to a screen
+                  reader. */}
+              <Button
+                variant="outline"
+                size="sm"
+                className="shrink-0 cursor-pointer"
+                data-walkthrough-action={item.id}
+                aria-label={`Start walkthrough: ${item.label}`}
+                disabled={isUnavailable}
+                onClick={() => start(item.id)}
+              >
+                <Play aria-hidden="true" />
+                Start
+              </Button>
+            </li>
+          ))}
+        </ol>
+        {/* The same withdrawal the zero-state and the checklist make when the
+            runtime will not load, said out loud because this card would
+            otherwise be four dead buttons and no explanation. */}
+        {isUnavailable && (
+          <p
+            data-testid="walkthrough-launcher-unavailable"
+            className="pt-3 text-sm text-muted-foreground"
+          >
+            The guided walkthrough could not be loaded. Nothing is lost — the getting-started guide
+            covers the same four steps in full.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/features/onboarding/components/WalkthroughLauncher.tsx
+++ b/apps/web/src/features/onboarding/components/WalkthroughLauncher.tsx
@@ -28,11 +28,20 @@
 //
 // What is NOT left alone is a set with nothing to open on. The close set starts
 // on one of the user's open positions and this component knows of none, so it
-// used to navigate nowhere and disappear; the account set is a tour of the
-// welcome screen, which is gone for good once an account exists. `start()` now
-// resolves the first from the user's own rows and answers for the second in
-// words — see `useWalkthroughLauncher`. Both happen at the CLICK, so this card
-// still asks the server nothing to render.
+// used to navigate nowhere and disappear; `start()` now resolves that row from
+// the user's own rows, and refuses in words when there is none — see
+// `useWalkthroughLauncher`. Both happen at the CLICK, so this card still asks
+// the server nothing to render.
+//
+// ALL FOUR OF THEM RUN. The account set was the last one that could not: it was
+// a tour of the dashboard's welcome screen, and that screen is gone for good
+// once any account exists, so for the user this card is FOR it could only ever
+// explain itself. It now runs on /accounts against "New Account" — the same
+// form, on the page where a second account is genuinely made — which is what
+// makes this card four walkthroughs rather than three and a note. The one state
+// it still declines is sample data, and that is the product's rule rather than
+// the tour's: a new account replaces the sample account, and the confirmation
+// that says so is not something a walkthrough can take the user through.
 
 import { Play } from 'lucide-react';
 

--- a/apps/web/src/features/onboarding/components/WalkthroughLauncher.tsx
+++ b/apps/web/src/features/onboarding/components/WalkthroughLauncher.tsx
@@ -20,11 +20,19 @@
 // here reads or writes onboarding state at all — see `useWalkthroughLauncher`,
 // which is the hook that property lives in.
 //
-// TWO OF THE SETS NEED THE USER TO ACT, AND ONE NEEDS A POSITION. The position
-// and close sets contain steps that only move on once the real thing has been
-// done, and the close set opens on a position this component has no way to
-// name. Neither is special-cased: a set that cannot carry on stops and says so,
-// which is the tour's own behaviour everywhere else it happens.
+// TWO OF THE SETS NEED THE USER TO ACT, AND THAT IS NOT THE SAME AS A BUTTON
+// THAT CANNOT BEGIN. The position and close sets contain steps that only move on
+// once the real thing has been done — creating the position, recording the exit
+// fill — and a tour that waits for the user is the tour working. That is left
+// alone here.
+//
+// What is NOT left alone is a set with nothing to open on. The close set starts
+// on one of the user's open positions and this component knows of none, so it
+// used to navigate nowhere and disappear; the account set is a tour of the
+// welcome screen, which is gone for good once an account exists. `start()` now
+// resolves the first from the user's own rows and answers for the second in
+// words — see `useWalkthroughLauncher`. Both happen at the CLICK, so this card
+// still asks the server nothing to render.
 
 import { Play } from 'lucide-react';
 

--- a/apps/web/src/features/onboarding/hooks/useWalkthrough.test.ts
+++ b/apps/web/src/features/onboarding/hooks/useWalkthrough.test.ts
@@ -709,13 +709,22 @@ describe('useWalkthrough — canStart', () => {
     >;
   }
 
-  it('offers the account set only while the zero-state is the screen the user is on', () => {
+  // THE ACCOUNT SET IS OFFERED TO A USER WHO ALREADY HAS ACCOUNTS, and that is
+  // the whole of why it was moved off the dashboard's welcome screen. Anchored
+  // there it could only run for a user with nothing, which is to say it could
+  // never be run twice; anchored on the Accounts page's "New Account" — a
+  // control `AccountList` renders for everybody — the only state it is withheld
+  // in is the one the product itself blocks, which is sample data (below).
+  it('offers the account set whether or not the user already has one', () => {
     accounts = [];
     expect(canStartAll().account).toBe(true);
 
-    // One account — of any kind, sample data included — and the dashboard shows
-    // the grid instead, so the button that set opens on is gone.
     accounts = [{ id: 'acct-1' }];
+    expect(canStartAll().account).toBe(true);
+
+    // Their own account alongside the sample one is still the sample state:
+    // creating another still starts by removing the sample data.
+    accounts = [{ id: 'acct-1' }, { id: 'demo-acct', isDemo: true }];
     expect(canStartAll().account).toBe(false);
   });
 
@@ -752,10 +761,12 @@ describe('useWalkthrough — canStart', () => {
     // one of the fixture's trades is not closing one of the user's.
     expect(answers.position).toBe(false);
     expect(answers.close).toBe(false);
-    // The account set is withheld for its own separate reason — the zero-state
-    // it opens on is gone the moment ANY account exists, sample or not — which
-    // leaves the calculator as this user's one guided entry point until they
-    // remove the sample data or create an account of their own.
+    // The account set is withheld here too, and for the product's own reason
+    // rather than the tour's: "New Account" asks to remove the sample data
+    // before it opens the form, the server refuses the create until it is gone,
+    // and that confirmation sits under the walkthrough's overlay where a click
+    // for it ends the walkthrough instead. That leaves the calculator as this
+    // user's one guided entry point until they remove the sample data.
     expect(answers.account).toBe(false);
     expect(answers.calculator).toBe(true);
   });
@@ -783,8 +794,9 @@ describe('useWalkthrough — canStart', () => {
   it('offers nothing that depends on an account count it does not have', () => {
     accounts = undefined;
     const answers = canStartAll();
-    expect(answers.account).toBe(false);
     expect(answers.position).toBe(false);
+    // The one that turns on no count at all is unaffected by not having one.
+    expect(answers.calculator).toBe(true);
   });
 
   // Completion is about the user's progress; `canStart` is about whether the
@@ -1051,7 +1063,7 @@ describe('useWalkthrough — action signals', () => {
     expect(downgraded).toEqual(
       [
         // Opens the account dialog.
-        '[data-testid="zero-state-create-account"]',
+        '[data-tour="account-new"]',
         // Chooses the Percent risk basis.
         '[data-tour="calculator-risk"]',
         // Picks the account to size against.

--- a/apps/web/src/features/onboarding/hooks/useWalkthrough.test.ts
+++ b/apps/web/src/features/onboarding/hooks/useWalkthrough.test.ts
@@ -55,6 +55,11 @@ vi.mock('./useOnboarding', async (importOriginal) => ({
 let positions: { id: string; status: string; accountId?: string }[] | undefined;
 vi.mock('@/features/positions/hooks/usePositions', () => ({
   usePositions: () => ({ data: positions }),
+  // The launcher's click-time read reaches for the query DEFINITION rather than
+  // the hook. Nothing in this file drives that path — `WalkthroughLauncher.test`
+  // does, against a real QueryClient — but the export has to exist for the
+  // module under test to import it.
+  positionsListQuery: () => ({ queryKey: ['positions', 'list', undefined], queryFn: () => [] }),
 }));
 
 // The accounts list, supplied directly for the same reason again. The
@@ -63,6 +68,7 @@ vi.mock('@/features/positions/hooks/usePositions', () => ({
 let accounts: { id: string; isDemo?: boolean }[] | undefined;
 vi.mock('@/features/accounts/hooks/useAccounts', () => ({
   useAccounts: () => ({ data: accounts }),
+  accountsListQuery: () => ({ queryKey: ['accounts', 'list'], queryFn: () => [] }),
 }));
 
 // `lib/analytics` is the REAL module here — only the vendor-facing capture is a
@@ -453,7 +459,27 @@ describe('useWalkthrough — the tour says why it stopped', () => {
     expect(why.textContent).toContain('the walkthrough cannot take that step for you');
     // Both ways out, said plainly.
     expect(why.textContent).toContain('carry on without it');
-    expect(why.textContent).toContain('start it again from the setup checklist');
+    expect(why.textContent).toContain('start it again whenever you want from Settings → Help');
+  });
+
+  /**
+   * THE WAY BACK IN HAS TO STILL BE THERE WHEN THEY GET THERE.
+   *
+   * This notice used to send the reader to the setup checklist, which is the one
+   * surface in the product that goes away for good: it retires the moment all
+   * four items are complete, and a user replaying a set from settings has by
+   * definition finished. Directing them to a screen that no longer exists is
+   * worse than saying nothing — they go looking for it.
+   */
+  it('does not send the reader back to a checklist that may have retired', async () => {
+    withToaster();
+    await start('close');
+
+    endTour('target-missing', { cause: 'target-missing', step: aGatedStep() });
+
+    const why = await screen.findByText(/is not on screen/);
+    expect(why.textContent).not.toContain('checklist');
+    expect(why.textContent).toContain('Settings → Help');
   });
 
   /**
@@ -488,7 +514,7 @@ describe('useWalkthrough — the tour says why it stopped', () => {
 
     const why = await screen.findByText(/is not on screen/);
     expect(why.textContent).toContain(plain.title);
-    expect(why.textContent).toContain('start it again from the setup checklist');
+    expect(why.textContent).toContain('start it again whenever you want from Settings → Help');
   });
 
   // The fallback that used to sit here — a `target-missing` naming no step —

--- a/apps/web/src/features/onboarding/hooks/useWalkthrough.ts
+++ b/apps/web/src/features/onboarding/hooks/useWalkthrough.ts
@@ -49,13 +49,14 @@
 // back. The checklist after a walkthrough is the same checklist as before it,
 // plus whatever the user actually did.
 
+import { useQueryClient, type QueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { toast } from 'sonner';
 import { create } from 'zustand';
 
-import { useAccounts } from '@/features/accounts/hooks/useAccounts';
-import { usePositions } from '@/features/positions/hooks/usePositions';
+import { accountsListQuery, useAccounts } from '@/features/accounts/hooks/useAccounts';
+import { positionsListQuery, usePositions } from '@/features/positions/hooks/usePositions';
 import { eventBus } from '@/stores/event-bus.store';
 import type { EventName } from '@/stores/events.types';
 
@@ -321,6 +322,11 @@ function withObservableActionsOnly(steps: WalkthroughStep[]): WalkthroughStep[] 
  * checklist ASKS before it offers a shortcut, and withholds the ones that cannot
  * run rather than putting a dead control on screen.
  *
+ * BOTH DOORS ASK IT, and they differ only in when they can. The permanent entry
+ * point in settings has no mounted reads to answer from, so it asks at the click
+ * (`resolveStartable`) and explains in place of starting. Same question, same
+ * function, so the two cannot come to disagree about what "can run" means.
+ *
  * DATA DECIDES, NOT THE MOUNT SITE, so the two places the checklist is mounted
  * need no rules of their own:
  *
@@ -385,6 +391,61 @@ function canStartSet(itemId: ChecklistItemId, from: StartableFrom): boolean {
       return from.ownAccountCount !== undefined && from.ownAccountCount > 0;
     case 'close':
       return from.hasOwnOpenPosition;
+  }
+}
+
+/** What a set needs to run, and the values the one that opens on a position needs. */
+interface Startable {
+  from: StartableFrom;
+  /** The position the close set opens on, or `undefined` when there is none. */
+  openPositionParams: Record<string, string> | undefined;
+}
+
+/**
+ * THE SAME TWO ANSWERS `useWalkthrough` DERIVES FROM ITS MOUNTED READS, ASKED
+ * FROM A CLICK INSTEAD OF FROM A RENDER.
+ *
+ * The checklist can subscribe to the accounts and positions lists because it is
+ * only ever mounted for a user whose read gate is open. The permanent entry
+ * point cannot: mounting those reads on a settings screen would put the two
+ * expensive queries back for every user, which is the property the gate exists
+ * to protect. So it asks the same questions of the same cache entries at the
+ * moment the user presses Start — a request the user asked for, not a passive
+ * read on the way past — and nothing at all before then.
+ *
+ * `ensureQueryData` rather than a fetch: it answers from the cache when the
+ * lists are already there (the user who has just been on /positions pays
+ * nothing) and issues exactly the request the hook would have issued when they
+ * are not.
+ *
+ * A FAILED READ IS "DON'T KNOW", NOT "NO", and the two must not be collapsed.
+ * The checklist withholds a shortcut it cannot substantiate because it can put
+ * the user on the item's own screen instead; there is no such screen here, and
+ * telling someone their trades are missing because a request failed would be a
+ * sentence about the wrong thing. `null` means the caller should go ahead and
+ * let the walkthrough report its own ending, which is what it did before this
+ * gate existed.
+ */
+async function resolveStartable(queryClient: QueryClient): Promise<Startable | null> {
+  try {
+    const [accounts, positions] = await Promise.all([
+      queryClient.ensureQueryData(accountsListQuery()),
+      queryClient.ensureQueryData(positionsListQuery()),
+    ]);
+    // The checklist's own selector, for the reason given where it is defined:
+    // "the user's data" has to mean here exactly what it means to completion.
+    const { ownAccounts, ownPositions } = selectOwnRows(accounts, positions);
+    const open = ownPositions.find((position) => position.status === 'open');
+    return {
+      from: {
+        accountCount: accounts.length,
+        ownAccountCount: ownAccounts.length,
+        hasOwnOpenPosition: open !== undefined,
+      },
+      openPositionParams: open ? { positionId: open.id } : undefined,
+    };
+  } catch {
+    return null;
   }
 }
 
@@ -529,17 +590,85 @@ function explainStop(blocked: TourBlock): string {
   }
 }
 
+/**
+ * WHERE TO START IT AGAIN — one answer, true for every reader.
+ *
+ * It used to name the setup checklist, which is the one surface that can have
+ * gone: the checklist RETIRES for good once all four items are complete, and a
+ * user who finished onboarding is precisely the user this notice was sending
+ * back to it. Settings › Help is the walkthrough's permanent home — it is there
+ * for every user, retired or not — so it is the direction that cannot come to be
+ * false under the person reading it.
+ */
+const START_AGAIN_HERE = 'start it again whenever you want from Settings → Help';
+
 function announceStop(blocked: TourBlock | undefined): void {
   if (blocked === undefined) return;
 
   toast.info('The walkthrough stopped', {
     id: STOP_NOTICE_ID,
     duration: STOP_NOTICE_MS,
-    // Both ways out, named: nothing was riding on the tour, and the checklist
-    // it was started from is still there. Exiting discards nothing — this
-    // module writes no onboarding state at all — so "nothing was lost" is a
-    // structural fact rather than a reassurance.
-    description: `${explainStop(blocked)} Nothing was lost — carry on without it, or start it again from the setup checklist whenever you want.`,
+    // Both ways out, named: nothing was riding on the tour, and the door it was
+    // started from is still there. Exiting discards nothing — this module writes
+    // no onboarding state at all — so "nothing was lost" is a structural fact
+    // rather than a reassurance.
+    description: `${explainStop(blocked)} Nothing was lost — carry on without it, or ${START_AGAIN_HERE}.`,
+  });
+}
+
+/**
+ * WHY A SET CANNOT BEGIN AT ALL, SAID AT THE CLICK RATHER THAN FIVE SECONDS
+ * LATER.
+ *
+ * This is a different thing from `explainStop`, and the difference is the one
+ * the launcher was shipped blurring: a tour that stops was running and could not
+ * carry on, while these three never had a first step to show. The screen each
+ * one opens on is not there — a welcome screen the user is past, a position they
+ * do not have — so starting them would put an overlay over nothing until the
+ * first step's `waitForMs` expired, which is a button that appears to do
+ * nothing.
+ *
+ * So each answer names the missing thing AND what to do about it. The set is
+ * still offered afterwards: the user who logs a position can press `close` five
+ * minutes later and it will run.
+ */
+function explainCannotStart(itemId: ChecklistItemId): string {
+  switch (itemId) {
+    case 'account':
+      return (
+        'This one is a tour of the welcome screen, which is only on screen before your first ' +
+        'account exists — so there is nothing left for it to point at. Add another account from ' +
+        'Accounts in the sidebar; the form is the same one it describes.'
+      );
+    case 'position':
+      return (
+        'A position is booked against an account, and you have none of your own yet — the sample ' +
+        'data does not count, because a position logged against it would tick nothing. Create an ' +
+        'account under Accounts and this walkthrough will run.'
+      );
+    case 'close':
+      return (
+        'This one runs on a position of yours that is still open, and you have none right now. ' +
+        'Log one and open it, then start this walkthrough again.'
+      );
+    case 'calculator':
+      // Unreachable: `canStartSet` answers yes for this set unconditionally,
+      // because /calculator renders its fields for every user. Kept so the
+      // switch stays exhaustive and a fifth set is a type error here.
+      return 'This walkthrough cannot start from where you are right now.';
+  }
+}
+
+function announceCannotStart(itemId: ChecklistItemId): void {
+  toast.info('That walkthrough cannot start yet', {
+    // The walkthrough's one notice, reused: a user who presses two sets in a row
+    // gets the second explanation in place of the first rather than a stack.
+    id: STOP_NOTICE_ID,
+    duration: STOP_NOTICE_MS,
+    // No "start it again from …" here, unlike `announceStop`: this notice can
+    // only be raised by the launcher, so the reader is already looking at the
+    // place they would be sent to. The set stays on the card either way.
+    description: `${explainCannotStart(itemId)} Nothing was changed.`,
   });
 }
 
@@ -703,13 +832,13 @@ export interface UseWalkthroughLauncherResult {
 }
 
 /**
- * START A NAMED SET, AND READ NO ONBOARDING STATE AT ALL.
+ * START A NAMED SET, AND READ NOTHING UNTIL THE USER ASKS.
  *
  * `useWalkthrough` composes `useOnboarding` because it answers questions about
  * the user's progress — which set is outstanding, which sets could run from the
- * data as it stands. A permanent entry point asks neither: it offers all four
- * sets to everyone, always, so the user's checklist is not an input to anything
- * it does.
+ * data as it stands. A permanent entry point asks neither on the way past: it
+ * offers all four sets to everyone, always, so the user's checklist is not an
+ * input to what it puts on screen.
  *
  * THAT IS THE WHOLE POINT OF THIS HOOK EXISTING. The checklist RETIRES when the
  * four items are complete, and the retirement write is what switches
@@ -719,7 +848,9 @@ export interface UseWalkthroughLauncherResult {
  * mounting one on an ordinary settings screen would put those reads back for
  * every `pending`/`active` user, and asking a retired user's checklist which
  * sets to offer would answer "none", which is the defect it was added to fix.
- * So this reads nothing, offers everything, and costs no request.
+ * So mounting this costs no request at all, and the onboarding preference — the
+ * value the gate is keyed on — is never read from here at any point, click
+ * included.
  *
  * It also WRITES nothing, and that matters more here than at the other doors.
  * The zero-state and the checklist slot write `status: 'active'` as the opt-in
@@ -729,22 +860,38 @@ export interface UseWalkthroughLauncherResult {
  * to see a walkthrough again.
  *
  * `run()` is the same launcher the checklist's per-item buttons go through, so
- * a set started from here is the set they start, step for step. The one thing
- * this cannot do is fill in a position for a set that opens on one: that
- * fallback is derived from the user's own rows, which is exactly the read this
- * hook does not make. Such a set starts, finds no target, and exits with the
- * notice that says why — the same ending it has always had when it cannot
- * carry on.
+ * a set started from here is the set they start, step for step — INCLUDING the
+ * position the close set opens on. That fallback is derived from the user's own
+ * rows, and this hook resolves them from the CLICK rather than from a render
+ * (`resolveStartable`): reading nothing on mount is the constraint, and it says
+ * nothing about a request the user asked for. Without it that button was a tour
+ * that navigated nowhere, waited out its first step and vanished — the exact
+ * "reachable and useless" failure the checklist path fixed for itself.
+ *
+ * AND A SET THAT STILL CANNOT RUN SAYS SO IMMEDIATELY, in place of starting.
+ * `canStartSet` is the same question the checklist asks before offering a
+ * shortcut; the difference is only when it can be asked. The checklist has the
+ * answer at render and withholds the button; this card cannot know until the
+ * click, so it answers then — which is a control that responds rather than one
+ * that appears to do nothing for five seconds and then apologises.
  */
 export function useWalkthroughLauncher(): UseWalkthroughLauncherResult {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const isUnavailable = useWalkthroughStore((state) => state.isUnavailable);
 
   const start = useCallback(
     (itemId: ChecklistItemId, params?: Record<string, string>) => {
-      void run(itemId, params, navigate as NavigateFn);
+      void (async () => {
+        const startable = await resolveStartable(queryClient);
+        if (startable && !canStartSet(itemId, startable.from)) {
+          announceCannotStart(itemId);
+          return;
+        }
+        await run(itemId, params, navigate as NavigateFn, startable?.openPositionParams);
+      })();
     },
-    [navigate],
+    [navigate, queryClient],
   );
 
   return { start, isUnavailable };

--- a/apps/web/src/features/onboarding/hooks/useWalkthrough.ts
+++ b/apps/web/src/features/onboarding/hooks/useWalkthrough.ts
@@ -330,12 +330,12 @@ function withObservableActionsOnly(steps: WalkthroughStep[]): WalkthroughStep[] 
  * DATA DECIDES, NOT THE MOUNT SITE, so the two places the checklist is mounted
  * need no rules of their own:
  *
- * - `account` opens on the zero-state's "Create my first account", and
- *   `_auth.dashboard.tsx` renders that screen only while the accounts list is
- *   EMPTY. The demo account counts here exactly as it counts for that gate:
- *   seeding sample data takes the zero-state away, and this set's first target
- *   with it — even though the checklist item stays outstanding, because sample
- *   data completes nothing.
+ * - `account` opens on `[data-tour="account-new"]` — the Accounts page's "New
+ *   Account" — which `AccountList` renders for every user, with accounts or
+ *   without. There is no state this set cannot start from, which is the point of
+ *   moving it there: it used to open on the dashboard's welcome screen, a screen
+ *   that is gone for good once any account exists, so the one walkthrough about
+ *   creating an account could not be replayed by anyone who had created one.
  * - `position` opens on `[data-tour="position-new"]`, which `PositionList` tags
  *   only on its enabled branch — the one it takes once an account exists. It
  *   needs an account the user OWNS, for the reason below.
@@ -343,8 +343,8 @@ function withObservableActionsOnly(steps: WalkthroughStep[]): WalkthroughStep[] 
  *   that route is the open position `useWalkthrough` falls back to — which is
  *   one of the user's own, for the same reason. No open position of theirs, no
  *   route to navigate to.
- * - `calculator` has nothing that can be missing: `/calculator` renders its
- *   fields for every user, which is why it is the one item a user with no
+ * - `calculator` has nothing that can be missing either: `/calculator` renders
+ *   its fields for every user, which is why it is the one item a user with no
  *   accounts can complete.
  *
  * "RUNS" MEANS "GETS THE USER SOMEWHERE", SO SAMPLE DATA DOES NOT COUNT FOR THE
@@ -362,10 +362,17 @@ function withObservableActionsOnly(steps: WalkthroughStep[]): WalkthroughStep[] 
  * the sample data or creating an account — either takes the demo rows away and
  * both buttons come back with something behind them.
  *
- * The `account` answer is the one place the demo account still counts, and that
- * is not an inconsistency: that set is gated on a SCREEN existing, not on a row
- * being written, and the screen it opens on is gone the moment any account
- * exists.
+ * THE SAMPLE ACCOUNT IS THE ONE STATE `account` IS WITHHELD IN, and the reason
+ * is the product's, not the tour's: sample data and real accounts cannot both
+ * exist, so "New Account" puts up a confirmation to remove the sample data
+ * instead of opening the form, and the server refuses the create outright until
+ * it is gone (`AccountList.beginCreate`, `useCreateAccount`'s
+ * `DEMO_ACCOUNT_EXISTS` branch). A tour cannot drive that confirmation: it sits
+ * under the walkthrough's own overlay, and the click that reaches for it lands
+ * on the overlay and ends the walkthrough where it stands — verified in a
+ * browser, and silent, which is the failure this whole branch exists to stop.
+ * So the set is refused in words, exactly as `position` is for the same user,
+ * and both come back the moment the sample data is removed.
  *
  * An unknown count (the read is disabled, in flight, or failed) answers "no" for
  * every set that depends on it. Withholding a shortcut that would have worked
@@ -373,10 +380,10 @@ function withObservableActionsOnly(steps: WalkthroughStep[]): WalkthroughStep[] 
  * costs them a walkthrough that silently never starts.
  */
 interface StartableFrom {
-  /** Every account, the demo one included — the zero-state gate's own read. */
-  accountCount: number | undefined;
   /** Accounts the user created themselves, on the checklist's terms. */
   ownAccountCount: number | undefined;
+  /** The sample account exists — `useDemoAccount`'s own rule. */
+  hasDemoAccount: boolean;
   /** One of the user's own positions is open — not one of the fixture's. */
   hasOwnOpenPosition: boolean;
 }
@@ -384,13 +391,37 @@ interface StartableFrom {
 function canStartSet(itemId: ChecklistItemId, from: StartableFrom): boolean {
   switch (itemId) {
     case 'account':
-      return from.accountCount === 0;
+      return !from.hasDemoAccount;
+    // Nothing on /calculator can be missing, for anyone.
     case 'calculator':
       return true;
     case 'position':
       return from.ownAccountCount !== undefined && from.ownAccountCount > 0;
     case 'close':
       return from.hasOwnOpenPosition;
+  }
+}
+
+/**
+ * Whether starting this set needs the user's rows read at all.
+ *
+ * The launcher has no mounted reads, so the only way it can answer `canStartSet`
+ * is to ask the server at the click — a request worth making for a question that
+ * has an answer, and worth NOT making for one that does not. `calculator` is
+ * that second case: it starts from anywhere, for anyone, and needs no route
+ * values, so a read before it could only ever come back "yes, as always".
+ *
+ * A switch rather than a set literal, and exhaustive, so it cannot fall out of
+ * step with `canStartSet` above: a fifth set is a type error in both or neither.
+ */
+function needsStartableRead(itemId: ChecklistItemId): boolean {
+  switch (itemId) {
+    case 'account':
+    case 'position':
+    case 'close':
+      return true;
+    case 'calculator':
+      return false;
   }
 }
 
@@ -413,10 +444,32 @@ interface Startable {
  * moment the user presses Start — a request the user asked for, not a passive
  * read on the way past — and nothing at all before then.
  *
- * `ensureQueryData` rather than a fetch: it answers from the cache when the
- * lists are already there (the user who has just been on /positions pays
- * nothing) and issues exactly the request the hook would have issued when they
- * are not.
+ * `fetchQuery` AND NOT `ensureQueryData`, AND THE DIFFERENCE IS THE WHOLE ANSWER
+ * BEING RIGHT. `ensureQueryData` hands back whatever is in the cache whenever
+ * something is, however old and however explicitly invalidated; it only fetches
+ * when the entry is missing outright. Nothing keeps this entry fresh, either:
+ * `['positions', 'list', undefined]` is subscribed to by the checklist and by
+ * `useWalkthrough`, both of which are switched off for exactly the retired user
+ * this door exists for, so the invalidation every create and close publishes
+ * marks it stale and no observer ever refetches it. The refusal below is
+ * therefore decided on a snapshot of the user's data from the last time they
+ * pressed one of these buttons.
+ *
+ * That made this notice's own remedy fail. It tells a user with no open position
+ * to go and log one — and a user who did exactly that, came back, and pressed
+ * Start was refused a second time in the same words, with no request sent. Only
+ * a full page reload, which drops the cache, made the button work. It goes wrong
+ * the other way too: close a position and the stale entry still calls it open,
+ * so the set starts and points at an exit control that is gone. A remedy that
+ * does not work is worse than no remedy, so the read that decides has to be a
+ * read of now.
+ *
+ * WHAT THAT COSTS IS ONE REQUEST PER PRESS, and it is the right price. The app's
+ * client keeps the library's `staleTime` of zero (`lib/queryClient.ts`), so this
+ * genuinely goes to the server each time — but only for the two sets whose
+ * answer depends on it (`needsStartableRead`), only when a user has pressed a
+ * button asking to be walked through something, and never on the way past. The
+ * alternative on offer was a free answer that was wrong.
  *
  * A FAILED READ IS "DON'T KNOW", NOT "NO", and the two must not be collapsed.
  * The checklist withholds a shortcut it cannot substantiate because it can put
@@ -429,8 +482,8 @@ interface Startable {
 async function resolveStartable(queryClient: QueryClient): Promise<Startable | null> {
   try {
     const [accounts, positions] = await Promise.all([
-      queryClient.ensureQueryData(accountsListQuery()),
-      queryClient.ensureQueryData(positionsListQuery()),
+      queryClient.fetchQuery(accountsListQuery()),
+      queryClient.fetchQuery(positionsListQuery()),
     ]);
     // The checklist's own selector, for the reason given where it is defined:
     // "the user's data" has to mean here exactly what it means to completion.
@@ -438,8 +491,8 @@ async function resolveStartable(queryClient: QueryClient): Promise<Startable | n
     const open = ownPositions.find((position) => position.status === 'open');
     return {
       from: {
-        accountCount: accounts.length,
         ownAccountCount: ownAccounts.length,
+        hasDemoAccount: accounts.length > ownAccounts.length,
         hasOwnOpenPosition: open !== undefined,
       },
       openPositionParams: open ? { positionId: open.id } : undefined,
@@ -622,23 +675,28 @@ function announceStop(blocked: TourBlock | undefined): void {
  *
  * This is a different thing from `explainStop`, and the difference is the one
  * the launcher was shipped blurring: a tour that stops was running and could not
- * carry on, while these three never had a first step to show. The screen each
- * one opens on is not there — a welcome screen the user is past, a position they
- * do not have — so starting them would put an overlay over nothing until the
- * first step's `waitForMs` expired, which is a button that appears to do
- * nothing.
+ * carry on, while none of these three could have got anywhere. Two have nothing
+ * to open on — a position the user does not have, an account they have not made
+ * — and starting them would put an overlay over nothing until the first step's
+ * `waitForMs` expired, which is a button that appears to do nothing. The third,
+ * `account`, opens fine and then cannot proceed: the form behind "New Account"
+ * only opens once the sample data has been removed, and that confirmation is not
+ * something a tour can drive.
  *
- * So each answer names the missing thing AND what to do about it. The set is
+ * So each answer names what is in the way AND what to do about it. The set is
  * still offered afterwards: the user who logs a position can press `close` five
- * minutes later and it will run.
+ * minutes later and it will run — and now genuinely does, because the read
+ * behind that decision is taken fresh at the click (`resolveStartable`). Both
+ * remedies were followed in a browser, from the refusal to the set running.
  */
 function explainCannotStart(itemId: ChecklistItemId): string {
   switch (itemId) {
     case 'account':
       return (
-        'This one is a tour of the welcome screen, which is only on screen before your first ' +
-        'account exists — so there is nothing left for it to point at. Add another account from ' +
-        'Accounts in the sidebar; the form is the same one it describes.'
+        'Your own accounts and the sample account cannot both exist, so creating one starts by ' +
+        'removing the sample data — and that is a confirmation this walkthrough cannot take you ' +
+        'through. Remove the sample data first, from the banner on your dashboard, and this ' +
+        'walkthrough will run.'
       );
     case 'position':
       return (
@@ -653,8 +711,10 @@ function explainCannotStart(itemId: ChecklistItemId): string {
       );
     case 'calculator':
       // Unreachable: `canStartSet` answers yes for this set unconditionally,
-      // because /calculator renders its fields for every user. Kept so the
-      // switch stays exhaustive and a fifth set is a type error here.
+      // because /calculator renders its fields for every user, and
+      // `needsStartableRead` means the launcher does not even ask before
+      // starting it. Kept so the switch stays exhaustive and a fifth set is a
+      // type error here.
       return 'This walkthrough cannot start from where you are right now.';
   }
 }
@@ -868,12 +928,22 @@ export interface UseWalkthroughLauncherResult {
  * that navigated nowhere, waited out its first step and vanished — the exact
  * "reachable and useless" failure the checklist path fixed for itself.
  *
+ * THREE OF THE FOUR ASK THAT QUESTION, AND ONLY THOSE THREE. `position` and
+ * `close` open on something the user may not have, and `account` cannot get past
+ * its own first step while sample data is what a new account would replace.
+ * `calculator` opens on fields `/calculator` renders for everybody and needs no
+ * route values, so it is started without a request at all
+ * (`needsStartableRead`).
+ *
  * AND A SET THAT STILL CANNOT RUN SAYS SO IMMEDIATELY, in place of starting.
  * `canStartSet` is the same question the checklist asks before offering a
  * shortcut; the difference is only when it can be asked. The checklist has the
  * answer at render and withholds the button; this card cannot know until the
  * click, so it answers then — which is a control that responds rather than one
- * that appears to do nothing for five seconds and then apologises.
+ * that appears to do nothing for five seconds and then apologises. What it
+ * answers from is the data as it is at that click, not as it was at the last
+ * one: see `resolveStartable`, where getting that wrong made the refusal's own
+ * advice impossible to act on.
  */
 export function useWalkthroughLauncher(): UseWalkthroughLauncherResult {
   const navigate = useNavigate();
@@ -883,6 +953,14 @@ export function useWalkthroughLauncher(): UseWalkthroughLauncherResult {
   const start = useCallback(
     (itemId: ChecklistItemId, params?: Record<string, string>) => {
       void (async () => {
+        // A set that starts from anywhere and needs no route values is started,
+        // not investigated: the read below could only come back "yes, as
+        // always", and a request nobody's answer depends on is one this card
+        // should not make.
+        if (!needsStartableRead(itemId)) {
+          await run(itemId, params, navigate as NavigateFn);
+          return;
+        }
         const startable = await resolveStartable(queryClient);
         if (startable && !canStartSet(itemId, startable.from)) {
           announceCannotStart(itemId);
@@ -916,11 +994,12 @@ export function useWalkthrough(): UseWalkthroughResult {
   // `params` from the caller always wins; this is only the fallback.
   const { data: positions } = usePositions(undefined, { enabled: checklist != null });
 
-  // The accounts list, on the same terms the dashboard's zero-state gate reads
-  // it — the whole thing, demo row included. Same query key as the gate's own
-  // read and as `useOnboarding`'s, and gated on the same condition as the
-  // positions observer, so this costs no extra request on either screen the
-  // checklist is mounted on.
+  // The accounts list, the whole thing with the demo row still in it — which is
+  // what makes it possible to tell the sample account's positions from the
+  // user's below. Same query key as the dashboard zero-state gate's own read and
+  // as `useOnboarding`'s, and gated on the same condition as the positions
+  // observer, so this costs no extra request on either screen the checklist is
+  // mounted on.
   const { data: accounts } = useAccounts({ enabled: checklist != null });
 
   // THE USER'S OWN ROWS, FROM THE CHECKLIST'S OWN SELECTOR. `canStartSet` has to
@@ -944,11 +1023,13 @@ export function useWalkthrough(): UseWalkthroughResult {
 
   const hasOwnOpenPosition = openPositionParams !== undefined;
   const ownAccountCount = own?.ownAccounts.length;
-  const accountCount = accounts?.length;
+  // The same rule `useDemoAccount` uses, from the list already read here rather
+  // than from a second read of it.
+  const hasDemoAccount = accounts?.some((account) => account.isDemo) ?? false;
   const canStart = useCallback(
     (itemId: ChecklistItemId) =>
-      canStartSet(itemId, { accountCount, ownAccountCount, hasOwnOpenPosition }),
-    [accountCount, ownAccountCount, hasOwnOpenPosition],
+      canStartSet(itemId, { ownAccountCount, hasDemoAccount, hasOwnOpenPosition }),
+    [ownAccountCount, hasDemoAccount, hasOwnOpenPosition],
   );
 
   // What the funnel counts as "offered": there is a walkthrough behind the

--- a/apps/web/src/features/onboarding/hooks/useWalkthrough.ts
+++ b/apps/web/src/features/onboarding/hooks/useWalkthrough.ts
@@ -695,6 +695,61 @@ export function useIsWalkthroughRunning(): boolean {
   return useWalkthroughStore((state) => state.isRunning);
 }
 
+export interface UseWalkthroughLauncherResult {
+  /** Run one named set. The id is required — nothing here knows what is outstanding. */
+  start: (itemId: ChecklistItemId, params?: Record<string, string>) => void;
+  /** The tour runtime failed to load; there is nothing behind the controls. */
+  isUnavailable: boolean;
+}
+
+/**
+ * START A NAMED SET, AND READ NO ONBOARDING STATE AT ALL.
+ *
+ * `useWalkthrough` composes `useOnboarding` because it answers questions about
+ * the user's progress — which set is outstanding, which sets could run from the
+ * data as it stands. A permanent entry point asks neither: it offers all four
+ * sets to everyone, always, so the user's checklist is not an input to anything
+ * it does.
+ *
+ * THAT IS THE WHOLE POINT OF THIS HOOK EXISTING. The checklist RETIRES when the
+ * four items are complete, and the retirement write is what switches
+ * `useOnboarding`'s two expensive reads — the accounts list and the whole
+ * unfiltered positions list — off for good. An entry point that has to outlive
+ * retirement therefore cannot be built on a hook that reads onboarding state:
+ * mounting one on an ordinary settings screen would put those reads back for
+ * every `pending`/`active` user, and asking a retired user's checklist which
+ * sets to offer would answer "none", which is the defect it was added to fix.
+ * So this reads nothing, offers everything, and costs no request.
+ *
+ * It also WRITES nothing, and that matters more here than at the other doors.
+ * The zero-state and the checklist slot write `status: 'active'` as the opt-in
+ * record before starting a tour; doing the same from settings would un-retire a
+ * user who had finished — turning both gated reads back on and putting the
+ * checklist back on their dashboard — for no reason other than that they asked
+ * to see a walkthrough again.
+ *
+ * `run()` is the same launcher the checklist's per-item buttons go through, so
+ * a set started from here is the set they start, step for step. The one thing
+ * this cannot do is fill in a position for a set that opens on one: that
+ * fallback is derived from the user's own rows, which is exactly the read this
+ * hook does not make. Such a set starts, finds no target, and exits with the
+ * notice that says why — the same ending it has always had when it cannot
+ * carry on.
+ */
+export function useWalkthroughLauncher(): UseWalkthroughLauncherResult {
+  const navigate = useNavigate();
+  const isUnavailable = useWalkthroughStore((state) => state.isUnavailable);
+
+  const start = useCallback(
+    (itemId: ChecklistItemId, params?: Record<string, string>) => {
+      void run(itemId, params, navigate as NavigateFn);
+    },
+    [navigate],
+  );
+
+  return { start, isUnavailable };
+}
+
 export function useWalkthrough(): UseWalkthroughResult {
   const navigate = useNavigate();
   const { checklist } = useOnboarding();

--- a/apps/web/src/features/onboarding/lib/derive-checklist.ts
+++ b/apps/web/src/features/onboarding/lib/derive-checklist.ts
@@ -100,29 +100,34 @@ export interface Checklist {
  * with each other. A checklist is a nudge — bad input should degrade to an
  * un-ticked item, never to an error the user cannot get past.
  */
+/**
+ * The four items as AUTHORED — their ids, their labels and the order they are
+ * shown in. No user data is involved, so this says nothing about completion.
+ *
+ * Split out of `deriveChecklist` because a second caller needs the NAMES
+ * without needing the answers. The walkthrough's permanent entry point in
+ * settings offers all four sets to every user, so it has nothing to derive a
+ * checklist from — and must not read onboarding state to find out what the four
+ * sets are called, because reading it is what the retired user's read gate
+ * exists to avoid. One list, so the two cannot disagree about which four items
+ * there are or what order they come in.
+ */
+export const CHECKLIST_ITEMS: readonly Omit<ChecklistItem, 'done'>[] = [
+  { id: 'account', label: 'Create a brokerage account' },
+  { id: 'calculator', label: 'Size a trade in the calculator' },
+  { id: 'position', label: 'Log a position' },
+  { id: 'close', label: 'Close it and see the stats' },
+];
+
 export function deriveChecklist(input: ChecklistInput): Checklist {
-  const items: ChecklistItem[] = [
-    {
-      id: 'account',
-      label: 'Create a brokerage account',
-      done: input.accountCount > 0,
-    },
-    {
-      id: 'calculator',
-      label: 'Size a trade in the calculator',
-      done: Boolean(input.calculatorFirstUsedAt),
-    },
-    {
-      id: 'position',
-      label: 'Log a position',
-      done: input.positionsEverCreatedCount > 0,
-    },
-    {
-      id: 'close',
-      label: 'Close it and see the stats',
-      done: input.closedPositionCount > 0,
-    },
-  ];
+  // The completion rules, still stated exactly once and only here.
+  const done: Record<ChecklistItemId, boolean> = {
+    account: input.accountCount > 0,
+    calculator: Boolean(input.calculatorFirstUsedAt),
+    position: input.positionsEverCreatedCount > 0,
+    close: input.closedPositionCount > 0,
+  };
+  const items: ChecklistItem[] = CHECKLIST_ITEMS.map((item) => ({ ...item, done: done[item.id] }));
 
   return { items, allComplete: items.every((item) => item.done) };
 }

--- a/apps/web/src/features/onboarding/lib/steps/account.ts
+++ b/apps/web/src/features/onboarding/lib/steps/account.ts
@@ -1,9 +1,18 @@
 /**
  * Checklist item 1 — create a brokerage account.
  *
- * Runs entirely on `/dashboard`: the zero-state mounts `AccountDialog` itself,
- * so the form opens over the same route the tour started on and no step here
- * navigates.
+ * RUNS ENTIRELY ON `/accounts`, AND THAT IS WHAT MAKES IT REPEATABLE. It used to
+ * run on `/dashboard`, against the zero-state's "Create my first account" — a
+ * screen the dashboard renders only while the user has no accounts at all. That
+ * anchored the whole set to a screen every user leaves within a minute of
+ * arriving and never sees again, so the one walkthrough about creating an
+ * account could not be replayed by anybody who had created one. `/accounts` is
+ * where a second account is actually made, it is on the sidebar for every user,
+ * and it mounts the SAME `AccountDialog` the zero-state does — so every field
+ * step below is unchanged, and the set now runs for the user who has finished
+ * onboarding as well as the one who has not started.
+ *
+ * No step navigates: the dialog opens over this route, as it did over the other.
  *
  * EVERY CLAIM, AND WHERE IT WAS CHECKED:
  * - Booked against an account, mirrors a real brokerage account, never places
@@ -37,14 +46,14 @@ import type { WalkthroughStepSource } from './index';
 
 export const accountSteps: readonly WalkthroughStepSource[] = [
   {
-    target: '[data-testid="zero-state-create-account"]',
-    route: '/dashboard',
+    target: '[data-tour="account-new"]',
+    route: '/accounts',
     docs: 'gettingStarted',
-    // The set is entered COLD, so its first step waits like any other: the
-    // dashboard route holds `DashboardSkeleton` until both the onboarding
-    // preference and the accounts list have answered, and only then mounts
-    // `ZeroState` (`routes/_auth.dashboard.tsx`). Without this the tour would
-    // exit `target-missing` before the screen it is describing exists.
+    // The set is entered COLD, so its first step waits like any other:
+    // `AccountList` renders skeletons until `useAccounts` has answered, and the
+    // button this points at is on the branch it takes afterwards. Without this
+    // the tour would exit `target-missing` before the screen it is describing
+    // has finished arriving.
     waitForMs: 5000,
     advanceOnAction: true,
     title: 'Start with an account',
@@ -52,11 +61,11 @@ export const accountSteps: readonly WalkthroughStepSource[] = [
       'Every position, fill and ledger entry is booked against an account, so this is the one ' +
       'thing to do first. A Tradr account mirrors a real brokerage account — the same currency, ' +
       'the same starting balance, the same trades — but it is not connected to your broker, and ' +
-      'Tradr never places or executes trades. Choose Create my first account to open the form.',
+      'Tradr never places or executes trades. Choose New Account to open the form.',
   },
   {
     target: '#name',
-    route: '/dashboard',
+    route: '/accounts',
     docs: 'gettingStarted',
     // THE WAIT COVERS A PERSON, NOT A RENDER, and that is why it is this long.
     // The step before asks the user to open the account dialog, a gesture the
@@ -73,7 +82,7 @@ export const accountSteps: readonly WalkthroughStepSource[] = [
   },
   {
     target: '#currency',
-    route: '/dashboard',
+    route: '/accounts',
     docs: 'gettingStarted',
     title: 'Currency',
     body:
@@ -82,7 +91,7 @@ export const accountSteps: readonly WalkthroughStepSource[] = [
   },
   {
     target: '#timezone',
-    route: '/dashboard',
+    route: '/accounts',
     docs: 'gettingStarted',
     title: 'Trading-day timezone',
     body:
@@ -93,7 +102,7 @@ export const accountSteps: readonly WalkthroughStepSource[] = [
   },
   {
     target: '#startingBalance',
-    route: '/dashboard',
+    route: '/accounts',
     docs: 'gettingStarted',
     title: 'Starting balance',
     body:
@@ -104,7 +113,7 @@ export const accountSteps: readonly WalkthroughStepSource[] = [
   },
   {
     target: '#defaultRiskPercent',
-    route: '/dashboard',
+    route: '/accounts',
     docs: 'gettingStarted',
     title: 'Default risk %',
     body:
@@ -117,7 +126,7 @@ export const accountSteps: readonly WalkthroughStepSource[] = [
   },
   {
     target: '#brokerage',
-    route: '/dashboard',
+    route: '/accounts',
     docs: 'gettingStarted',
     title: 'Brokerage',
     body:
@@ -127,20 +136,20 @@ export const accountSteps: readonly WalkthroughStepSource[] = [
   },
   {
     target: '[data-tour="account-submit"]',
-    route: '/dashboard',
+    route: '/accounts',
     docs: 'gettingStarted',
     advanceOnAction: true,
     title: 'Create the account',
     body:
-      'Choose Create. Your dashboard replaces this welcome screen as soon as the account exists, ' +
-      'and the first item on the setup checklist ticks itself.',
+      'Choose Create. The account appears in the list behind this form as soon as it exists, and ' +
+      'you can book positions against it straight away.',
   },
   {
     // No target: the reporting timezone is not a control on this screen, and the
     // invitation belongs at the point the account is created rather than as a
     // detour into settings mid-walkthrough. Centred, so it reads as the aside it
     // is.
-    route: '/dashboard',
+    route: '/accounts',
     docs: 'gettingStarted',
     title: 'Your reporting timezone',
     body:

--- a/apps/web/src/features/positions/hooks/usePositions.ts
+++ b/apps/web/src/features/positions/hooks/usePositions.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 import type { CreatePositionInput, Position, PositionListItem } from '@tradr/shared';
@@ -44,6 +44,26 @@ export function handleCreatePositionError(
 }
 
 /**
+ * The list as a query DEFINITION rather than a subscription.
+ *
+ * `usePositions` is built on it, so a caller that needs the list ONCE — in
+ * response to a click, without mounting a hook that would fetch on render —
+ * reads the same cache entry through the same fetcher rather than a second copy
+ * of the key that could drift from this one.
+ */
+export function positionsListQuery(filters?: { status?: string; accountId?: string }) {
+  const params = new URLSearchParams();
+  if (filters?.status) params.set('status', filters.status);
+  if (filters?.accountId) params.set('accountId', filters.accountId);
+  const query = params.toString();
+
+  return queryOptions({
+    queryKey: ['positions', 'list', filters],
+    queryFn: () => api.get<PositionListItem[]>(`/positions${query ? `?${query}` : ''}`),
+  });
+}
+
+/**
  * `GET /positions` has no LIMIT and returns every enriched row, so it is the
  * most expensive list the app fetches. `options.enabled` lets a caller that may
  * not need it at all skip the request entirely; omitted, it fetches as before.
@@ -53,14 +73,8 @@ export function usePositions(
   filters?: { status?: string; accountId?: string },
   options?: { enabled?: boolean },
 ) {
-  const params = new URLSearchParams();
-  if (filters?.status) params.set('status', filters.status);
-  if (filters?.accountId) params.set('accountId', filters.accountId);
-  const query = params.toString();
-
-  return useQuery<PositionListItem[]>({
-    queryKey: ['positions', 'list', filters],
-    queryFn: () => api.get<PositionListItem[]>(`/positions${query ? `?${query}` : ''}`),
+  return useQuery({
+    ...positionsListQuery(filters),
     enabled: options?.enabled,
   });
 }

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as AuthPositionsIndexRouteImport } from './routes/_auth/positions
 import { Route as AuthAdvisorIndexRouteImport } from './routes/_auth.advisor.index'
 import { Route as AuthAccountsIndexRouteImport } from './routes/_auth/accounts/index'
 import { Route as AuthSettingsProfileRouteImport } from './routes/_auth.settings.profile'
+import { Route as AuthSettingsHelpRouteImport } from './routes/_auth.settings.help'
 import { Route as AuthSettingsBillingRouteImport } from './routes/_auth.settings.billing'
 import { Route as AuthSettingsAdvisorRouteImport } from './routes/_auth.settings.advisor'
 import { Route as AuthSettingsAccountRouteImport } from './routes/_auth.settings.account'
@@ -139,6 +140,11 @@ const AuthSettingsProfileRoute = AuthSettingsProfileRouteImport.update({
   path: '/profile',
   getParentRoute: () => AuthSettingsRoute,
 } as any)
+const AuthSettingsHelpRoute = AuthSettingsHelpRouteImport.update({
+  id: '/help',
+  path: '/help',
+  getParentRoute: () => AuthSettingsRoute,
+} as any)
 const AuthSettingsBillingRoute = AuthSettingsBillingRouteImport.update({
   id: '/billing',
   path: '/billing',
@@ -218,6 +224,7 @@ export interface FileRoutesByFullPath {
   '/settings/account': typeof AuthSettingsAccountRoute
   '/settings/advisor': typeof AuthSettingsAdvisorRoute
   '/settings/billing': typeof AuthSettingsBillingRoute
+  '/settings/help': typeof AuthSettingsHelpRoute
   '/settings/profile': typeof AuthSettingsProfileRoute
   '/accounts/': typeof AuthAccountsIndexRoute
   '/advisor/': typeof AuthAdvisorIndexRoute
@@ -250,6 +257,7 @@ export interface FileRoutesByTo {
   '/settings/account': typeof AuthSettingsAccountRoute
   '/settings/advisor': typeof AuthSettingsAdvisorRoute
   '/settings/billing': typeof AuthSettingsBillingRoute
+  '/settings/help': typeof AuthSettingsHelpRoute
   '/settings/profile': typeof AuthSettingsProfileRoute
   '/accounts': typeof AuthAccountsIndexRoute
   '/advisor': typeof AuthAdvisorIndexRoute
@@ -283,6 +291,7 @@ export interface FileRoutesById {
   '/_auth/settings/account': typeof AuthSettingsAccountRoute
   '/_auth/settings/advisor': typeof AuthSettingsAdvisorRoute
   '/_auth/settings/billing': typeof AuthSettingsBillingRoute
+  '/_auth/settings/help': typeof AuthSettingsHelpRoute
   '/_auth/settings/profile': typeof AuthSettingsProfileRoute
   '/_auth/accounts/': typeof AuthAccountsIndexRoute
   '/_auth/advisor/': typeof AuthAdvisorIndexRoute
@@ -317,6 +326,7 @@ export interface FileRouteTypes {
     | '/settings/account'
     | '/settings/advisor'
     | '/settings/billing'
+    | '/settings/help'
     | '/settings/profile'
     | '/accounts/'
     | '/advisor/'
@@ -349,6 +359,7 @@ export interface FileRouteTypes {
     | '/settings/account'
     | '/settings/advisor'
     | '/settings/billing'
+    | '/settings/help'
     | '/settings/profile'
     | '/accounts'
     | '/advisor'
@@ -381,6 +392,7 @@ export interface FileRouteTypes {
     | '/_auth/settings/account'
     | '/_auth/settings/advisor'
     | '/_auth/settings/billing'
+    | '/_auth/settings/help'
     | '/_auth/settings/profile'
     | '/_auth/accounts/'
     | '/_auth/advisor/'
@@ -538,6 +550,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthSettingsProfileRouteImport
       parentRoute: typeof AuthSettingsRoute
     }
+    '/_auth/settings/help': {
+      id: '/_auth/settings/help'
+      path: '/help'
+      fullPath: '/settings/help'
+      preLoaderRoute: typeof AuthSettingsHelpRouteImport
+      parentRoute: typeof AuthSettingsRoute
+    }
     '/_auth/settings/billing': {
       id: '/_auth/settings/billing'
       path: '/billing'
@@ -631,6 +650,7 @@ interface AuthSettingsRouteChildren {
   AuthSettingsAccountRoute: typeof AuthSettingsAccountRoute
   AuthSettingsAdvisorRoute: typeof AuthSettingsAdvisorRoute
   AuthSettingsBillingRoute: typeof AuthSettingsBillingRoute
+  AuthSettingsHelpRoute: typeof AuthSettingsHelpRoute
   AuthSettingsProfileRoute: typeof AuthSettingsProfileRoute
 }
 
@@ -638,6 +658,7 @@ const AuthSettingsRouteChildren: AuthSettingsRouteChildren = {
   AuthSettingsAccountRoute: AuthSettingsAccountRoute,
   AuthSettingsAdvisorRoute: AuthSettingsAdvisorRoute,
   AuthSettingsBillingRoute: AuthSettingsBillingRoute,
+  AuthSettingsHelpRoute: AuthSettingsHelpRoute,
   AuthSettingsProfileRoute: AuthSettingsProfileRoute,
 }
 

--- a/apps/web/src/routes/__tests__/settings-layout.test.tsx
+++ b/apps/web/src/routes/__tests__/settings-layout.test.tsx
@@ -34,6 +34,7 @@ import { Route as SettingsLayoutRoute } from '../_auth.settings';
 import { Route as AdvisorRoute } from '../_auth.settings.advisor';
 import { Route as ProfileRoute } from '../_auth.settings.profile';
 import { Route as AccountRoute } from '../_auth.settings.account';
+import { Route as HelpRoute } from '../_auth.settings.help';
 
 // The real routes are typed against the app's route registration; re-hosting
 // them under a fresh root requires loosening those option types.
@@ -42,6 +43,7 @@ const layoutOpts = SettingsLayoutRoute.options as any;
 const advisorOpts = AdvisorRoute.options as any;
 const profileOpts = ProfileRoute.options as any;
 const accountOpts = AccountRoute.options as any;
+const helpOpts = HelpRoute.options as any;
 
 // ---- Test router ----------------------------------------------------------
 // Re-host the real Settings routes under a fresh root so we can exercise the
@@ -74,8 +76,14 @@ function buildRouter(initialPath: string) {
     component: accountOpts.component,
   });
 
+  const help = createRoute({
+    getParentRoute: () => settingsLayout as any,
+    path: '/help',
+    component: helpOpts.component,
+  });
+
   const routeTree = rootRoute.addChildren([
-    settingsLayout.addChildren([advisor, profile, account]),
+    settingsLayout.addChildren([advisor, profile, account, help]),
   ]);
 
   return createRouter({
@@ -127,5 +135,27 @@ describe('Settings tabbed layout', () => {
     const btn = await screen.findByRole('button', { name: /Log out/i });
     fireEvent.click(btn);
     expect(logoutMutate).toHaveBeenCalledTimes(1);
+  });
+
+  // The walkthrough's permanent door. Every other one is temporary — the
+  // zero-state goes with the first account, and the activation checklist retires
+  // when all four items are complete — so it has to be reachable from a tab that
+  // is always there, for a user who has no checklist left.
+  it('case 4: the Help tab is reachable and offers all four walkthrough sets', async () => {
+    renderAt('/settings/advisor');
+
+    const tab = await screen.findByRole('tab', { name: /Help/i });
+    fireEvent.click(tab.querySelector('a') ?? tab);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('walkthrough-launcher')).toBeTruthy();
+    });
+    const sets = [...document.querySelectorAll('[data-walkthrough-set]')];
+    expect(sets.map((el) => el.getAttribute('data-walkthrough-set'))).toEqual([
+      'account',
+      'calculator',
+      'position',
+      'close',
+    ]);
   });
 });

--- a/apps/web/src/routes/_auth.settings.help.tsx
+++ b/apps/web/src/routes/_auth.settings.help.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { WalkthroughLauncher } from '@/features/onboarding/components/WalkthroughLauncher';
+
+function SettingsHelp() {
+  return (
+    <div className="space-y-6" data-slot="settings-help">
+      <div>
+        <h2 className="text-lg font-medium">Help</h2>
+        <p className="text-sm text-muted-foreground">
+          Start the guided walkthrough again, whenever you want it.
+        </p>
+      </div>
+
+      <WalkthroughLauncher />
+    </div>
+  );
+}
+
+export const Route = createFileRoute('/_auth/settings/help')({
+  component: SettingsHelp,
+});

--- a/apps/web/src/routes/_auth.settings.tsx
+++ b/apps/web/src/routes/_auth.settings.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, Outlet, redirect, useLocation } from '@tanstack/react-router';
-import { Bot, Settings as SettingsIcon, User, Wallet } from 'lucide-react';
+import { Bot, CircleQuestionMark, Settings as SettingsIcon, User, Wallet } from 'lucide-react';
 
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
@@ -10,6 +10,11 @@ const SETTINGS_TABS = [
   { id: 'billing', label: 'Billing', icon: Wallet, route: '/settings/billing' },
   { id: 'profile', label: 'Profile', icon: User, route: '/settings/profile' },
   { id: 'account', label: 'Account', icon: SettingsIcon, route: '/settings/account' },
+  // The guided walkthrough's permanent home. It lives here rather than on the
+  // dashboard because every dashboard door into it is temporary: the zero-state
+  // goes when the first account is created and the activation checklist retires
+  // when all four items are done.
+  { id: 'help', label: 'Help', icon: CircleQuestionMark, route: '/settings/help' },
 ] as const;
 
 function SettingsLayout() {

--- a/e2e/tests/user-onboarding.spec.ts
+++ b/e2e/tests/user-onboarding.spec.ts
@@ -794,19 +794,31 @@ test.describe('user onboarding', () => {
     await expect(popover(page)).toHaveCount(0);
 
     // The item is ticked off the user's data — nothing here is a stored per-step
-    // flag — and the account set's button is gone, because the control its first
-    // step opens on belongs to a zero-state this user has left. An honest
-    // omission rather than a button that would start a tour and end it in
-    // silence three seconds later.
+    // flag — and the account set's button is still there on the item that has
+    // been ticked. It used to be withheld the moment an account existed, back
+    // when the set opened on a zero-state control: the walkthrough about
+    // creating an account was then unreplayable by anyone who had created one.
+    // It runs on /accounts now, a screen this user has, so the offer stands.
     await page.goto('/dashboard');
     await expect(checklistProgress(page)).toHaveText('2 of 4 complete');
     await expect(checklistItemLabel(page, 'calculator')).toHaveText(/— completed$/);
     await expect(checklistItemLabel(page, 'account')).toHaveText(/— completed$/);
-    await expect(page.locator('[data-checklist-action="account"]')).toHaveCount(0);
+    await expect(page.locator('[data-checklist-action="account"]')).toBeVisible();
+
+    // And the offer is honest, which is the half of the old assertion that still
+    // holds: a button here must not start a tour that ends in silence three
+    // seconds later. Pressed, it goes to the screen the set runs on and opens at
+    // the front of it.
+    await page.locator('[data-checklist-action="account"]').click();
+    await expect(page).toHaveURL(/\/accounts$/);
+    await expect(popoverTitle(page)).toHaveText(ACCOUNT_STEP_TITLES[0]);
+    await expect(popoverProgress(page)).toHaveText(`1 of ${ACCOUNT_STEP_TITLES.length}`);
+    await escapeTour(page);
+    await page.goto('/dashboard');
 
     // THE ASSERTION THIS TEST EXISTS FOR. A user who has completed an item
-    // reaches a LATER set through the UI, from the one control that is on
-    // screen — and it opens at the front of that set, on that set's own screen,
+    // reaches a LATER set through the UI, from the control that set carries —
+    // and it opens at the front of that set, on that set's own screen,
     // because no step index was ever stored to land anywhere else.
     await page.locator('[data-checklist-action="position"]').click();
     await expect(page).toHaveURL(/\/positions$/);

--- a/e2e/tests/user-onboarding.spec.ts
+++ b/e2e/tests/user-onboarding.spec.ts
@@ -242,9 +242,15 @@ async function tabTo(page: Page, selector: string): Promise<void> {
  * Walk the account set from its first step to `stopAt`, opening the account
  * dialog on the way because the six field steps anchor to controls that only
  * exist once it is open.
+ *
+ * The button that opens it is the Accounts page's "New Account", which is where
+ * this set runs: it used to run on the dashboard's welcome screen, and anchoring
+ * it there meant the one walkthrough about creating an account could not be
+ * replayed by anyone who had created one. The form is the same `AccountDialog`
+ * either way, which is why nothing below this line changed with it.
  */
 async function walkAccountSetTo(page: Page, stopAt: number): Promise<void> {
-  await page.getByTestId('zero-state-create-account').click();
+  await page.locator('[data-tour="account-new"]').click();
   await expect(page.getByLabel('Name')).toBeVisible();
   for (let index = 1; index <= stopAt; index += 1) {
     await advanceTo(page, index);
@@ -398,13 +404,17 @@ test.describe('user onboarding', () => {
     await createAccountFromDialog(page, 'Guided account');
     await expect(popoverTitle(page)).toHaveText(ACCOUNT_STEP_TITLES[CREATE_STEP + 1]);
 
-    // Finish. The dashboard behind the tour has already swapped to the grid.
+    // Finish, on the Accounts page the set runs on, with the account the user
+    // just made listed behind it.
     await popoverNext(page).click();
     await expect(popover(page)).toHaveCount(0);
+    await expect(page.getByRole('cell', { name: 'Guided account' })).toBeVisible();
+
+    // And the dashboard has swapped to the grid, off the account that now
+    // exists. Item 1 ticked itself off the user's real data, no flag written.
+    await page.goto('/dashboard');
     await expect(page.getByTestId('onboarding-zero-state')).toHaveCount(0);
     await expect(page.locator('[data-widget-type]').first()).toBeVisible();
-
-    // Item 1 ticked itself off the user's real data, no flag written.
     await expect(checklistProgress(page)).toHaveText('1 of 4 complete');
     await expect(checklistItemLabel(page, 'account')).toHaveText(/— completed$/);
   });
@@ -435,7 +445,7 @@ test.describe('user onboarding', () => {
     await expect(popoverTitle(page)).toHaveText(ACCOUNT_STEP_TITLES[0]);
 
     // And the moment the user does the thing, the tour is there.
-    await page.getByTestId('zero-state-create-account').click();
+    await page.locator('[data-tour="account-new"]').click();
     await expect(popoverTitle(page)).toHaveText(ACCOUNT_STEP_TITLES[1]);
     await escapeTour(page);
   });
@@ -706,16 +716,19 @@ test.describe('user onboarding', () => {
     await walkAccountSetTo(page, CREATE_STEP);
     await createAccountFromDialog(page, 'Exit account');
     await expect(popoverTitle(page)).toHaveText(ACCOUNT_STEP_TITLES[CREATE_STEP + 1]);
-    await expect(page.getByTestId('onboarding-zero-state')).toHaveCount(0);
+    await expect(page.getByRole('cell', { name: 'Exit account' })).toBeVisible();
 
     // Escape — one action, and the tour is abandoned rather than completed.
     await escapeTour(page);
 
-    await expect(checklistProgress(page)).toHaveText('1 of 4 complete');
     // And it is on the server, not just on the screen.
     const accounts = (await (await request.get('/api/accounts')).json()) as { name: string }[];
     expect(accounts.map((account) => account.name)).toEqual(['Exit account']);
 
+    // The checklist counted it, on the screen the checklist lives on, and still
+    // does after a reload: an abandoned walkthrough rolls nothing back.
+    await page.goto('/dashboard');
+    await expect(checklistProgress(page)).toHaveText('1 of 4 complete');
     await page.reload();
     await expect(page.locator('[data-widget-type]').first()).toBeVisible();
     await expect(checklistProgress(page)).toHaveText('1 of 4 complete');
@@ -952,6 +965,12 @@ test.describe('user onboarding', () => {
 
     // Escape ends it in one key, from any step.
     await escapeTour(page);
+
+    // Back to the checklist, which is on the dashboard the account set has just
+    // taken the user off — that set runs on /accounts, where the button it opens
+    // on lives.
+    await page.goto('/dashboard');
+    await expect(page.getByTestId('activation-checklist')).toBeVisible();
 
     // And a set whose steps all live on one screen traverses on the arrow keys
     // alone — the account set cannot, because its field steps need a dialog the


### PR DESCRIPTION
Finishing onboarding removed every way into the guided walkthrough.

The activation checklist puts a play button on each item, and those buttons were the only
way to start or restart a tour. The checklist retires once all four items are complete —
required behaviour, and what lets the onboarding read gate switch its expensive queries
off. So on the fourth completion every entry point disappeared, permanently.

That returned the user to a state already fixed once: the play buttons exist precisely
because someone who had created their first account previously had no way back into the
walkthrough at all. Completing onboarding put them right back there.

## Settings › Help

A "Guided walkthrough" card listing all four sets, each with its own Start. It lives on
the existing Settings surface rather than a new one, and it does not depend on onboarding
state, so it survives retirement.

The constraint that shaped it: **the launcher issues no network request on mount, or on
entering the Help tab.** Retirement is what turns the expensive onboarding reads off, and
an entry point that quietly turned them back on would defeat its own purpose. Verified
with a network spy rather than by reading the hook. Pressing Start does read — one
`GET /positions`, to find the position the close set demonstrates on and to tell the
user's own rows from the sample account's — but only on that explicit click, and only for
the sets that need it.

## Three rounds, and what each got wrong

Worth recording, because every defect here was invisible to unit tests and only a real
browser found them.

**Round 1 shipped two dead buttons.** `close` produced no tour at all even with an open
position. `account` navigated away to the dashboard, showed nothing, then told the user to
"start it again from the setup checklist" — a surface that had retired forever. A notice
pointing at the thing this change exists to replace.

**Round 2 fixed `close` and wrongly declared `account` spec-sized**, on the grounds that
making it run for someone who already has an account meant re-anchoring all nine steps and
rewriting copy. Review disproved that live: every target already resolved except step 1's
zero-state anchor. It needed one anchor attribute, a route on nine steps, and two
rewritten paragraphs. Mechanical work, nearly shipped as a permanently explaining button.

**Round 2 also introduced a subtler failure.** The click-time read used `ensureQueryData`,
which serves cached-but-stale data without refetching. So a user refused for `close`, who
went and logged a position and came back, was refused again — with zero network requests.
Only a full reload helped. The notice told them to do something that then did not work.
Now `fetchQuery`, and the loop was re-run to confirm the second attempt starts.

## Found and fixed along the way

With sample data present, the New Account button raises a teardown confirmation
*underneath* the tour overlay, so the tour's own click on it killed the walkthrough
silently. That is now refused in words instead, and removing the sample data makes the set
run.

## Verification

All four sets driven live from Settings as a retired user: account 1/9 through to 9/9 with
a real account created, calculator 1/7, position 1/5, close 1/3 on the user's own position.

The regression that mattered most was the brand-new-user path — the account set is also the
first tour someone meets from the zero state, and its steps were rerouted. Driven live with
a fresh account-less user: still runs 1/9 to 9/9, checklist item ticks, and the rewritten
copy still reads correctly for someone who has never created an account.

One e2e assertion encoded the old rule that a completed item's Start disappears. This change
deliberately reverses that, so it was updated to assert what is now correct — and
strengthened rather than loosened: it checks the control is present *and* that pressing it
really runs the set.

562 scoped web tests, 13/13 on the onboarding e2e spec, typecheck and lint clean after
rebasing onto current main. Every assertion proved by deliberate breakage.
