### PR TITLE
fix(docker): retry the native install so a dropped download isn't fatal

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -44,7 +44,21 @@ RUN printf '%s\n' \
   '    "tiktoken": "1.0.22"' \
   '  }' \
   '}' > package.json
-RUN npm install --omit=dev --no-audit --no-fund
+# bcrypt's prebuilt .node is fetched from a GitHub release, and node-pre-gyp
+# does NOT retry that download. A transient hang-up there is not recoverable:
+# node-pre-gyp falls back to compiling from source, which this slim image
+# cannot do (no Python, no toolchain), so a dropped connection fails the whole
+# build. Retry with backoff rather than carry a full build toolchain in the
+# builder — a retry costs nothing on the happy path, whereas python3 + g++ +
+# make would be installed on every build to serve a fallback we never want.
+RUN for attempt in 1 2 3; do \
+      npm install --omit=dev --no-audit --no-fund && exit 0; \
+      echo "native npm install failed (attempt ${attempt}/3); retrying"; \
+      rm -rf node_modules; \
+      sleep $((attempt * 5)); \
+    done; \
+    echo "native npm install failed after 3 attempts" >&2; \
+    exit 1
 
 # Assert the assembled tree is RUNTIME-USABLE, not merely resolvable: both a
 # resolve check (import succeeds) and a named-export shape check. tiktoken's


### PR DESCRIPTION
`docker-smoke` failed three times in under an hour — on #52, then again
on `main` after it merged — always at the same step, and never for a
reason related to the code under test. Both times a re-run went green,
which is the signature of a transient fault rather than a broken build.

## What breaks

```
node-pre-gyp http GET .../bcrypt_lib-v5.1.1-napi-v3-linux-x64-glibc.tar.gz
node-pre-gyp ERR! install request ... failed, reason: socket hang up
WARN Pre-built binaries not installable for bcrypt@5.1.1 (falling back to source compile)
gyp ERR! find Python — Could not find any Python installation to use
```

bcrypt's prebuilt `.node` is fetched from a GitHub release, and
node-pre-gyp does **not** retry that download. What makes it fatal rather
than merely slow is the fallback: node-pre-gyp drops to compiling from
source, and `node:22-bookworm-slim` has neither Python nor a toolchain.
So a single dropped connection fails the whole image build.

This is on the release path too — `release.yml` builds the same
Dockerfile — so it isn't only a CI annoyance.

## The fix

Retry with backoff, clearing the partial tree between attempts.

The alternative is installing `python3`/`make`/`g++` so the source
fallback actually works. That pays an install cost on every build to
serve a path we never want to take, and it would silently substitute a
locally compiled binary for the published one. A retry costs nothing on
the happy path.

## Verification

- Full `docker compose build api` locally: passes.
- The retry construct was tested against `/bin/sh` for all three
  outcomes — succeeds first try (exit 0), fails then recovers (exit 0),
  and **exhausts all attempts (exit 1)**. That last case is the one that
  matters: a retry wrapper that exits 0 after its attempts run out would
  convert a broken build into a silently broken image.

Only `Dockerfile.api` is touched. The `pnpm install --frozen-lockfile`
steps talk to the npm registry, which retries internally, so they carry a
different risk profile and are left alone.
