### PR TITLE
fix(onboarding): stop tour popovers covering controls, and measure for it

### DIFF
--- a/apps/web/src/features/dashboard/components/DashboardHeader.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardHeader.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from 'react';
+import { useState, type ReactElement, type ReactNode } from 'react';
 
 import type { WidgetPlacement, WidgetType } from '@tradr/shared';
 
@@ -28,6 +28,27 @@ export interface DashboardHeaderProps {
   onResetLayout?: () => void;
   /** Disables the reset action while the default layout is being rebuilt. */
   resetBusy?: boolean;
+  /**
+   * The dashboard's coach mark, rendered BESIDE THE HEADING — which is where
+   * every other surface's mark sits (`ImportPage`, `OptionsPage`,
+   * `PositionDetail` all put it immediately after their `<h1>`/`<h2>`), and
+   * where it has to sit here too.
+   *
+   * A coach mark opens below its anchor. Anchored at the far right of this row,
+   * as this one was, it opens over the right-hand edge of everything beneath —
+   * which on the dashboard is the column the app keeps its per-row and per-card
+   * buttons in. Measured in Chromium at 1280x720, the card landed at x
+   * 984-1272 with its "Got it" directly on top of the activation checklist's
+   * play button for "Log a position" (x 1207-1239): a click aimed at the play
+   * button pressed "Got it" instead. Those play buttons are the only way back
+   * into a walkthrough once the zero-state has gone, so the mark was covering
+   * the control that restores the thing it is a substitute for. With the
+   * checklist retired it landed on the first widget's card menu instead.
+   *
+   * Beside the heading the card opens over body text and nothing else. The
+   * prop exists because the heading lives in here, not in the route.
+   */
+  coachMark?: ReactNode;
 }
 
 /**
@@ -50,12 +71,16 @@ export function DashboardHeader({
   onAdd,
   onResetLayout,
   resetBusy,
+  coachMark,
 }: DashboardHeaderProps): ReactElement {
   const [confirmingReset, setConfirmingReset] = useState(false);
 
   return (
     <header data-slot="dashboard-header" className="flex items-center justify-between gap-2">
-      <h1 className="text-2xl font-bold">Dashboard</h1>
+      <div className="flex items-center gap-2">
+        <h1 className="text-2xl font-bold">Dashboard</h1>
+        {coachMark}
+      </div>
       <div className="flex items-center gap-2">
         <AddWidgetPopover placedTypes={placedTypes} onAdd={onAdd} />
         {onResetLayout ? (

--- a/apps/web/src/features/onboarding/lib/steps/account.ts
+++ b/apps/web/src/features/onboarding/lib/steps/account.ts
@@ -40,6 +40,36 @@
  *   Profile (`ReportingTimezoneSelect`). A user must not be able to conclude
  *   that setting one has set the other, so the trading-day step disclaims it
  *   and this set closes by naming it on its own.
+ *
+ * BESIDE THE DIALOG, NEVER OVER IT — every field step declares `side: 'left'`,
+ * and that is a fix rather than a preference.
+ *
+ * Left to itself, driver.js puts the popover below the field it is describing,
+ * which on a stack of form rows is on top of the next two. Measured in Chromium
+ * at 1280x720, with the dialog's controls running x 409-871: the Name step's
+ * popover (x 399-699) covered the middle of Currency and of Trading-day
+ * timezone; the Currency step's covered Trading-day timezone; the Trading-day
+ * step's covered Starting balance and three of the four risk presets; and the
+ * Starting balance step's covered those presets and Brokerage.
+ *
+ * NONE OF THOSE STEPS WAS UNFINISHABLE, which is exactly why it survived six
+ * rounds of fixing this class one control at a time: each step's OWN field was
+ * always clear, so every test that drove the tour passed. The user it costs is
+ * the one who fills the form in their own order, or who changes their mind and
+ * reaches for Cancel, and finds a control that will not take a click with
+ * nothing on screen to say why. `tour.css` deliberately hands the whole dialog
+ * back its `pointer-events` while a tour is running, so these ARE live controls
+ * with a popover sitting on them.
+ *
+ * Left of the field the popover lands at x 89-399, clear of every control in
+ * the dialog. The last two field steps already resolved there because nothing
+ * else fitted; declaring it makes the placement a property of the step rather
+ * than of the space left over, and keeps one placement for the whole walk of
+ * one form instead of the popover jumping sides halfway down it.
+ *
+ * The submit step is the exception, and goes ABOVE: its control is at the
+ * bottom right of the dialog, so "left" is on top of Cancel — which is the one
+ * control a user reaching past the walkthrough is most likely to want.
  */
 
 import type { WalkthroughStepSource } from './index';
