### PR TITLE
fix: repair both broken ticker-lookup paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -293,8 +293,9 @@ FEATURE_GATING_ADVISOR_TURNS_PER_MONTH=200
 # STOCK_QUOTE_BASE_URL=https://api.api-ninjas.com
 # SEC contact User-Agent for the ticker-file fetch (SEC asks for a contact).
 # Override to your own contact if you like; the default is a safe non-personal
-# value. Optional (default tradr (+https://github.com/madmatt112/tradr)).
-# SEC_USER_AGENT=tradr (+https://github.com/madmatt112/tradr)
+# value. Do NOT point it at a github.com URL — SEC 403s those, and the symbol
+# table then silently stays empty. Optional (default tradr (+https://tradr.cloud)).
+# SEC_USER_AGENT=tradr (+https://tradr.cloud)
 # SEC ticker file URL — test/E2E seam; leave unset in production.
 # Optional (default https://www.sec.gov/files/company_tickers_exchange.json).
 # SEC_TICKERS_URL=https://www.sec.gov/files/company_tickers_exchange.json

--- a/apps/api/src/features/advisor/advisor.options-chain.route.test.ts
+++ b/apps/api/src/features/advisor/advisor.options-chain.route.test.ts
@@ -87,16 +87,19 @@ describe('advisor options-chain route', () => {
   // --- 2. key + success → parsed chain (REQ-12.4) ----------------------------
   it('returns the parsed chain from the shared projection on success', async () => {
     selectUnusualWhalesKeyCiphertext.mockResolvedValue({ encryptedKey: 'enc(k)', keyVersion: 1 });
+    // UW's `greeks=true` row, spelled the way UW's own example spells it:
+    // `expires` / `nbbo_bid` / `nbbo_ask`, normalised by the shared projection
+    // into the `expiry` / `bid` / `ask` the viewer and calculator read.
     getOptionChain.mockResolvedValue({
       data: [
         {
           option_symbol: 'AAPL250620C00150000',
           option_type: 'call',
           strike: 150,
-          expiry: '2025-06-20',
+          expires: '2025-06-20',
           last_price: 3.2,
-          bid: 3.1,
-          ask: 3.3,
+          nbbo_bid: 3.1,
+          nbbo_ask: 3.3,
           volume: 100,
           open_interest: 2000,
           extra_field_dropped: 'x',
@@ -112,10 +115,41 @@ describe('advisor options-chain route', () => {
     expect(body.chain.symbol).toBe('AAPL');
     expect(body.chain.expiration).toBe('2025-06-20');
     expect(body.chain.count).toBe(1);
-    expect(body.chain.contracts[0]).toMatchObject({ strike: 150, option_type: 'call' });
+    expect(body.chain.contracts[0]).toMatchObject({
+      strike: 150,
+      option_type: 'call',
+      expiry: '2025-06-20',
+      bid: 3.1,
+      ask: 3.3,
+      last_price: 3.2,
+    });
     // Compact projection drops unknown fields.
     expect(body.chain.contracts[0].extra_field_dropped).toBeUndefined();
     expect(getOptionChain).toHaveBeenCalledWith('AAPL', '2025-06-20');
+  });
+
+  // --- 2b. the production failure: a real ticker's bare-symbol chain ---------
+  // SPY returned `data: ["SPY…", …]`, which the old object-only schema rejected
+  // as MARKET_DATA_UNAVAILABLE → 503, while bogus SPYSD's empty `data: []`
+  // parsed and correctly 404'd. This asserts the real ticker now succeeds.
+  it('decodes a bare option-symbol chain instead of failing as unavailable', async () => {
+    selectUnusualWhalesKeyCiphertext.mockResolvedValue({ encryptedKey: 'enc(k)', keyVersion: 1 });
+    getOptionChain.mockResolvedValue({
+      data: ['SPY251219C00500000', 'SPY251219P00450000'],
+    });
+
+    const app = makeApp();
+    const res = await get(app, '?symbol=SPY');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.chain.count).toBe(2);
+    expect(body.chain.contracts[0]).toEqual({
+      option_symbol: 'SPY251219C00500000',
+      option_type: 'call',
+      strike: 500,
+      expiry: '2025-12-19',
+    });
+    expect(body.chain.contracts[1]).toMatchObject({ option_type: 'put', strike: 450 });
   });
 
   // --- 3. bad symbol → 400 validation ----------------------------------------

--- a/apps/api/src/features/advisor/lib/unusual-whales.client.test.ts
+++ b/apps/api/src/features/advisor/lib/unusual-whales.client.test.ts
@@ -70,14 +70,41 @@ describe('createUnusualWhalesClient — request shape & auth', () => {
     expect(url).toBe(`${STUB_BASE}/api/stock/AAPL/flow-alerts?limit=5`);
   });
 
-  it('passes the option-chain expiration as the date query param', async () => {
+  it('passes the option-chain expiration as the date query param, and asks for greeks', async () => {
     const fetchImpl = mockFetch(() => jsonResponse({ data: [{ strike: 100 }] }));
     const client = createUnusualWhalesClient(makeDeps(fetchImpl));
 
     await client.getOptionChain('AAPL', '2026-06-19');
 
     const [url] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(url).toBe(`${STUB_BASE}/api/stock/AAPL/option-chains?date=2026-06-19`);
+    // Without `greeks=true` UW returns bare option-symbol strings and the chain
+    // carries no pricing at all.
+    expect(url).toBe(`${STUB_BASE}/api/stock/AAPL/option-chains?date=2026-06-19&greeks=true`);
+  });
+
+  it('asks for greeks even when no expiration is given', async () => {
+    const fetchImpl = mockFetch(() => jsonResponse({ data: [{ strike: 100 }] }));
+    const client = createUnusualWhalesClient(makeDeps(fetchImpl));
+
+    await client.getOptionChain('AAPL');
+
+    const [url] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe(`${STUB_BASE}/api/stock/AAPL/option-chains?greeks=true`);
+  });
+
+  // The bug this guards: UW's DEFAULT option-chains response is an array of
+  // bare option-symbol STRINGS, not objects. An object-only schema rejected
+  // every real ticker as MARKET_DATA_UNAVAILABLE (503) while a bogus ticker's
+  // empty `data: []` parsed fine and 404'd — the exact inversion seen in prod.
+  it('accepts the bare option-symbol-string chain form without erroring', async () => {
+    const fetchImpl = mockFetch(() =>
+      jsonResponse({ data: ['AAPL260619C00190000', 'AAPL260619P00185000'] }),
+    );
+    const client = createUnusualWhalesClient(makeDeps(fetchImpl));
+
+    await expect(client.getOptionChain('AAPL')).resolves.toEqual({
+      data: ['AAPL260619C00190000', 'AAPL260619P00185000'],
+    });
   });
 });
 

--- a/apps/api/src/features/advisor/lib/unusual-whales.client.ts
+++ b/apps/api/src/features/advisor/lib/unusual-whales.client.ts
@@ -143,7 +143,16 @@ export class MarketDataMeter {
 
 const stockInfoSchema = z.object({ data: z.record(z.unknown()) });
 const flowAlertsSchema = z.object({ data: z.array(z.record(z.unknown())) });
-const optionChainsSchema = z.object({ data: z.array(z.record(z.unknown())) });
+
+// option-chains returns EITHER shape depending on whether `greeks=true` is
+// honoured: bare OCC option-symbol strings (the documented default) or an
+// enriched object per contract. Accepting both is deliberate — a strict
+// object-only schema is what made every real ticker fail its parse and surface
+// as MARKET_DATA_UNAVAILABLE (503), while a bogus ticker's empty `data: []`
+// passed and correctly 404'd. `parseOptionChain` normalises both forms.
+const optionChainsSchema = z.object({
+  data: z.array(z.union([z.string(), z.record(z.unknown())])),
+});
 
 // --- Client -----------------------------------------------------------------
 
@@ -367,11 +376,17 @@ export function createUnusualWhalesClient(deps: UnusualWhalesClientDeps): Unusua
     },
 
     // Pinned: GET /api/stock/{ticker}/option-chains (PublicApi.TickerController.option_chains).
+    //
+    // `greeks=true` asks for the enriched object per contract (strike, expiry,
+    // type, NBBO, IV, OI, volume, greeks) instead of the default bare
+    // option-symbol strings. Without it the response carries no pricing at all,
+    // and the chain viewer's whole purpose is handing a contract's premium to
+    // the calculator as the entry price.
     getOptionChain(symbol, expiration, signal) {
       return request(
         'getOptionChain',
         `/api/stock/${encodeURIComponent(symbol)}/option-chains`,
-        { date: expiration },
+        { date: expiration, greeks: 'true' },
         optionChainsSchema,
         (p) => !Array.isArray(p.data) || (p.data as unknown[]).length === 0,
         signal,

--- a/apps/api/src/features/advisor/tools/market-data.test.ts
+++ b/apps/api/src/features/advisor/tools/market-data.test.ts
@@ -207,6 +207,65 @@ describe('options-chain handler + shared parsing (REQ-12.4)', () => {
     expect(out.count).toBe(50);
     expect(out.contracts).toHaveLength(50);
   });
+
+  // UW's enriched rows spell these three differently from the names the chain
+  // viewer and calculator read; the projection normalises them.
+  it('normalises UW expires/nbbo_bid/nbbo_ask onto expiry/bid/ask', () => {
+    const out = parseOptionChain('AAPL', {
+      data: [
+        {
+          option_symbol: 'AAPL260619C00190000',
+          expires: '2026-06-19',
+          nbbo_bid: 4.1,
+          nbbo_ask: 4.25,
+          strike: 190,
+        },
+      ],
+    }) as { contracts: Record<string, unknown>[] };
+
+    expect(out.contracts[0]).toMatchObject({ expiry: '2026-06-19', bid: 4.1, ask: 4.25 });
+    expect(out.contracts[0].expires).toBeUndefined();
+    expect(out.contracts[0].nbbo_bid).toBeUndefined();
+  });
+
+  it('prefers the plain spelling when UW sends both', () => {
+    const out = parseOptionChain('AAPL', {
+      data: [{ expiry: '2026-06-19', expires: '1999-01-01', bid: 1, nbbo_bid: 9 }],
+    }) as { contracts: Record<string, unknown>[] };
+
+    expect(out.contracts[0]).toMatchObject({ expiry: '2026-06-19', bid: 1 });
+  });
+
+  // The production 503: UW's default response is bare OCC symbol strings.
+  it('decodes bare option-symbol strings into contracts', () => {
+    const out = parseOptionChain('SPY', {
+      data: ['SPY251219C00500000', 'SPY251219P00450000'],
+    }) as { count: number; contracts: Record<string, unknown>[] };
+
+    expect(out.count).toBe(2);
+    expect(out.contracts[0]).toEqual({
+      option_symbol: 'SPY251219C00500000',
+      option_type: 'call',
+      strike: 500,
+      expiry: '2025-12-19',
+    });
+    expect(out.contracts[1]).toEqual({
+      option_symbol: 'SPY251219P00450000',
+      option_type: 'put',
+      strike: 450,
+      expiry: '2025-12-19',
+    });
+  });
+
+  it('keeps an undecodable symbol as a bare row rather than dropping it', () => {
+    const out = parseOptionChain('SPY', { data: ['NOT-AN-OCC-SYMBOL'] }) as {
+      count: number;
+      contracts: Record<string, unknown>[];
+    };
+
+    expect(out.count).toBe(1);
+    expect(out.contracts[0]).toEqual({ option_symbol: 'NOT-AN-OCC-SYMBOL' });
+  });
 });
 
 describe('missing UW client', () => {

--- a/apps/api/src/features/advisor/tools/market-data.ts
+++ b/apps/api/src/features/advisor/tools/market-data.ts
@@ -21,6 +21,8 @@
 
 import { z } from 'zod';
 
+import { parseOccSymbol } from '@tradr/shared';
+
 import { MarketDataError, PlatformRateLimitedError } from '../lib/unusual-whales.client';
 
 import { TOOL_RESULT_CODES } from './error-codes';
@@ -123,34 +125,81 @@ function parseOptionsFlow(symbol: string, raw: unknown, limit: number): Record<s
   return { symbol, count: alerts.length, alerts };
 }
 
+/** First present (non-null) value among `keys` — UW spells some fields two ways. */
+function firstOf(row: Record<string, unknown>, keys: string[]): unknown {
+  for (const k of keys) {
+    if (row[k] !== undefined && row[k] !== null) return row[k];
+  }
+  return undefined;
+}
+
+/**
+ * Project one enriched contract row. UW is inconsistent about three field
+ * names — its `greeks=true` example spells them `expires`/`nbbo_bid`/`nbbo_ask`
+ * while the parameter docs say `expiry`/NBBO — so both spellings are accepted
+ * and normalised to the one name the chain viewer and calculator read.
+ */
+function projectContract(row: Record<string, unknown>): Record<string, unknown> {
+  const out = pick(row, [
+    'option_symbol',
+    'option_type',
+    'strike',
+    'last_price',
+    'volume',
+    'open_interest',
+    'implied_volatility',
+    'delta',
+    'gamma',
+    'theta',
+    'vega',
+  ]);
+  const aliased: Record<string, string[]> = {
+    expiry: ['expiry', 'expires'],
+    bid: ['bid', 'nbbo_bid'],
+    ask: ['ask', 'nbbo_ask'],
+  };
+  for (const [name, keys] of Object.entries(aliased)) {
+    const value = firstOf(row, keys);
+    if (value !== undefined) out[name] = value;
+  }
+  return out;
+}
+
+/**
+ * Project one bare OCC option-symbol string — the shape UW returns when
+ * `greeks=true` is not honoured. Decoding recovers strike/expiry/type so the
+ * chain still renders; there is no pricing in this form, and the calculator
+ * hand-off already treats a missing `last_price` as "enter the premium
+ * manually". An unparseable symbol degrades to the symbol alone rather than
+ * dropping the row.
+ */
+function projectBareSymbol(optionSymbol: string): Record<string, unknown> {
+  const parsed = parseOccSymbol(optionSymbol);
+  if (!parsed.ok) return { option_symbol: optionSymbol };
+  const { expiration, type, strike } = parsed.value;
+  return {
+    option_symbol: optionSymbol,
+    option_type: type,
+    strike: Number(strike),
+    expiry: expiration,
+  };
+}
+
 /**
  * Compact options-chain projection from `{ data: [...] }`, capped to
  * `CHAIN_MAX_CONTRACTS`. Exported for the options-chain viewer (task 35,
- * REQ-12.4) so the tool and the viewer parse identically.
+ * REQ-12.4) so the tool and the viewer parse identically. Handles both UW
+ * response forms (see `optionChainsSchema`).
  */
 export function parseOptionChain(
   symbol: string,
   raw: unknown,
   expiration?: string,
 ): Record<string, unknown> {
-  const rows = asRows((raw as { data?: unknown }).data).slice(0, CHAIN_MAX_CONTRACTS);
+  const data = (raw as { data?: unknown }).data;
+  const rows = (Array.isArray(data) ? data : []).slice(0, CHAIN_MAX_CONTRACTS);
   const contracts = rows.map((row) =>
-    pick(row, [
-      'option_symbol',
-      'option_type',
-      'strike',
-      'expiry',
-      'last_price',
-      'bid',
-      'ask',
-      'volume',
-      'open_interest',
-      'implied_volatility',
-      'delta',
-      'gamma',
-      'theta',
-      'vega',
-    ]),
+    typeof row === 'string' ? projectBareSymbol(row) : projectContract(asRecord(row)),
   );
   return {
     symbol,

--- a/apps/api/src/features/symbols/sec-symbols.client.test.ts
+++ b/apps/api/src/features/symbols/sec-symbols.client.test.ts
@@ -1,9 +1,12 @@
 // Unit tests for the PURE SEC parser (design v4, REQ-2.1/2.2/2.5). NO network:
-// `parseSecTickers` is exercised against a hand-built columnar fixture.
+// `parseSecTickers` is exercised against a hand-built columnar fixture, and
+// `fetchSecSymbols` against a stubbed global fetch.
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { parseSecTickers } from './sec-symbols.client';
+import { config } from '@/lib/config';
+
+import { fetchSecSymbols, parseSecTickers } from './sec-symbols.client';
 
 // A deliberately NON-canonical `fields` order (the real SEC file is
 // ["cik","name","ticker","exchange"]). Reading by index proves the parser maps
@@ -71,5 +74,32 @@ describe('parseSecTickers', () => {
     expect(parseSecTickers({})).toEqual([]);
     expect(parseSecTickers(null)).toEqual([]);
     expect(parseSecTickers({ fields: FIELDS, data: 'nope' })).toEqual([]);
+  });
+});
+
+describe('fetchSecSymbols request headers (REQ-2.2)', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('sends the configured contact User-Agent', async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({ fields: ['cik', 'name', 'ticker', 'exchange'], data: [] }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchSecSymbols();
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect((init.headers as Record<string, string>)['User-Agent']).toBe(config.SEC_USER_AGENT);
+  });
+
+  // The bug this guards: SEC serves a 403 to any User-Agent referencing
+  // github.com (verified against the live host). `fetchSecSymbols` then threw,
+  // the sync recorded `last_error`, and `symbols` stayed empty — so symbol
+  // search returned 200 with no results indefinitely, with nothing in the API
+  // response to indicate a failure.
+  it('defaults to a contact SEC accepts — never a github.com URL', () => {
+    expect(config.SEC_USER_AGENT).not.toMatch(/github\.com/i);
+    // A bare name with no contact at all is also rejected.
+    expect(config.SEC_USER_AGENT).toMatch(/https?:\/\/|@/);
   });
 });

--- a/apps/api/src/lib/config.ts
+++ b/apps/api/src/lib/config.ts
@@ -333,9 +333,16 @@ export const envSchema = z.object({
   // hard-coded personal contact in source, REQ-9.4) + test/E2E URL seam. Both
   // empty-tolerant (the CHANGELOG_GITHUB_BASE_URL idiom); SEC_USER_AGENT has no
   // `.url()` so it drops the validator but keeps the '' → default preprocess.
+  //
+  // The contact URL must NOT be a github.com address: SEC serves a 403 ("Request
+  // Rate Threshold Exceeded", misleadingly) to any agent referencing github.com,
+  // and to a bare name carrying no contact at all. Both were verified against
+  // the live host; the project's own domain is accepted. A 403 here is silent —
+  // the sync records `last_error` and leaves `symbols` empty, so search returns
+  // 200 with no results forever.
   SEC_USER_AGENT: z.preprocess(
     (v) => (v === '' ? undefined : v),
-    z.string().default('tradr (+https://github.com/madmatt112/tradr)'),
+    z.string().default('tradr (+https://tradr.cloud)'),
   ),
   SEC_TICKERS_URL: z.preprocess(
     (v) => (v === '' ? undefined : v),

--- a/apps/docs/src/content/docs/self-hosting/reference/env-vars.mdx
+++ b/apps/docs/src/content/docs/self-hosting/reference/env-vars.mdx
@@ -162,7 +162,7 @@ is **absent, not broken**: nothing logs an error and no outbound call is made.
 | --- | --- | --- |
 | `STOCK_QUOTE_API_KEY` | Optional | Symbol AUTOCOMPLETE needs NO key — it is backed by the public SEC ticker file. Only the delayed LAST-PRICE lookup needs a key. Absent ⇒ that affordance is simply absent for everyone (isStockQuoteConfigured false); a fresh clone + `docker compose up` runs identically with it unset. api-only: the frontend learns configuredness from an authed config endpoint, not from a web env var. Platform-global delayed-quote provider key (API Ninjas). Optional. |
 | `STOCK_QUOTE_BASE_URL` | Optional | Quote-provider base URL — test/E2E seam; leave unset in production. Optional (default https://api.api-ninjas.com). |
-| `SEC_USER_AGENT` | Optional | SEC contact User-Agent for the ticker-file fetch (SEC asks for a contact). Override to your own contact if you like; the default is a safe non-personal value. Optional (default tradr (+https://github.com/madmatt112/tradr)). |
+| `SEC_USER_AGENT` | Optional | SEC contact User-Agent for the ticker-file fetch (SEC asks for a contact). Override to your own contact if you like; the default is a safe non-personal value. Do NOT point it at a github.com URL — SEC 403s those, and the symbol table then silently stays empty. Optional (default tradr (+https://tradr.cloud)). |
 | `SEC_TICKERS_URL` | Optional | SEC ticker file URL — test/E2E seam; leave unset in production. Optional (default https://www.sec.gov/files/company_tickers_exchange.json). |
 
 ## Transactional email (api container)

--- a/e2e/support/uw-stub-server.ts
+++ b/e2e/support/uw-stub-server.ts
@@ -86,6 +86,12 @@ function deterministicResponse(pathname: string): { status: number; body: unknow
   //     and the advisor-tools spec's `strike 190 / expiry 2026-06-19` assertions
   //     still resolve uniquely (Row A uses a distinct strike/expiry that share no
   //     substring with either).
+  //
+  // The rows are spelled the way UW's `greeks=true` example spells them
+  // (`expires` / `nbbo_bid` / `nbbo_ask`) — the previous fixture used the
+  // POST-projection names, so it agreed with the client's schema instead of
+  // testing it, and the real array-of-strings response 503'd in production
+  // against a fully green suite.
   return {
     status: 200,
     body: empty
@@ -96,11 +102,11 @@ function deterministicResponse(pathname: string): { status: number; body: unknow
               ticker,
               option_symbol: `${ticker}260717C00200000`,
               strike: '200',
-              expiry: '2026-07-17',
+              expires: '2026-07-17',
               option_type: 'call',
               last_price: 5.25,
-              bid: '5.10',
-              ask: '5.30',
+              nbbo_bid: '5.10',
+              nbbo_ask: '5.30',
               volume: 150,
               open_interest: 400,
             },
@@ -108,10 +114,10 @@ function deterministicResponse(pathname: string): { status: number; body: unknow
               ticker,
               option_symbol: `${ticker}260619C00190000`,
               strike: '190',
-              expiry: '2026-06-19',
+              expires: '2026-06-19',
               option_type: 'call',
-              bid: '4.10',
-              ask: '4.25',
+              nbbo_bid: '4.10',
+              nbbo_ask: '4.25',
               volume: 320,
               open_interest: 980,
             },


### PR DESCRIPTION
Two independent ticker-lookup paths were broken in staging. Both failed
silently or misleadingly, and both were green in CI.

## 1. Symbol search returned no results for any ticker

`GET /api/symbols/search?q=SPY` answered `200 {"results": []}` for every
input, including obviously valid ones, because the `symbols` table was
never populated.

SEC serves a **403 to any User-Agent referencing github.com**, which the
default `tradr (+https://github.com/madmatt112/tradr)` did. Verified
against the live host by isolating the variables:

| User-Agent | Status |
| --- | --- |
| `tradr (+https://github.com/madmatt112/tradr)` | 403 |
| `tradr (+https://tradr.cloud)` | 200 |
| `tradr (+https://github.com/madmatt112/tradr; contact@tradr.cloud)` | 403 |
| `tradr` | 403 |

So it is the github.com token that triggers it — not the missing contact
email the 403 body ("Request Rate Threshold Exceeded") implies, and not
rate limiting: the accepted and rejected forms were interleaved from the
same IP seconds apart. A bare name carrying no contact at all is also
rejected.

The failure was silent by design. `fetchSecSymbols` threw, the sync
recorded `last_error` and deliberately left the table intact rather than
pruning it against a bad fetch, and search then answered from an empty
table with a valid 200. Nothing in the API response indicated a fault.

The default now points at the project's own domain, which SEC accepts
and which keeps a personal contact out of source. A test guards it.

## 2. Options chain returned 503 for every real ticker

`GET /api/advisor/options-chain?symbol=SPY` returned 503 while a
nonexistent ticker correctly returned 404 — the inversion was the clue.
Logs showed SPY failing as `MARKET_DATA_UNAVAILABLE` in ~550ms, far
short of the 10s timeout, with a key that authenticates (a rejected key
maps to 400).

`optionChainsSchema` required `data` to be an array of objects. Unusual
Whales documents the opposite: `data` is an array of bare OCC
option-symbol strings unless `greeks=true` is passed. Every populated
chain failed its Zod parse and surfaced as "temporarily unavailable",
while a bogus ticker's empty `data: []` satisfied the array-of-objects
schema, hit the empty check, and 404'd. The one input that appeared to
work was the only one whose response could pass.

- Ask for `greeks=true` — the default form carries no pricing at all,
  and the viewer exists to hand a contract's premium to the calculator
  as the entry price.
- Accept **both** documented forms rather than betting on the parameter
  being honoured. Bare symbols are decoded via the existing shared
  `parseOccSymbol` into strike/expiry/type, which keeps the chain
  usable; the calculator hand-off already treats a missing `last_price`
  as "enter the premium manually".
- Normalise `expires`/`nbbo_bid`/`nbbo_ask` onto the `expiry`/`bid`/`ask`
  the viewer and calculator read. UW's own spec spells these two ways —
  the parameter docs one way, the response example the other — so both
  are accepted.

This also fixes the `market_data_options_chain` advisor tool, which
shares the client method. `info` and `flow-alerts` were checked against
the spec and already match.

## Why CI was green

All three test doubles — the unit mock, the route test, and the e2e stub
— hand-authored the same array-of-objects shape the provider never
sends, so they agreed with the client instead of testing it. They now
carry UW's real spelling, and every new case was confirmed to **fail
against the old implementation** before being accepted.

## Reviewer notes

- **The `greeks=true` payload is unverified against the live API.** No
  working credential was available locally, so the enriched-row field
  names come from UW's spec rather than observation. That spec
  contradicts itself on `expiry` vs `expires`, which is why both
  spellings are accepted. Worth one manual call against staging to
  confirm the premium hand-off before trusting it.
- **Response size.** A full chain with greeks attached is a much larger
  payload than the bare-symbol list, against a 10s timeout and a
  50-contract cap applied to an unordered list. Worth watching the first
  real request's latency.
- `.env.example` changed, so the generated env-vars reference page was
  regenerated in the same commit.
- e2e was not run locally. The stub's post-projection output is
  byte-identical, so the existing `190` / `2026-06-19` assertions should
  hold, but CI is the real check.