@@ -75,6 +105,7 @@ export const accountSteps: readonly WalkthroughStepSource[] = [
     // seconds later and ended the walkthrough on a field that was about to
     // exist. It still ends cleanly for a dialog that is genuinely never opened.
     waitForMs: 15000,
+    side: 'left',
     title: 'Name',
     body:
       'Name the account after the brokerage account it mirrors. You pick it by this name every ' +
@@ -84,6 +115,7 @@ export const accountSteps: readonly WalkthroughStepSource[] = [
     target: '#currency',
     route: '/accounts',
     docs: 'gettingStarted',
+    side: 'left',
     title: 'Currency',
     body:
       'The currency this account trades in. Its balance, fees and P&amp;L are all recorded and ' +
@@ -93,6 +125,7 @@ export const accountSteps: readonly WalkthroughStepSource[] = [
     target: '#timezone',
     route: '/accounts',
     docs: 'gettingStarted',
+    side: 'left',
     title: 'Trading-day timezone',
     body:
       'This defaults to America/New_York because NYSE, NASDAQ and NYSE Arca all operate on US ' +
@@ -104,6 +137,7 @@ export const accountSteps: readonly WalkthroughStepSource[] = [
     target: '#startingBalance',
     route: '/accounts',
     docs: 'gettingStarted',
+    side: 'left',
     title: 'Starting balance',
     body:
       'The account&rsquo;s opening cash, and the baseline every later figure is measured against. ' +
@@ -115,6 +149,7 @@ export const accountSteps: readonly WalkthroughStepSource[] = [
     target: '#defaultRiskPercent',
     route: '/accounts',
     docs: 'gettingStarted',
+    side: 'left',
     title: 'Default risk %',
     body:
       'The share of this account&rsquo;s balance you risk on a single trade. It prefills the ' +
@@ -128,6 +163,7 @@ export const accountSteps: readonly WalkthroughStepSource[] = [
     target: '#brokerage',
     route: '/accounts',
     docs: 'gettingStarted',
+    side: 'left',
     title: 'Brokerage',
     body:
       'Choose a brokerage and Tradr calculates and records this account&rsquo;s fees from that ' +
@@ -138,6 +174,16 @@ export const accountSteps: readonly WalkthroughStepSource[] = [
     target: '[data-tour="account-submit"]',
     route: '/accounts',
     docs: 'gettingStarted',
+    // ABOVE THE FOOTER, NOT BESIDE IT. Every other step on this dialog goes
+    // left; this one cannot, because Cancel is what is immediately to the left
+    // of the control it highlights, and the popover reached 68px across it.
+    // Above and end-aligned, the popover clears the whole footer row.
+    // ABOVE THE FOOTER, NOT BESIDE IT. Every other step on this dialog goes
+    // left; this one cannot, because Cancel is what is immediately to the left
+    // of the control it highlights, and the popover reached 68px across it.
+    // Above and end-aligned, the popover clears the whole footer row.
+    side: 'top',
+    align: 'end',
     advanceOnAction: true,
     title: 'Create the account',
     body:

--- a/apps/web/src/features/onboarding/lib/steps/account.ts
+++ b/apps/web/src/features/onboarding/lib/steps/account.ts
@@ -178,10 +178,6 @@ export const accountSteps: readonly WalkthroughStepSource[] = [
     // left; this one cannot, because Cancel is what is immediately to the left
     // of the control it highlights, and the popover reached 68px across it.
     // Above and end-aligned, the popover clears the whole footer row.
-    // ABOVE THE FOOTER, NOT BESIDE IT. Every other step on this dialog goes
-    // left; this one cannot, because Cancel is what is immediately to the left
-    // of the control it highlights, and the popover reached 68px across it.
-    // Above and end-aligned, the popover clears the whole footer row.
     side: 'top',
     align: 'end',
     advanceOnAction: true,

--- a/apps/web/src/features/onboarding/lib/steps/calculator.ts
+++ b/apps/web/src/features/onboarding/lib/steps/calculator.ts
@@ -28,6 +28,23 @@
  *   risk lands at or under the budget rather than on it.
  * - Card titles are "Position Sizing" and "Risk / Reward"; the rows named below
  *   are that component's own labels. Risk / Reward renders only with a target.
+ *
+ * BESIDE THE FORM, NEVER OVER IT — every field step declares `side: 'right'`.
+ *
+ * `CalculatorForm` is a two-column grid: the form on the left, the results on
+ * the right. Left to itself driver.js put the popover wherever it happened to
+ * fit, which on a short page is BELOW the field it is describing and therefore
+ * on top of the next two. Measured in Chromium at 1280x720, reached the way a
+ * user with no account reaches it — the entry-price popover at x 254-554,
+ * y 472-680 sat squarely over the middle of both Stop loss and Target price
+ * (x 264-748). It moved as the page did: the same step, on the same viewport,
+ * placed itself to the RIGHT for a user who had an account, so this was a
+ * defect that appeared and disappeared with the layout rather than one anybody
+ * would reliably see and report.
+ *
+ * Right of the field is the results column, which is read-only: `CalculatorResults`
+ * renders figures and no controls at all, so nothing there can be covered.
+ * Declaring it also stops the placement moving with the page height.
  */
 
 import type { WalkthroughStepSource } from './index';
@@ -41,6 +58,7 @@ export const calculatorSteps: readonly WalkthroughStepSource[] = [
     // step waits for the calculator to mount rather than assuming the
     // navigation has already landed.
     waitForMs: 5000,
+    side: 'right',
     title: 'Entry price',
     body:
       'Start with the price you plan to get in at. Nothing here is submitted or saved — the ' +
@@ -50,6 +68,7 @@ export const calculatorSteps: readonly WalkthroughStepSource[] = [
     target: '#stopLoss',
     route: '/calculator',
     docs: 'gettingStarted',
+    side: 'right',
     title: 'Stop loss',
     body:
       'The price at which you would accept the trade is wrong. The distance from entry to stop ' +
@@ -60,6 +79,7 @@ export const calculatorSteps: readonly WalkthroughStepSource[] = [
     target: '#targetPrice',
     route: '/calculator',
     docs: 'gettingStarted',
+    side: 'right',
     title: 'Target price (optional)',
     body:
       'Optional, as the label says. Add it and you also get the Per-unit reward and the ' +
@@ -69,6 +89,7 @@ export const calculatorSteps: readonly WalkthroughStepSource[] = [
     target: '[data-tour="calculator-risk"]',
     route: '/calculator',
     docs: 'gettingStarted',
+    side: 'right',
     advanceOnAction: true,
     title: 'Risk',
     body:
@@ -81,6 +102,7 @@ export const calculatorSteps: readonly WalkthroughStepSource[] = [
     route: '/calculator',
     docs: 'gettingStarted',
     waitForMs: 3000,
+    side: 'right',
     advanceOnAction: true,
     title: 'Account',
     body:
@@ -95,6 +117,7 @@ export const calculatorSteps: readonly WalkthroughStepSource[] = [
     route: '/calculator',
     docs: 'gettingStarted',
     waitForMs: 3000,
+    side: 'right',
     title: 'The amount at risk',
     body:
       'Under Percent, Risk percent is prefilled from that account&rsquo;s Default risk % when it ' +

--- a/apps/web/src/features/onboarding/lib/steps/calculator.ts
+++ b/apps/web/src/features/onboarding/lib/steps/calculator.ts
@@ -45,6 +45,25 @@
  * Right of the field is the results column, which is read-only: `CalculatorResults`
  * renders figures and no controls at all, so nothing there can be covered.
  * Declaring it also stops the placement moving with the page height.
+ *
+ * THE LAST STEP IS THE ONE THAT CANNOT BE BESIDE ANYTHING, and it is left over
+ * the form on purpose. It anchors to the results panel, and driver.js will only
+ * use a side the popover fits on: measured in Chromium at 1280x720, the panel
+ * lands at x 772-1256, y 0-780 once driver.js has scrolled it in, and the
+ * popover is 300x268. Above wants 278px over a top edge at 0, below wants 278px
+ * under a bottom edge at 780, right wants 300px past 1256 — none of the three
+ * exist, so `left` is the only side there is, whatever the step declares, and
+ * left is x 452-752 against a form column at x 264-748. Centring instead is
+ * worse, not better: driver.js centres on the VIEWPORT rather than on the
+ * element, which is x 490-790, y 226-494 — three fields rather than two.
+ *
+ * What it covers there is `#symbol` whole and the top 10px of `#entryPrice`,
+ * and neither is anybody's to press: a running tour holds the page inert and
+ * the wash says so. That is the one case `e2e/support/popover-clearance.ts`
+ * gates out by design, and the reason it reads `pointer-events` rather than
+ * geometry alone. It went red here once, and the popover was not what had
+ * moved — the tour had leaked a live control under it. See `tour-engine.ts`,
+ * `releaseStaleHighlights`.
  */
 
 import type { WalkthroughStepSource } from './index';

--- a/apps/web/src/features/onboarding/lib/tour-engine.test.ts
+++ b/apps/web/src/features/onboarding/lib/tour-engine.test.ts
@@ -613,6 +613,41 @@ describe('missing targets', () => {
   });
 });
 
+/**
+ * ONE CONTROL IS THE HIGHLIGHTED ONE, AND A STEP CHANGE THAT ARRIVES EARLY MUST
+ * NOT LEAVE A SECOND ONE BEHIND.
+ *
+ * `driver-active-element` carries the lock as well as the ring: `driver.css`
+ * takes `pointer-events` off the whole page and gives them back to that element,
+ * so a stale copy is a control the dimming says is locked and is not. driver.js
+ * decides what to un-highlight from a value it only writes when a step's 400ms
+ * transition finishes, so a press inside that window strands the class on the
+ * control the abandoned transition had just moved to.
+ *
+ * ANIMATION ON IS THE POINT, not incidental: with `prefers-reduced-motion` the
+ * engine passes `animate: false` and driver.js does its bookkeeping inline, so
+ * the window does not exist and this test would pass against the bug. Every
+ * other test here runs reduced — this one must not.
+ */
+describe('a highlight the tour has moved off', () => {
+  it('is released even when the next step arrives before the transition ends', () => {
+    stubReducedMotion(false);
+    startTour(TWO_STEPS);
+    expect(document.querySelector('#one')?.classList.contains('driver-active-element')).toBe(true);
+
+    // No wait: the whole defect is the step change that lands inside the
+    // previous step's transition.
+    advance();
+
+    expect(document.querySelectorAll('.driver-active-element')).toHaveLength(1);
+    expect(document.querySelector('#two')?.classList.contains('driver-active-element')).toBe(true);
+    // And the ARIA driver.js sets beside the class goes with it, or the control
+    // the tour has left goes on announcing itself as the popover's trigger.
+    expect(document.querySelector('#one')?.hasAttribute('aria-haspopup')).toBe(false);
+    expect(document.querySelector('#one')?.getAttribute('aria-expanded')).toBeNull();
+  });
+});
+
 describe('reduced motion', () => {
   it('disables animation when the user prefers reduced motion', () => {
     stubReducedMotion(true);

--- a/apps/web/src/features/onboarding/lib/tour-engine.ts
+++ b/apps/web/src/features/onboarding/lib/tour-engine.ts
@@ -346,7 +346,59 @@ function handleKeyup(event: KeyboardEvent): void {
   }
 }
 
+/**
+ * EXACTLY ONE CONTROL IS THE HIGHLIGHTED ONE — which driver.js 1.8.0 does not
+ * guarantee, and the gap is a control the tour has walked away from that stays
+ * live and outlined for the rest of the walkthrough.
+ *
+ * `driver-active-element` is what the lock turns on. `driver.css` takes
+ * `pointer-events` off `.driver-active *` and hands them back to
+ * `.driver-active .driver-active-element` and its descendants, and `tour.css`
+ * draws the focus ring on the same selector. So the class is both "this is the
+ * control the step is about" and "this is the one thing on the page you may
+ * still press".
+ *
+ * driver.js decides which element to take it OFF by reading `__activeElement`,
+ * and it only writes that value when a step's 400ms highlight transition runs to
+ * completion — from a `requestAnimationFrame` loop that abandons itself the
+ * moment a newer transition starts. So a step change that lands inside the
+ * previous step's 400ms reads a stale `__activeElement`, strips the class from
+ * an element that never had it, and leaves it on the one the abandoned
+ * transition had just added it to. Nothing removes it again until the tour is
+ * destroyed.
+ *
+ * Reproduced against the real stack: two "Next" presses in one tick leave the
+ * middle step's control carrying the class, `pointer-events: auto` and the focus
+ * ring, six steps after the tour moved off it — and a walkthrough opened onto a
+ * busy page does the same to its FIRST control, because the opening highlight is
+ * a transition too and the user's first press beats its commit. It shows up as a
+ * ring on the wrong control, and it means a control the dimming says is locked
+ * is not.
+ *
+ * Fixed here rather than upstream because this hook is the one moment we know a
+ * new highlight is starting: driver.js calls it BEFORE it moves the class, so
+ * clearing every stale copy leaves it to add the one that belongs, and the end
+ * state is the same one it intended. `element` is skipped so a re-highlight of
+ * the step already showing does not blink its own ring off and on.
+ */
+function releaseStaleHighlights(element: Element | undefined): void {
+  for (const stale of document.querySelectorAll('.driver-active-element')) {
+    if (stale === element) continue;
+    stale.classList.remove('driver-active-element', 'driver-no-interaction');
+    // driver.js sets these three alongside the class and takes them off the same
+    // stale reference, so they are left behind by the same race: a control the
+    // tour has left would keep announcing itself as the popover's trigger.
+    stale.removeAttribute('aria-haspopup');
+    stale.removeAttribute('aria-expanded');
+    stale.removeAttribute('aria-controls');
+  }
+}
+
 const handleHighlightStarted: DriverHook = (element, _driveStep, opts) => {
+  // Before anything that can return: a step whose target went missing ends the
+  // tour, and the control the PREVIOUS step highlighted must not outlive it.
+  releaseStaleHighlights(element);
+
   const index = opts.index ?? -1;
   const step = activeSteps[index];
   if (!step) return;

--- a/apps/web/src/routes/_auth.dashboard.test.tsx
+++ b/apps/web/src/routes/_auth.dashboard.test.tsx
@@ -788,11 +788,21 @@ describe('_auth.dashboard route — the widget coach mark', () => {
     const { container } = renderRoute();
 
     expect(screen.getByTestId('coach-mark-dashboard-widgets')).toBeTruthy();
-    // Anchored in the header row, not floating somewhere else on the page: the
-    // mark points at the widget controls it describes.
+    // INSIDE the header, beside the heading — not merely somewhere on the page,
+    // and not at the right-hand end of the row, which is where it used to sit.
+    // A coach mark opens BELOW its anchor, so an anchor at the right-hand end
+    // opens the card over the column the dashboard keeps its buttons in: the
+    // checklist's per-item play buttons, and the widget card menus once the
+    // checklist has retired. Measured at 1280x720, its "Got it" landed exactly
+    // on the play button for "Log a position" — the control that restarts a
+    // walkthrough. The e2e suite measures that; this pins the structure the
+    // measurement depends on.
     const anchor = container.querySelector('[data-slot="coach-mark-anchor"]');
     expect(anchor).not.toBeNull();
-    expect(anchor!.parentElement!.querySelector('[data-slot="dashboard-header"]')).not.toBeNull();
+    const header = anchor!.closest('[data-slot="dashboard-header"]');
+    expect(header).not.toBeNull();
+    // Beside the heading specifically: same parent, heading first.
+    expect(anchor!.parentElement!.querySelector('h1')?.textContent).toBe('Dashboard');
   });
 
   it('stays off the zero-state, which has one thing to say and is entitled to say it', () => {

--- a/apps/web/src/routes/_auth.dashboard.tsx
+++ b/apps/web/src/routes/_auth.dashboard.tsx
@@ -464,20 +464,21 @@ function DashboardPage(): ReactElement {
           layout button, and the zero-state above returns before either. A mark
           also has to stay off a surface the deployment does not offer, but
           there is no deployment gate to consult here: the grid is local layout
-          state persisted per user, configured nowhere. */}
-      <div className="flex items-center gap-2">
-        <div className="flex-1">
-          <DashboardHeader
-            placedTypes={placedTypes}
-            onAdd={handleAdd}
-            onResetLayout={() => {
-              void handleUseDefaultLayout();
-            }}
-            resetBusy={defaultBusy}
-          />
-        </div>
-        <CoachMark surface="dashboard-widgets" />
-      </div>
+          state persisted per user, configured nowhere.
+
+          It is handed to the header rather than placed beside it so that it
+          anchors to the HEADING, as every other surface's mark does — see the
+          prop's own note. Anchored at the right-hand end of this row it opened
+          on top of the checklist's play buttons. */}
+      <DashboardHeader
+        placedTypes={placedTypes}
+        onAdd={handleAdd}
+        onResetLayout={() => {
+          void handleUseDefaultLayout();
+        }}
+        resetBusy={defaultBusy}
+        coachMark={<CoachMark surface="dashboard-widgets" />}
+      />
       {/* Above the grid, below the page heading and its actions — see the note
           on the empty branch. */}
       <ChecklistSlot />

--- a/e2e/support/popover-clearance.ts
+++ b/e2e/support/popover-clearance.ts
@@ -28,6 +28,46 @@
  * defect. The test for it is the element's own resolved `pointer-events`, which
  * is the same value the browser decides hit-testing by.
  *
+ * WHAT A GREEN RUN HERE PROVES — AND WHERE IT NARROWS TO ALMOST NOTHING. Because
+ * the gate is `pointer-events`, the size of the set this sweeps is the size of
+ * the set the page has left live, and that varies enormously step to step. All
+ * three of these were measured in Chromium at 1280x720, walking the account set:
+ *
+ *   A STEP WITH ONE OF THE APP'S DIALOGS OPEN — 12 controls on screen, 0 gated
+ *   out, all 12 measured. `tour.css` hands the whole dialog its `pointer-events`
+ *   back, so the sweep is at full strength exactly where it matters most: every
+ *   one of the six shipped defects was a control on an open dialog.
+ *
+ *   A STEP HIGHLIGHTING A CONTROL, NO DIALOG — 24 on screen, 23 gated out, 1
+ *   measured, and that one is the highlighted control itself. driver.js has made
+ *   the rest of the page inert, so here the sweep is no stronger than the
+ *   per-step assertion it exists to generalise beyond. It is not finding
+ *   anything new on these steps; it is confirming the same one control.
+ *
+ *   A STEP THAT HIGHLIGHTS NOTHING (the closing aside) — 28 on screen, 28 gated
+ *   out, 0 measured. It asserts nothing whatever there, which is right, because
+ *   there is nothing on that screen a user can press.
+ *
+ * So "every step swept clear" does NOT mean "every control on every step was
+ * checked". Read a pass as: nothing the page had left live was covered.
+ *
+ * THE GATE IS SOUND FOR THE POINTER, AND CLAIMS NOTHING BEYOND IT. Measured on
+ * the same step: a real mouse click at the dead centre of a gated button fired
+ * neither `pointerdown` nor `click` on it, `elementFromPoint` there returned the
+ * overlay's own `<path>` rather than the button, and the click closed the tour —
+ * which is where it had actually landed. The pointer genuinely cannot reach it.
+ * What `pointer-events: none` does NOT do is make the control inert: it stays
+ * `tabIndex` 0, still takes focus, and Enter and Space still fire its click
+ * handler. That costs this assertion nothing, because a prompt's geometry cannot
+ * block a keyboard activation — a covered control that is operated by keyboard
+ * is operated whether the prompt is on it or a screen away. What the overlap
+ * does cost that user is the sight of their own focus ring, and no measurement
+ * in this file is about that.
+ *
+ * There is deliberately no "the sweep looked at at least one control" guard
+ * against a silently empty pass, tempting as it is: the closing step above has
+ * legitimately zero, so the guard would fail on correct code.
+ *
  * WHAT COUNTS AS "THE PROMPT IS ON IT" IS ANY OVERLAP THE PROMPT WOULD WIN, not
  * a swallowed click. Those are not the same test, and the difference is the
  * whole reason this class kept getting through: Playwright hit-tests the CENTRE
@@ -154,8 +194,12 @@ export async function findCoveredControls(
       if (el.closest('[aria-hidden="true"],[data-aria-hidden="true"],[inert]') !== null) continue;
 
       const style = getComputedStyle(el);
-      // THE GATE. A control the page has already made unclickable is not one the
-      // prompt is blocking — see the note at the top of the file.
+      // THE GATE, and the reason this sweep is narrower than its name. A control
+      // the page has already made unclickable is not one the prompt is blocking.
+      // It is also most of them on a tour-locked step — 23 of 24 on one measured
+      // here — so read the note at the top of the file before trusting a pass:
+      // it says what a green run does and does not establish, and why the gate
+      // is right about the pointer and silent about the keyboard.
       if (style.pointerEvents === 'none') continue;
       if (style.visibility === 'hidden' || style.display === 'none') continue;
 

--- a/e2e/support/popover-clearance.ts
+++ b/e2e/support/popover-clearance.ts
@@ -1,0 +1,280 @@
+/**
+ * DOES THE PROMPT ON SCREEN STAND ON TOP OF ANYTHING THE USER CAN STILL PRESS?
+ *
+ * The onboarding surfaces have now shipped six separate versions of one defect:
+ * a walkthrough popover or a coach mark laid over a control. A combobox on the
+ * import screen, the fill dialog's Add button twice, the account dialog's
+ * neighbouring fields, the checklist's play button. Each was found by a person,
+ * fixed on its own, and pinned by a test naming that one control — so the next
+ * one had nothing to fail against and was found by a person too.
+ *
+ * The reason a per-control test cannot close it is that each fix asserted the
+ * control the CURRENT STEP DESCRIBES is clear. Every one of these defects was a
+ * control the step said nothing about: the neighbour, the Cancel, the button
+ * that restarts the walkthrough. Nobody writes an assertion for a control their
+ * step is not about, which is exactly the set the defect lives in.
+ *
+ * So this measures the prompt against EVERY control the user could press at that
+ * moment, and the caller names none of them.
+ *
+ * WHAT COUNTS AS "COULD PRESS", AND WHY IT IS NOT "IS ON SCREEN". A running tour
+ * deliberately locks the page: driver.js drops `pointer-events` on everything and
+ * hands them back to the highlighted control, the popover, and — because
+ * `tour.css` says so — to a dialog the tour itself told the user to open. A
+ * popover lying over a widget the tour has already made inert blocks nothing;
+ * the wash over it says so on screen. A popover lying over the Currency field of
+ * the open account dialog blocks a control the user can see, can tab to, and
+ * would expect to click. Those are different things, and only the second is a
+ * defect. The test for it is the element's own resolved `pointer-events`, which
+ * is the same value the browser decides hit-testing by.
+ *
+ * WHAT COUNTS AS "THE PROMPT IS ON IT" IS ANY OVERLAP THE PROMPT WOULD WIN, not
+ * a swallowed click. Those are not the same test, and the difference is the
+ * whole reason this class kept getting through: Playwright hit-tests the CENTRE
+ * of the box it is about to click, so a prompt lying across a control's edge and
+ * stopping short of its middle dispatches cleanly and every click-based
+ * assertion goes green over an overlap a user can see and can land a pointer in.
+ * That is the exact state the two fill-dialog steps shipped in — 21px of popover
+ * across the Add button, 9px of clearance at its centre — and the state the
+ * account dialog's Cancel was in, 68px under the popover with its middle free.
+ * So the rule here is the strict one `expectClearOfPopover` below already holds
+ * the step's own control to, applied to every control instead of one.
+ *
+ * Two questions, answered by the two things that can answer them:
+ *
+ *   DO THEY OVERLAP AT ALL? Rectangles. Any intersection counts.
+ *
+ *   AND WOULD THE PROMPT WIN THERE? `elementFromPoint`, in the middle of that
+ *   intersection. This is the browser's own hit test, so stacking, opacity and
+ *   `pointer-events` are all accounted for without re-deriving any of them —
+ *   which matters most for the coach mark, whose card is deliberately
+ *   transparent to the pointer (a click goes straight through it to the control
+ *   underneath, and dismisses the mark on the way) while the "Got it" and "Read
+ *   more" inside it opt back in and DO catch clicks. Rectangles alone would fail
+ *   the harmless case and pass the real one; the hit test tells them apart. It
+ *   also means a control that is on top of the prompt — a select's dropdown, a
+ *   dialog raised over it — is correctly not a hit.
+ *
+ * The overlap is reported in pixels, because "Got it is on top of the play
+ * button" is not something the next person should have to re-derive from a
+ * screenshot.
+ */
+
+import { expect, type Locator, type Page } from '@playwright/test';
+
+/** The driver.js walkthrough popover. */
+export const WALKTHROUGH_POPOVER = '.driver-popover';
+/** A coach mark's card — `CoachMark.tsx` sets the attribute for exactly this. */
+export const COACH_MARK = '[data-coach-mark]';
+
+export interface ClearanceRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface ClearanceHit {
+  /** The control, named the way the person reading the failure would name it. */
+  what: string;
+  /** Intersection of prompt and control, in px — reported, never asserted on. */
+  dx: number;
+  dy: number;
+  control: ClearanceRect;
+  prompt: ClearanceRect;
+}
+
+/**
+ * Every live control the prompt is lying across and would win a click on.
+ *
+ * Returns an empty list when the prompt is not on screen: a step with no prompt
+ * covers nothing, and making that an error would turn every teardown assertion
+ * into a race.
+ */
+export async function findCoveredControls(
+  page: Page,
+  promptSelector: string,
+): Promise<ClearanceHit[]> {
+  return page.evaluate((selector) => {
+    const promptEl = document.querySelector(selector);
+    if (promptEl === null) return [];
+    const promptBox = promptEl.getBoundingClientRect();
+    if (promptBox.width === 0 || promptBox.height === 0) return [];
+
+    // Anything a user can operate. Deliberately wider than "button": the six
+    // shipped instances covered a combobox, a text field, a select and three
+    // buttons between them.
+    //
+    // A `label` that WRAPS a control is in the list because on some of these
+    // forms it is the only thing a pointer can be aimed at: the account
+    // dialog's risk presets are button-styled labels around `sr-only` radios,
+    // so the radio is a clipped 1x1 point nobody clicks and the label is the
+    // whole control as far as the user is concerned. A `label` that merely
+    // points at a control with `for` is NOT — that one is a caption sitting
+    // beside its field, and the field is already measured on its own account.
+    const INTERACTIVE = [
+      'button',
+      '[role="button"]',
+      'a[href]',
+      'input:not([type="hidden"])',
+      'select',
+      'textarea',
+      'label:has(> input:not([type="hidden"]))',
+      '[role="combobox"]',
+      '[role="checkbox"]',
+      '[role="switch"]',
+      '[role="radio"]',
+      '[role="tab"]',
+      '[role="menuitem"]',
+      '[role="option"]',
+      '[contenteditable="true"]',
+    ].join(',');
+
+    function rect(box: DOMRect) {
+      return { x: box.x, y: box.y, width: box.width, height: box.height };
+    }
+
+    function describe(el: Element): string {
+      const bits = [el.tagName.toLowerCase()];
+      if (el.id !== '') bits.push(`#${el.id}`);
+      const label =
+        el.getAttribute('aria-label') ??
+        (el.textContent ?? '').replace(/\s+/g, ' ').trim().slice(0, 48);
+      const testid = el.getAttribute('data-testid');
+      if (testid !== null) bits.push(`[data-testid="${testid}"]`);
+      return label === '' ? bits.join('') : `${bits.join('')} "${label}"`;
+    }
+
+    const covered: ClearanceHit[] = [];
+    for (const el of Array.from(document.querySelectorAll(INTERACTIVE))) {
+      // The prompt's own controls are the prompt.
+      if (promptEl.contains(el)) continue;
+      // Hidden from everyone, or explicitly inert — a modal dialog marks the
+      // whole app behind it this way, and none of it is anybody's to click.
+      if (el.closest('[aria-hidden="true"],[data-aria-hidden="true"],[inert]') !== null) continue;
+
+      const style = getComputedStyle(el);
+      // THE GATE. A control the page has already made unclickable is not one the
+      // prompt is blocking — see the note at the top of the file.
+      if (style.pointerEvents === 'none') continue;
+      if (style.visibility === 'hidden' || style.display === 'none') continue;
+
+      const box = el.getBoundingClientRect();
+      // Visually hidden rather than merely small — an `sr-only` control is
+      // clipped to a point, so no pointer is ever aimed at it and nothing can
+      // be said to be covering it. Where one of these carries a real target it
+      // is the label wrapped round it, which is measured in its own right.
+      if (box.width < 4 || box.height < 4) continue;
+
+      // DO THEY OVERLAP AT ALL — any intersection, not just a covered centre.
+      const left = Math.max(promptBox.left, box.left);
+      const right = Math.min(promptBox.right, box.right);
+      const top = Math.max(promptBox.top, box.top);
+      const bottom = Math.min(promptBox.bottom, box.bottom);
+      if (right <= left || bottom <= top) continue;
+
+      const cx = (left + right) / 2;
+      const cy = (top + bottom) / 2;
+      // Off screen: no pointer can reach it there whatever the prompt does.
+      if (cx < 0 || cy < 0 || cx > window.innerWidth || cy > window.innerHeight) continue;
+
+      // AND WOULD THE PROMPT WIN THERE — asked of the browser rather than of
+      // arithmetic, in the middle of the overlap.
+      const hit = document.elementFromPoint(cx, cy);
+      if (hit === null || hit.closest(selector) === null) continue;
+
+      covered.push({
+        what: describe(el),
+        dx: right - left,
+        dy: bottom - top,
+        control: rect(box),
+        prompt: rect(promptBox),
+      });
+    }
+    return covered;
+  }, promptSelector);
+}
+
+function report(hits: ClearanceHit[], where: string): string {
+  const lines = hits.map(
+    (hit) =>
+      `  • ${hit.what} — overlapped by ${hit.dx.toFixed(0)}x${hit.dy.toFixed(0)}px ` +
+      `(control x ${hit.control.x.toFixed(0)}–${(hit.control.x + hit.control.width).toFixed(0)}, ` +
+      `y ${hit.control.y.toFixed(0)}–${(hit.control.y + hit.control.height).toFixed(0)})`,
+  );
+  const prompt = hits[0]?.prompt;
+  const promptLine =
+    prompt === undefined
+      ? ''
+      : `\nprompt x ${prompt.x.toFixed(0)}–${(prompt.x + prompt.width).toFixed(0)}, ` +
+        `y ${prompt.y.toFixed(0)}–${(prompt.y + prompt.height).toFixed(0)}`;
+  return (
+    `${where}: the prompt is standing on ${hits.length} control(s) the user can still press. ` +
+    `Move it (side/align on the step, or the anchor for a coach mark) — do not narrow this ` +
+    `assertion to the controls the step happens to describe.${promptLine}\n${lines.join('\n')}`
+  );
+}
+
+/**
+ * NOTHING THE USER CAN PRESS IS UNDER THE PROMPT. Call it at every step of every
+ * set and on every coach mark; it names no control, so a control added tomorrow
+ * is covered by it today.
+ *
+ * One round trip and one pass over the document — a few milliseconds, which is
+ * why it can afford to run on every step rather than on the ones somebody
+ * remembered.
+ */
+export async function expectPromptClearOfEveryControl(
+  page: Page,
+  promptSelector: string,
+  where: string,
+): Promise<void> {
+  // `toPass` rather than a single read: a step change animates for 400ms and a
+  // Radix popover positions itself after its first paint, so a bare read can
+  // catch either mid-flight. It settles on the first attempt in the ordinary
+  // case and costs nothing extra there.
+  await expect(async () => {
+    const hits = await findCoveredControls(page, promptSelector);
+    expect(hits.length === 0, hits.length === 0 ? where : report(hits, where)).toBe(true);
+  }).toPass({ timeout: 5_000, intervals: [100, 200, 400, 800] });
+}
+
+/**
+ * THE POPOVER MUST NOT LIE ACROSS THE CONTROL ITS OWN STEP IS FINISHED BY, and
+ * a click cannot always tell you that it does.
+ *
+ * Playwright hit-tests the CENTRE of the box it is about to click, so a popover
+ * that covers a control's edge — but stops short of its middle — dispatches
+ * cleanly and the suite goes green over an overlap a user can see and can land
+ * a pointer in. That is exactly the state the two fill-dialog steps shipped in:
+ * the popover sat 21px across the Add button's right-hand end while its centre
+ * stayed 9px clear, so every real click here passed.
+ *
+ * Measuring the rectangles is what closes that gap, and it is why this stays
+ * alongside the sweep above rather than being replaced by it: the sweep asks the
+ * browser what a click at the centre would hit, which is the right question for
+ * a control nobody named, while this one is deliberately stricter for the one
+ * control the step is about. It fails on any intersection at all, and reports
+ * the overlap in pixels so the next person does not have to re-measure it.
+ */
+export async function expectClearOfPopover(
+  page: Page,
+  control: Locator,
+  what: string,
+): Promise<void> {
+  const pop = await page.locator(WALKTHROUGH_POPOVER).boundingBox();
+  const box = await control.boundingBox();
+  if (pop === null || box === null) {
+    throw new Error(`${what}: the popover and the control must both be on screen to be measured`);
+  }
+  const dx = Math.min(pop.x + pop.width, box.x + box.width) - Math.max(pop.x, box.x);
+  const dy = Math.min(pop.y + pop.height, box.y + box.height) - Math.max(pop.y, box.y);
+  expect(
+    dx > 0 && dy > 0,
+    `the walkthrough popover overlaps ${what} by ${dx.toFixed(0)}x${dy.toFixed(0)}px ` +
+      `(popover x ${pop.x.toFixed(0)}–${(pop.x + pop.width).toFixed(0)}, ` +
+      `y ${pop.y.toFixed(0)}–${(pop.y + pop.height).toFixed(0)}; ` +
+      `control x ${box.x.toFixed(0)}–${(box.x + box.width).toFixed(0)}, ` +
+      `y ${box.y.toFixed(0)}–${(box.y + box.height).toFixed(0)})`,
+  ).toBe(false);
+}

--- a/e2e/support/popover-clearance.ts
+++ b/e2e/support/popover-clearance.ts
@@ -68,6 +68,24 @@
  * against a silently empty pass, tempting as it is: the closing step above has
  * legitimately zero, so the guard would fail on correct code.
  *
+ * IT READS THE LOCK RATHER THAN TRUSTING IT, AND THAT IS HOW IT CAUGHT ONE. The
+ * gate is the element's own resolved `pointer-events`, never a list of what the
+ * tour ought to have locked — so a lock that leaks is visible here rather than
+ * assumed away. It leaked: driver.js 1.8.0 decides which element to
+ * un-highlight from a value it writes only when a step's 400ms transition runs
+ * to completion, so a step change landing inside that window leaves
+ * `driver-active-element` — and with it `pointer-events: auto` and the focus
+ * ring — on a control the tour has walked away from. On a loaded CI runner the
+ * calculator's opening step lost that race and `#entryPrice` was still live six
+ * steps later, under the closing step's popover. The popover was in the SAME
+ * place, to the pixel, on the machine where this passed; what differed was
+ * whether the page had left a control under it to press. `tour-engine.ts`
+ * releases stale highlights now.
+ *
+ * So read a failure here as one of two things, and measure before choosing: a
+ * prompt in the wrong place, or a lock that leaked under it. Moving a prompt
+ * that was already clear of everything the tour meant to lock fixes neither.
+ *
  * WHAT COUNTS AS "THE PROMPT IS ON IT" IS ANY OVERLAP THE PROMPT WOULD WIN, not
  * a swallowed click. Those are not the same test, and the difference is the
  * whole reason this class kept getting through: Playwright hit-tests the CENTRE

--- a/e2e/tests/user-onboarding.spec.ts
+++ b/e2e/tests/user-onboarding.spec.ts
@@ -1,5 +1,12 @@
 import { expect, test, type APIRequestContext, type Locator, type Page } from '@playwright/test';
 
+import {
+  COACH_MARK,
+  WALKTHROUGH_POPOVER,
+  expectClearOfPopover,
+  expectPromptClearOfEveryControl,
+} from '../support/popover-clearance';
+
 /**
  * User-onboarding e2e suite.
  *
@@ -156,12 +163,20 @@ async function startWalkthrough(page: Page): Promise<void> {
   await expect(button).not.toHaveAttribute('aria-disabled', 'true');
   await button.click();
   await expect(popoverTitle(page)).toHaveText(ACCOUNT_STEP_TITLES[0]);
+  await expectStepClear(page, `account step 1, "${ACCOUNT_STEP_TITLES[0]}"`);
 }
 
-/** Advance with the popover's own button and assert where it landed. */
+/**
+ * Advance with the popover's own button and assert where it landed — and that
+ * it landed clear of everything on screen. The clearance check rides on the
+ * traversal rather than living in a test of its own so that every scenario that
+ * walks this set measures every step of it, at no cost worth counting: one
+ * round trip and one pass over the document, a few milliseconds a step.
+ */
 async function advanceTo(page: Page, index: number): Promise<void> {
   await popoverNext(page).click();
   await expect(popoverTitle(page)).toHaveText(ACCOUNT_STEP_TITLES[index]);
+  await expectStepClear(page, `account step ${index + 1}, "${ACCOUNT_STEP_TITLES[index]}"`);
 }
 
 /**
@@ -182,39 +197,38 @@ async function advanceTo(page: Page, index: number): Promise<void> {
 async function pressToTitle(page: Page, key: string, expected: string): Promise<void> {
   await page.keyboard.press(key);
   await expect(popoverTitle(page)).toHaveText(expected);
+  await expectStepClear(page, `calculator step "${expected}"`);
 }
 
 /**
- * THE POPOVER MUST NOT LIE ACROSS THE CONTROL ITS OWN STEP IS FINISHED BY, and
- * a click cannot always tell you that it does.
+ * NOTHING THE USER CAN PRESS IS UNDER THE POPOVER — asserted at EVERY step of
+ * every set, against EVERY control on screen, and naming none of them.
  *
- * Playwright hit-tests the CENTRE of the box it is about to click, so a popover
- * that covers a control's edge — but stops short of its middle — dispatches
- * cleanly and the suite goes green over an overlap a user can see and can land
- * a pointer in. That is exactly the state the two fill-dialog steps shipped in:
- * the popover sat 21px across the Add button's right-hand end while its centre
- * stayed 9px clear, so every real click here passed.
+ * This walkthrough has now shipped six versions of one defect: a popover or a
+ * coach mark laid over a control. Each was found by a person and pinned by a
+ * test naming that one control, and the next one landed somewhere no assertion
+ * was looking — because the fixes all asserted that the control the CURRENT
+ * STEP DESCRIBES is clear, and every one of these defects was a control the
+ * step said nothing about. The neighbouring field, the Cancel, the button that
+ * restarts the walkthrough. Nobody writes an assertion for a control their step
+ * is not about, so that is the set the defect lives in.
  *
- * Measuring the rectangles is what closes that gap. It fails on any intersection
- * at all rather than on the one that happens to swallow a click, and it reports
- * the overlap in pixels so the next person does not have to re-measure it.
+ * `expectPromptClearOfEveryControl` is therefore called with no control at all:
+ * it enumerates them itself and asks the browser what a click aimed at the
+ * middle of each would actually hit. See `support/popover-clearance.ts` for
+ * what counts as a control the user can press, and why a page the tour has
+ * deliberately made inert is not it.
+ *
+ * IF THIS FAILS, MOVE THE POPOVER. Do not narrow it to the controls the step
+ * happens to describe — that is the fix that has been made five times.
  */
-async function expectClearOfPopover(page: Page, control: Locator, what: string): Promise<void> {
-  const pop = await popover(page).boundingBox();
-  const box = await control.boundingBox();
-  if (pop === null || box === null) {
-    throw new Error(`${what}: the popover and the control must both be on screen to be measured`);
-  }
-  const dx = Math.min(pop.x + pop.width, box.x + box.width) - Math.max(pop.x, box.x);
-  const dy = Math.min(pop.y + pop.height, box.y + box.height) - Math.max(pop.y, box.y);
-  expect(
-    dx > 0 && dy > 0,
-    `the walkthrough popover overlaps ${what} by ${dx.toFixed(0)}x${dy.toFixed(0)}px ` +
-      `(popover x ${pop.x.toFixed(0)}–${(pop.x + pop.width).toFixed(0)}, ` +
-      `y ${pop.y.toFixed(0)}–${(pop.y + pop.height).toFixed(0)}; ` +
-      `control x ${box.x.toFixed(0)}–${(box.x + box.width).toFixed(0)}, ` +
-      `y ${box.y.toFixed(0)}–${(box.y + box.height).toFixed(0)})`,
-  ).toBe(false);
+function expectStepClear(page: Page, where: string): Promise<void> {
+  return expectPromptClearOfEveryControl(page, WALKTHROUGH_POPOVER, where);
+}
+
+/** The same assertion for a coach mark, whose card is its own kind of prompt. */
+function expectMarkClear(page: Page, where: string): Promise<void> {
+  return expectPromptClearOfEveryControl(page, COACH_MARK, where);
 }
 
 /** Escape out of the tour — also one press, for the same reason. */
@@ -403,6 +417,9 @@ test.describe('user onboarding', () => {
     // Doing the thing is what advances it.
     await createAccountFromDialog(page, 'Guided account');
     await expect(popoverTitle(page)).toHaveText(ACCOUNT_STEP_TITLES[CREATE_STEP + 1]);
+    // The last step of the set, which no `advanceTo` reaches: the tour gets
+    // here on the account being created, not on a press.
+    await expectStepClear(page, `account step ${ACCOUNT_STEP_TITLES.length}, the closing aside`);
 
     // Finish, on the Accounts page the set runs on, with the account the user
     // just made listed behind it.
@@ -474,6 +491,7 @@ test.describe('user onboarding', () => {
     await page.locator('[data-checklist-action="position"]').click();
     await expect(page).toHaveURL(/\/positions$/);
     await expect(popoverTitle(page)).toHaveText(POSITION_STEP_TITLES[0]);
+    await expectStepClear(page, `position step 1, "${POSITION_STEP_TITLES[0]}"`);
 
     // The gesture step 1 asks for, from the control it highlights.
     await page.locator('[data-tour="position-new"]').click();
@@ -481,6 +499,7 @@ test.describe('user onboarding', () => {
     await expect(dialog.locator('#symbol')).toBeVisible();
     await popoverNext(page).click();
     await expect(popoverTitle(page)).toHaveText(POSITION_STEP_TITLES[1]);
+    await expectStepClear(page, `position step 2, "${POSITION_STEP_TITLES[1]}", dialog open`);
 
     // The three controls the popover covered. Each click is the assertion.
     await dialogSelect(dialog, 'Side').click({ timeout: 5_000 });
@@ -497,13 +516,16 @@ test.describe('user onboarding', () => {
     // own page, which nothing but the walkthrough was going to do.
     await expect(popoverTitle(page)).toHaveText(POSITION_STEP_TITLES[2]);
     await expect(page).toHaveURL(/\/positions\/[0-9a-f-]{36}/);
+    await expectStepClear(page, `position step 3, "${POSITION_STEP_TITLES[2]}"`);
 
     // Draft → open, through the two controls the remaining steps highlight.
     await page.locator('[data-tour="position-add-fill"]').click();
     await expect(page.getByLabel('Price')).toBeVisible();
-    // The step highlights Add Fill, but what FINISHES it is the Add button in
-    // the dialog Add Fill opens, so that is the control the popover has to keep
-    // out of the way of.
+    // EVERY control in that dialog first, none of them named — then the one
+    // this step is finished by. In that order, because the general measurement
+    // is the one that reports the whole picture and the named one is a
+    // narrower, louder restatement of part of it.
+    await expectStepClear(page, `position step 3, "${POSITION_STEP_TITLES[2]}", fill dialog open`);
     await expectClearOfPopover(
       page,
       page.getByRole('button', { name: 'Add', exact: true }),
@@ -513,10 +535,12 @@ test.describe('user onboarding', () => {
     await page.locator('#quantity').fill('10');
     await page.getByRole('button', { name: 'Add', exact: true }).click();
     await expect(popoverTitle(page)).toHaveText(POSITION_STEP_TITLES[3]);
+    await expectStepClear(page, `position step 4, "${POSITION_STEP_TITLES[3]}"`);
 
     await page.locator('[data-tour="position-open"]').click();
     await expect(popoverTitle(page)).toHaveText(POSITION_STEP_TITLES[4]);
     await expect(popoverProgress(page)).toHaveText(`5 of ${POSITION_STEP_TITLES.length}`);
+    await expectStepClear(page, `position step 5, "${POSITION_STEP_TITLES[4]}"`);
 
     // "Done" finishes it, and item 3 ticks off the user's real data. The set
     // ends on the position rather than the dashboard, so the checklist is read
@@ -557,12 +581,15 @@ test.describe('user onboarding', () => {
     // checklist names the ITEM, never the row.
     await expect(page).toHaveURL(new RegExp(`/positions/${positionId}`));
     await expect(popoverTitle(page)).toHaveText(CLOSE_STEP_TITLES[0]);
+    await expectStepClear(page, `close step 1, "${CLOSE_STEP_TITLES[0]}"`);
 
     // The exit, recorded from the control this step highlights.
     await page.locator('[data-tour="position-add-fill"]').click();
     await expect(page.getByLabel('Price')).toBeVisible();
     // Same control, same dialog, same step shape as the position set's draft
-    // step — and it shipped with the same overlap, so it is measured here too.
+    // step — and it shipped with the same overlap, so it is measured here too,
+    // in the same order.
+    await expectStepClear(page, `close step 1, "${CLOSE_STEP_TITLES[0]}", fill dialog open`);
     await expectClearOfPopover(
       page,
       page.getByRole('button', { name: 'Add', exact: true }),
@@ -579,6 +606,7 @@ test.describe('user onboarding', () => {
     await expect(popoverTitle(page)).toHaveText(CLOSE_STEP_TITLES[2]);
     await expect(page).toHaveURL(/\/dashboard/);
     await expect(page.locator('[data-grid-mode]')).toBeVisible();
+    await expectStepClear(page, `close step 3, "${CLOSE_STEP_TITLES[2]}"`);
     // And it got there without anyone closing anything by hand — that button
     // renders only while a position is open, and this one is not.
     await expect(page.locator('[data-tour="position-close"]')).toHaveCount(0);
@@ -624,6 +652,7 @@ test.describe('user onboarding', () => {
     // exit leaves unpressable.
     await expect(popoverTitle(page)).toHaveText(CLOSE_STEP_TITLES[1]);
     await expect(page.locator('[data-tour="position-close"]')).toBeDisabled();
+    await expectStepClear(page, `close step 2, "${CLOSE_STEP_TITLES[1]}"`);
 
     // THE ASSERTION. "Next" is live, because the gate behind it cannot be
     // opened — and it carries the user to the last step, on the dashboard,
@@ -772,10 +801,12 @@ test.describe('user onboarding', () => {
     // into the controls each step highlights. It is the one item completable
     // without an account, and item 2's only trace is the stored first-use
     // timestamp the calculation writes.
+    await expectStepClear(page, `calculator step 1, "${CALCULATOR_STEP_TITLES[0]}"`);
     await page.locator('#entryPrice').fill('100');
     for (const title of CALCULATOR_STEP_TITLES.slice(1)) {
       await popoverNext(page).click();
       await expect(popoverTitle(page)).toHaveText(title);
+      await expectStepClear(page, `calculator step "${title}"`);
       if (title === 'Stop loss') await page.locator('#stopLoss').fill('95');
       if (title === 'The amount at risk') await page.locator('#dollarRisk').fill('50');
     }
@@ -947,6 +978,7 @@ test.describe('user onboarding', () => {
     await page.goto('/import');
     const coachMark = page.getByTestId('coach-mark-csv-import');
     await expect(coachMark).toBeVisible();
+    await expectMarkClear(page, 'the csv-import coach mark');
 
     // THE CLICK IS THE ASSERTION. With the popover in the pointer path this
     // times out with "subtree intercepts pointer events" — the exact failure
@@ -958,6 +990,41 @@ test.describe('user onboarding', () => {
     // And the same gesture dismissed the mark: reaching past it is an outside
     // press, which is a dismissal like any other close.
     await expect(coachMark).toHaveCount(0);
+  });
+
+  // THE OTHER THREE MARKS, MEASURED THE SAME WAY, and the reason this test
+  // exists separately from the one above: that one pins the surface that broke,
+  // by clicking the control that broke. A click can only ever prove the control
+  // somebody thought of, and the mark this test was written for was blocking one
+  // nobody had — the dashboard mark's "Got it" sat on the activation checklist's
+  // play button for "Log a position", so a click meant for the button that
+  // RESTARTS A WALKTHROUGH acknowledged the tip instead. The mark opened at
+  // x 984-1272 from an anchor at the right-hand end of the header row, which put
+  // it over the column the whole app keeps its per-row buttons in.
+  //
+  // So this names no control at all. It opens each mark and asks what a click
+  // aimed at the middle of every control on the page would actually hit.
+  test('no coach mark stands on a control the user can press', async ({ page, request }) => {
+    const email = await registerUser(request, 'markclear');
+    const accountId = await createAccount(request, 'Mark account');
+    // An open position, so the dashboard has widgets to arrange (the mark's own
+    // gate) and the position detail has an Add Fill for its mark to describe.
+    const positionId = await createOpenPosition(request, accountId);
+    await loginViaUi(page, email);
+
+    // The dashboard, with the checklist up — the mark and the checklist share
+    // this screen for every user who has not finished setting up.
+    await expect(page.getByTestId('activation-checklist')).toBeVisible();
+    await expect(page.getByTestId('coach-mark-dashboard-widgets')).toBeVisible();
+    await expectMarkClear(page, 'the dashboard-widgets coach mark, checklist on screen');
+
+    await page.goto(`/positions/${positionId}`);
+    await expect(page.getByTestId('coach-mark-position-partials')).toBeVisible();
+    await expectMarkClear(page, 'the position-partials coach mark');
+
+    await page.goto('/options');
+    await expect(page.getByTestId('coach-mark-options-tools')).toBeVisible();
+    await expectMarkClear(page, 'the options-tools coach mark');
   });
 
   test('the walkthrough is reachable and traversable with the keyboard alone', async ({

--- a/e2e/tests/user-onboarding.spec.ts
+++ b/e2e/tests/user-onboarding.spec.ts
@@ -216,8 +216,10 @@ async function pressToTitle(page: Page, key: string, expected: string): Promise<
  * `expectPromptClearOfEveryControl` is therefore called with no control at all:
  * it enumerates them itself and asks the browser what a click aimed at the
  * middle of each would actually hit. See `support/popover-clearance.ts` for
- * what counts as a control the user can press, and why a page the tour has
- * deliberately made inert is not it.
+ * what counts as a control the user can press, why a page the tour has
+ * deliberately made inert is not it, and — measured, per step — how much a pass
+ * of this therefore does and does not establish. On a locked step with no dialog
+ * open it comes down to the highlighted control alone.
  *
  * IF THIS FAILS, MOVE THE POPOVER. Do not narrow it to the controls the step
  * happens to describe — that is the fix that has been made five times.


### PR DESCRIPTION
Tour popovers and coach marks have landed on top of interactive controls six times in this
feature: a coach mark over a combobox, two over the fill dialog's Add button, the
account-dialog neighbours, a coach mark over the activation-checklist play button, and a
teardown confirmation raised underneath the tour overlay so the tour's own click killed it.

Each was found by someone noticing, and fixed individually. Nothing measured for it as a
class — every previous assertion checked only that the control the current step *describes*
is clear, never that every other control is. So the seventh was coming.

This closes the class rather than the two open instances.

## What the sweep found

Measured in Chromium at 1280x720, every step of all four sets plus all four coach marks.
Before → after, all now zero:

| Step | Covered control | Overlap |
| --- | --- | --- |
| Name | `#currency`, `#timezone` | 161x36, 175x36 |
| Currency | `#timezone` | 175x36 |
| Trading-day timezone | `#startingBalance`, three risk presets | 290x36, 114x56 / 111x56 / 140x56 |
| Starting balance | same presets + `#brokerage` | — |
| Create the account | **Cancel**, `#brokerage`, "No rule" | 68x9, 19x36, 74x21 |
| Calculator entry price | `#stopLoss`, `#targetPrice` | 290x36 each |
| Dashboard coach mark | "Start: Log a position" | 32x32 |
| Retired checklist | Stats Summary menu | 23x32 |

Three of those were not in either report — the two records described what someone happened
to notice, not a survey. **The calculator overlap only appears for a user with no account**;
the same step placed itself safely once an account existed. A per-scenario spot check would
have missed it.

The position and close sets, and three of the four coach marks, were already clear.

## The part that matters

`e2e/support/popover-clearance.ts` measures, for every visible control whose own
`pointer-events` are live, any rectangle intersection with the prompt where
`elementFromPoint` at the overlap's centre returns the prompt. It names no control and
knows nothing about any particular step, so a new step, a moved control, or a new coach mark
that reintroduces an overlap goes red on its own.

Proved by introducing overlaps in code the sweep was never written against: widening
`AccountDialog` so `side: 'left'` no longer fits went red naming Currency and Trading-day
timezone; dropping `side: 'top'` from the close set went red naming `#fill-notes` and Add —
and `#fill-notes` is named by no assertion anywhere in the suite.

Cost: ~1.8ms per call, about a second across the 14-test spec.

## What it deliberately does not measure

Documented at the assertion, because a green run should not be trusted further than it
deserves.

Clearance is only meaningful for a control that is actually clickable at that moment. During
a driver.js step most controls are inert — measured: 23 of 24 gated on a locked step, 28 of
28 on a closing step — so there the sweep narrows to the highlighted control. That is the
right behaviour, and it was verified rather than assumed: a real click at the dead centre of
a gated control fires neither `pointerdown` nor `click`, and `elementFromPoint` returns the
overlay.

One qualification, also measured: such a control stays `tabIndex 0`, takes focus, and
Enter/Space still fire its handler. So "cannot be clicked" is true of the pointer only.
Geometry cannot block a keyboard activation, so this costs the assertion nothing — but the
narrow truth is what is written down, not the comfortable stronger one.

## Placement changes

Account field steps to `side: 'left'`, the submit step to `side: 'top'` / `align: 'end'`,
calculator field steps to `side: 'right'`. The dashboard coach mark moved into
`DashboardHeader` beside the heading rather than the row's right end.

At 390x844 these placements have no room and driver.js lands identically with or without
them — nothing off-screen or clipped. Mobile remains unmeasured by the sweep.

## Verification

Onboarding e2e 14 passed, dashboard e2e 6 passed, 476 onboarding unit tests, dashboard
branch tests 70, typecheck across the monorepo and in `e2e/`, eslint and prettier clean.
Each placement fix was reverted individually and watched to fail.
