### PR TITLE
feat(options): scope the chain to one expiry and resolve a real premium

### DIFF
--- a/apps/api/src/features/advisor/advisor.options-chain.route.test.ts
+++ b/apps/api/src/features/advisor/advisor.options-chain.route.test.ts
@@ -21,8 +21,9 @@ import { errorHandler } from '@/middleware/error.middleware';
 // --- Module mocks ------------------------------------------------------------
 
 const selectUnusualWhalesKeyCiphertext = vi.fn();
-const getOptionChain = vi.fn();
-const createUnusualWhalesClient = vi.fn(() => ({ getOptionChain }));
+const getExpiryBreakdown = vi.fn();
+const getOptionContracts = vi.fn();
+const createUnusualWhalesClient = vi.fn(() => ({ getExpiryBreakdown, getOptionContracts }));
 
 vi.mock('@/db', () => ({ db: {} }));
 vi.mock('./external-keys.query', () => ({
@@ -66,7 +67,8 @@ function get(app: ReturnType<typeof makeApp>, query: string) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  createUnusualWhalesClient.mockReturnValue({ getOptionChain });
+  createUnusualWhalesClient.mockReturnValue({ getExpiryBreakdown, getOptionContracts });
+  getExpiryBreakdown.mockResolvedValue({ data: [{ expires: '2030-06-21' }] });
 });
 
 afterEach(() => {
@@ -81,25 +83,22 @@ describe('advisor options-chain route', () => {
     const res = await get(app, '?symbol=AAPL');
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ configured: false });
-    expect(getOptionChain).not.toHaveBeenCalled();
+    expect(getOptionContracts).not.toHaveBeenCalled();
   });
 
   // --- 2. key + success → parsed chain (REQ-12.4) ----------------------------
   it('returns the parsed chain from the shared projection on success', async () => {
     selectUnusualWhalesKeyCiphertext.mockResolvedValue({ encryptedKey: 'enc(k)', keyVersion: 1 });
-    // UW's `greeks=true` row, spelled the way UW's own example spells it:
-    // `expires` / `nbbo_bid` / `nbbo_ask`, normalised by the shared projection
-    // into the `expiry` / `bid` / `ask` the viewer and calculator read.
-    getOptionChain.mockResolvedValue({
+    getExpiryBreakdown.mockResolvedValue({ data: [{ expires: '2030-06-21' }] });
+    // An `option-contracts` row: no strike/type/expiry fields, prices as
+    // decimal strings. The projection decodes the OCC symbol and numifies.
+    getOptionContracts.mockResolvedValue({
       data: [
         {
-          option_symbol: 'AAPL250620C00150000',
-          option_type: 'call',
-          strike: 150,
-          expires: '2025-06-20',
-          last_price: 3.2,
-          nbbo_bid: 3.1,
-          nbbo_ask: 3.3,
+          option_symbol: 'AAPL300621C00150000',
+          last_price: '3.2',
+          nbbo_bid: '3.1',
+          nbbo_ask: '3.3',
           volume: 100,
           open_interest: 2000,
           extra_field_dropped: 'x',
@@ -108,48 +107,58 @@ describe('advisor options-chain route', () => {
     });
 
     const app = makeApp();
-    const res = await get(app, '?symbol=AAPL&expiration=2025-06-20');
+    const res = await get(app, '?symbol=AAPL&expiration=2030-06-21');
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.configured).toBe(true);
     expect(body.chain.symbol).toBe('AAPL');
-    expect(body.chain.expiration).toBe('2025-06-20');
+    expect(body.expiration).toBe('2030-06-21');
     expect(body.chain.count).toBe(1);
     expect(body.chain.contracts[0]).toMatchObject({
       strike: 150,
       option_type: 'call',
-      expiry: '2025-06-20',
+      expiry: '2030-06-21',
       bid: 3.1,
       ask: 3.3,
       last_price: 3.2,
+      premium: 3.2,
     });
     // Compact projection drops unknown fields.
     expect(body.chain.contracts[0].extra_field_dropped).toBeUndefined();
-    expect(getOptionChain).toHaveBeenCalledWith('AAPL', '2025-06-20');
+    expect(getOptionContracts).toHaveBeenCalledWith('AAPL', '2030-06-21', undefined);
   });
 
-  // --- 2b. the production failure: a real ticker's bare-symbol chain ---------
-  // SPY returned `data: ["SPY…", …]`, which the old object-only schema rejected
-  // as MARKET_DATA_UNAVAILABLE → 503, while bogus SPYSD's empty `data: []`
-  // parsed and correctly 404'd. This asserts the real ticker now succeeds.
-  it('decodes a bare option-symbol chain instead of failing as unavailable', async () => {
+  // --- 2b. expiry resolution + picker payload --------------------------------
+  it('defaults to the nearest expiry and returns the list for the picker', async () => {
     selectUnusualWhalesKeyCiphertext.mockResolvedValue({ encryptedKey: 'enc(k)', keyVersion: 1 });
-    getOptionChain.mockResolvedValue({
-      data: ['SPY251219C00500000', 'SPY251219P00450000'],
+    getExpiryBreakdown.mockResolvedValue({
+      data: [{ expires: '2030-09-20' }, { expires: '2030-06-21' }],
     });
+    getOptionContracts.mockResolvedValue({ data: [{ option_symbol: 'AAPL300621C00150000' }] });
 
     const app = makeApp();
-    const res = await get(app, '?symbol=SPY');
+    const res = await get(app, '?symbol=AAPL');
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.chain.count).toBe(2);
-    expect(body.chain.contracts[0]).toEqual({
-      option_symbol: 'SPY251219C00500000',
-      option_type: 'call',
-      strike: 500,
-      expiry: '2025-12-19',
-    });
-    expect(body.chain.contracts[1]).toMatchObject({ option_type: 'put', strike: 450 });
+    expect(body.expiration).toBe('2030-06-21');
+    expect(body.expirations).toEqual(['2030-06-21', '2030-09-20']);
+    expect(getOptionContracts).toHaveBeenCalledWith('AAPL', '2030-06-21', undefined);
+  });
+
+  // The bug this guards: `option-chains?date=` is a MARKET day, not an expiry,
+  // so a future expiry there returned an empty envelope and surfaced as a bare
+  // "Symbol not found." for a symbol that plainly exists.
+  it('reports an unavailable expiry without calling the contracts endpoint', async () => {
+    selectUnusualWhalesKeyCiphertext.mockResolvedValue({ encryptedKey: 'enc(k)', keyVersion: 1 });
+    getExpiryBreakdown.mockResolvedValue({ data: [{ expires: '2030-06-21' }] });
+
+    const app = makeApp();
+    const res = await get(app, '?symbol=AAPL&expiration=2030-06-22');
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe('SYMBOL_NOT_FOUND');
+    expect(body.error.message).toContain('expire on that date');
+    expect(getOptionContracts).not.toHaveBeenCalled();
   });
 
   // --- 3. bad symbol → 400 validation ----------------------------------------
@@ -169,7 +178,7 @@ describe('advisor options-chain route', () => {
     [TOOL_RESULT_CODES.MARKET_DATA_UNAVAILABLE, 503],
   ])('maps UW %s to HTTP %i', async (code, status) => {
     selectUnusualWhalesKeyCiphertext.mockResolvedValue({ encryptedKey: 'enc(k)', keyVersion: 1 });
-    getOptionChain.mockRejectedValue(new MarketDataError(code, 'msg'));
+    getOptionContracts.mockRejectedValue(new MarketDataError(code, 'msg'));
     const app = makeApp();
     const res = await get(app, '?symbol=AAPL');
     expect(res.status).toBe(status);
@@ -182,7 +191,7 @@ describe('advisor options-chain route', () => {
   // --- 8. platform meter trip → 429 PLATFORM_RATE_LIMITED --------------------
   it('maps a platform meter trip to 429 PLATFORM_RATE_LIMITED', async () => {
     selectUnusualWhalesKeyCiphertext.mockResolvedValue({ encryptedKey: 'enc(k)', keyVersion: 1 });
-    getOptionChain.mockRejectedValue(new PlatformRateLimitedError());
+    getOptionContracts.mockRejectedValue(new PlatformRateLimitedError());
     const app = makeApp();
     const res = await get(app, '?symbol=AAPL');
     expect(res.status).toBe(429);

--- a/apps/api/src/features/advisor/advisor.route.ts
+++ b/apps/api/src/features/advisor/advisor.route.ts
@@ -722,18 +722,26 @@ advisorRouter.put('/trade-data-consent', setTradeDataConsentHandler);
  * @swagger
  * /api/advisor/options-chain:
  *   get:
- *     summary: Get the live options chain for a symbol from Unusual Whales.
+ *     summary: Get one expiry's option chain for a symbol from Unusual Whales.
  *     description: >
  *       Backs the options-tools page chain viewer. Shares the Unusual Whales client and
  *       the `market_data_options_chain` tool's parsing (no duplicate fetch logic). When
  *       the authenticated user has no Unusual Whales key the response is `{ configured:
- *       false }` so the viewer shows an empty-state CTA to Settings, not an error. With
- *       a key the response is `{ configured: true, chain }` where `chain` is the
- *       compact projection `{ symbol, expiration?, count, contracts[] }`. Upstream
- *       failures are mapped to their reason codes on the matching HTTP status: 400
- *       MARKET_DATA_KEY_INVALID, 429 MARKET_DATA_RATE_LIMITED / PLATFORM_RATE_LIMITED,
- *       404 SYMBOL_NOT_FOUND, 503 MARKET_DATA_UNAVAILABLE. The plaintext key is never
- *       returned or logged.
+ *       false }` so the viewer shows an empty-state CTA to Settings, not an error.
+ *
+ *       A chain is scoped to ONE expiry. Omit `expiration` to get the nearest tradeable
+ *       one. The response is `{ configured: true, expiration, expirations[], chain }`:
+ *       `expiration` is the expiry actually returned, `expirations` is every tradeable
+ *       expiry (soonest first) for the picker, and `chain` is the compact projection
+ *       `{ symbol, expiration?, count, contracts[] }` sorted by strike. Each contract
+ *       carries `premium` — the last traded price, or the NBBO midpoint when the
+ *       contract has not traded — which is what the calculator uses as an entry price.
+ *
+ *       Requesting an `expiration` the symbol has no contracts for is 404
+ *       SYMBOL_NOT_FOUND with an explicit message. Other upstream failures map to their
+ *       reason codes on the matching HTTP status: 400 MARKET_DATA_KEY_INVALID, 429
+ *       MARKET_DATA_RATE_LIMITED / PLATFORM_RATE_LIMITED, 503 MARKET_DATA_UNAVAILABLE.
+ *       The plaintext key is never returned or logged.
  *     tags: [Advisor]
  *     parameters:
  *       - in: query
@@ -742,11 +750,13 @@ advisorRouter.put('/trade-data-consent', setTradeDataConsentHandler);
  *         schema: { type: string, pattern: '^[A-Z.]{1,6}$' }
  *       - in: query
  *         name: expiration
+ *         description: Expiry to fetch (YYYY-MM-DD). Defaults to the nearest tradeable expiry.
  *         schema: { type: string, pattern: '^\d{4}-\d{2}-\d{2}$' }
  *     responses:
- *       200: { description: '{ configured: false } or { configured: true, chain }.' }
+ *       200:
+ *         description: '{ configured: false } or { configured: true, expiration, expirations, chain }.'
  *       400: { description: 'Validation error or MARKET_DATA_KEY_INVALID.' }
- *       404: { description: SYMBOL_NOT_FOUND. }
+ *       404: { description: 'SYMBOL_NOT_FOUND — unknown symbol, or no contracts on that expiry.' }
  *       429: { description: 'MARKET_DATA_RATE_LIMITED or PLATFORM_RATE_LIMITED.' }
  *       503: { description: MARKET_DATA_UNAVAILABLE. }
  */

--- a/apps/api/src/features/advisor/lib/unusual-whales.client.test.ts
+++ b/apps/api/src/features/advisor/lib/unusual-whales.client.test.ts
@@ -70,41 +70,30 @@ describe('createUnusualWhalesClient — request shape & auth', () => {
     expect(url).toBe(`${STUB_BASE}/api/stock/AAPL/flow-alerts?limit=5`);
   });
 
-  it('passes the option-chain expiration as the date query param, and asks for greeks', async () => {
-    const fetchImpl = mockFetch(() => jsonResponse({ data: [{ strike: 100 }] }));
+  it('fetches the cheap expiry index with no query params', async () => {
+    const fetchImpl = mockFetch(() => jsonResponse({ data: [{ expires: '2026-06-19' }] }));
     const client = createUnusualWhalesClient(makeDeps(fetchImpl));
 
-    await client.getOptionChain('AAPL', '2026-06-19');
+    await client.getExpiryBreakdown('AAPL');
 
     const [url] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
-    // Without `greeks=true` UW returns bare option-symbol strings and the chain
-    // carries no pricing at all.
-    expect(url).toBe(`${STUB_BASE}/api/stock/AAPL/option-chains?date=2026-06-19&greeks=true`);
+    expect(url).toBe(`${STUB_BASE}/api/stock/AAPL/expiry-breakdown`);
   });
 
-  it('asks for greeks even when no expiration is given', async () => {
-    const fetchImpl = mockFetch(() => jsonResponse({ data: [{ strike: 100 }] }));
+  // The bug this guards: `option-chains` takes `date`, which is the MARKET day,
+  // NOT the expiry — a future expiry passed there returns an empty envelope,
+  // which the empty-check reports as SYMBOL_NOT_FOUND for a symbol that plainly
+  // exists. `option-contracts` has a real `expiry` filter.
+  it('scopes contracts by a real expiry filter, not the market-date param', async () => {
+    const fetchImpl = mockFetch(() => jsonResponse({ data: [{ option_symbol: 'X' }] }));
     const client = createUnusualWhalesClient(makeDeps(fetchImpl));
 
-    await client.getOptionChain('AAPL');
+    await client.getOptionContracts('AAPL', '2026-06-19');
 
     const [url] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(url).toBe(`${STUB_BASE}/api/stock/AAPL/option-chains?greeks=true`);
-  });
-
-  // The bug this guards: UW's DEFAULT option-chains response is an array of
-  // bare option-symbol STRINGS, not objects. An object-only schema rejected
-  // every real ticker as MARKET_DATA_UNAVAILABLE (503) while a bogus ticker's
-  // empty `data: []` parsed fine and 404'd — the exact inversion seen in prod.
-  it('accepts the bare option-symbol-string chain form without erroring', async () => {
-    const fetchImpl = mockFetch(() =>
-      jsonResponse({ data: ['AAPL260619C00190000', 'AAPL260619P00185000'] }),
-    );
-    const client = createUnusualWhalesClient(makeDeps(fetchImpl));
-
-    await expect(client.getOptionChain('AAPL')).resolves.toEqual({
-      data: ['AAPL260619C00190000', 'AAPL260619P00185000'],
-    });
+    expect(url).toBe(`${STUB_BASE}/api/stock/AAPL/option-contracts?expiry=2026-06-19&limit=500`);
+    expect(url).not.toContain('date=');
+    expect(url).not.toContain('option-chains');
   });
 });
 

--- a/apps/api/src/features/advisor/lib/unusual-whales.client.ts
+++ b/apps/api/src/features/advisor/lib/unusual-whales.client.ts
@@ -17,7 +17,8 @@
 // Authorization header, the key, or response bodies.
 //
 // Endpoint paths are pinned against the live UW docs (api.unusualwhales.com/docs,
-// PublicApi.TickerController): info / flow-alerts / option-chains.
+// PublicApi.TickerController): info / flow-alerts / expiry-breakdown /
+// option-contracts.
 
 import { z } from 'zod';
 
@@ -143,16 +144,8 @@ export class MarketDataMeter {
 
 const stockInfoSchema = z.object({ data: z.record(z.unknown()) });
 const flowAlertsSchema = z.object({ data: z.array(z.record(z.unknown())) });
-
-// option-chains returns EITHER shape depending on whether `greeks=true` is
-// honoured: bare OCC option-symbol strings (the documented default) or an
-// enriched object per contract. Accepting both is deliberate — a strict
-// object-only schema is what made every real ticker fail its parse and surface
-// as MARKET_DATA_UNAVAILABLE (503), while a bogus ticker's empty `data: []`
-// passed and correctly 404'd. `parseOptionChain` normalises both forms.
-const optionChainsSchema = z.object({
-  data: z.array(z.union([z.string(), z.record(z.unknown())])),
-});
+const expiryBreakdownSchema = z.object({ data: z.array(z.record(z.unknown())) });
+const optionContractsSchema = z.object({ data: z.array(z.record(z.unknown())) });
 
 // --- Client -----------------------------------------------------------------
 
@@ -174,7 +167,10 @@ export interface UnusualWhalesClientDeps {
 export interface UnusualWhalesClient {
   getStockQuote(symbol: string, signal?: AbortSignal): Promise<unknown>;
   getOptionsFlow(symbol: string, limit?: number, signal?: AbortSignal): Promise<unknown>;
-  getOptionChain(symbol: string, expiration?: string, signal?: AbortSignal): Promise<unknown>;
+  /** The ticker's expiries (cheap — no contract rows). */
+  getExpiryBreakdown(symbol: string, signal?: AbortSignal): Promise<unknown>;
+  /** One expiry's contracts, with NBBO + greeks. */
+  getOptionContracts(symbol: string, expiry: string, signal?: AbortSignal): Promise<unknown>;
 }
 
 /** Stable cache/normalized-args key for `(method, args)` (REQ-6.7). */
@@ -375,19 +371,40 @@ export function createUnusualWhalesClient(deps: UnusualWhalesClientDeps): Unusua
       );
     },
 
-    // Pinned: GET /api/stock/{ticker}/option-chains (PublicApi.TickerController.option_chains).
+    // Pinned: GET /api/stock/{ticker}/expiry-breakdown.
     //
-    // `greeks=true` asks for the enriched object per contract (strike, expiry,
-    // type, NBBO, IV, OI, volume, greeks) instead of the default bare
-    // option-symbol strings. Without it the response carries no pricing at all,
-    // and the chain viewer's whole purpose is handing a contract's premium to
-    // the calculator as the entry price.
-    getOptionChain(symbol, expiration, signal) {
+    // The cheap expiry index (~2.5 KB): one row per expiry with its contract
+    // count. Used to resolve "nearest expiry" and to populate the viewer's
+    // expiry picker without pulling any contract rows.
+    getExpiryBreakdown(symbol, signal) {
       return request(
-        'getOptionChain',
-        `/api/stock/${encodeURIComponent(symbol)}/option-chains`,
-        { date: expiration, greeks: 'true' },
-        optionChainsSchema,
+        'getExpiryBreakdown',
+        `/api/stock/${encodeURIComponent(symbol)}/expiry-breakdown`,
+        {},
+        expiryBreakdownSchema,
+        (p) => !Array.isArray(p.data) || (p.data as unknown[]).length === 0,
+        signal,
+      );
+    },
+
+    // Pinned: GET /api/stock/{ticker}/option-contracts.
+    //
+    // NOT `option-chains`. That endpoint's `date` parameter is the MARKET day
+    // ("symbols present at the given day"), not the expiry — passing a future
+    // expiry to it returns an empty envelope, which the empty-check then
+    // reports as SYMBOL_NOT_FOUND. `option-contracts` takes a real `expiry`
+    // filter, and its rows carry `last_price` and NBBO, which the chain rows
+    // do not. One expiry is ~200 KB against ~4.7 MB for a whole greeks chain.
+    //
+    // `limit` is the endpoint's documented maximum (500). Rows carry
+    // `option_symbol` but no strike/type/expiry fields — the projection decodes
+    // those from the symbol.
+    getOptionContracts(symbol, expiry, signal) {
+      return request(
+        'getOptionContracts',
+        `/api/stock/${encodeURIComponent(symbol)}/option-contracts`,
+        { expiry, limit: 500 },
+        optionContractsSchema,
         (p) => !Array.isArray(p.data) || (p.data as unknown[]).length === 0,
         signal,
       );

--- a/apps/api/src/features/advisor/options-chain.handler.ts
+++ b/apps/api/src/features/advisor/options-chain.handler.ts
@@ -30,7 +30,19 @@ import {
   PlatformRateLimitedError,
 } from './lib/unusual-whales.client';
 import { TOOL_RESULT_CODES } from './tools/error-codes';
-import { optionsChainInputSchema, parseOptionChain } from './tools/market-data';
+import {
+  fetchChainForExpiry,
+  optionsChainInputSchema,
+  parseOptionChain,
+} from './tools/market-data';
+
+/**
+ * Contract cap for the VIEWER (the advisor tool keeps its own smaller cap —
+ * its result is persisted, this response is not). One expiry's ladder for a
+ * liquid ticker runs to a few hundred strikes; this bounds a pathological
+ * ticker without truncating a normal chain.
+ */
+const VIEWER_MAX_CONTRACTS = 400;
 
 type AuthEnv = { Variables: { userId: string; isAdmin: boolean } };
 
@@ -112,8 +124,13 @@ export async function getOptionsChainHandler(c: Context<AuthEnv>) {
   });
 
   try {
-    const raw = await client.getOptionChain(symbol, expiration);
-    return c.json({ configured: true, chain: parseOptionChain(symbol, raw, expiration) });
+    const resolved = await fetchChainForExpiry(client, symbol, expiration);
+    return c.json({
+      configured: true,
+      expiration: resolved.expiration,
+      expirations: resolved.expirations,
+      chain: parseOptionChain(symbol, resolved.raw, resolved.expiration, VIEWER_MAX_CONTRACTS),
+    });
   } catch (error) {
     logger.warn('options-chain fetch failed', {
       userId,

--- a/apps/api/src/features/advisor/streaming.test.ts
+++ b/apps/api/src/features/advisor/streaming.test.ts
@@ -935,7 +935,8 @@ describe('per-iteration re-read + UW-client rebuild (task 26)', () => {
     const fakeUw: UnusualWhalesClient = {
       getStockQuote: vi.fn().mockResolvedValue({ price: 1 }),
       getOptionsFlow: vi.fn(),
-      getOptionChain: vi.fn(),
+      getExpiryBreakdown: vi.fn(),
+      getOptionContracts: vi.fn(),
     };
     const { registry } = uwRegistry();
 
@@ -967,7 +968,8 @@ describe('per-iteration re-read + UW-client rebuild (task 26)', () => {
     const makeUwClient = vi.fn(() => ({
       getStockQuote: vi.fn().mockResolvedValue({ price: 1 }),
       getOptionsFlow: vi.fn(),
-      getOptionChain: vi.fn(),
+      getExpiryBreakdown: vi.fn(),
+      getOptionContracts: vi.fn(),
     }));
     const { registry } = uwRegistry();
 
@@ -1005,7 +1007,8 @@ describe('per-iteration re-read + UW-client rebuild (task 26)', () => {
       return {
         getStockQuote: vi.fn().mockResolvedValue({ price: 1 }),
         getOptionsFlow: vi.fn(),
-        getOptionChain: vi.fn(),
+        getExpiryBreakdown: vi.fn(),
+        getOptionContracts: vi.fn(),
       };
     });
     const { registry } = uwRegistry();

--- a/apps/api/src/features/advisor/tools/dispatch.test.ts
+++ b/apps/api/src/features/advisor/tools/dispatch.test.ts
@@ -376,7 +376,8 @@ describe('buildToolContext — per-tool abort controller seam', () => {
       () => ({
         getStockQuote: async () => null,
         getOptionsFlow: async () => null,
-        getOptionChain: async () => null,
+        getExpiryBreakdown: async () => null,
+        getOptionContracts: async () => null,
       }),
     );
     expect(ctx.signal.aborted).toBe(false);
@@ -395,7 +396,8 @@ describe('buildToolContext — per-tool abort controller seam', () => {
     const makeUw = () => ({
       getStockQuote: async () => null,
       getOptionsFlow: async () => null,
-      getOptionChain: async () => null,
+      getExpiryBreakdown: async () => null,
+      getOptionContracts: async () => null,
     });
     const md = buildToolContext(
       'market-data',

--- a/apps/api/src/features/advisor/tools/market-data.test.ts
+++ b/apps/api/src/features/advisor/tools/market-data.test.ts
@@ -11,6 +11,7 @@ import {
   marketDataTools,
   optionsChainTool,
   optionsFlowTool,
+  parseExpirations,
   parseOptionChain,
   stockQuoteTool,
 } from './market-data';
@@ -22,7 +23,8 @@ function stubUw(overrides: Partial<UnusualWhalesClient> = {}): UnusualWhalesClie
   return {
     getStockQuote: vi.fn(async () => ({ data: {} })),
     getOptionsFlow: vi.fn(async () => ({ data: [] })),
-    getOptionChain: vi.fn(async () => ({ data: [] })),
+    getExpiryBreakdown: vi.fn(async () => ({ data: [{ expires: '2030-06-21' }] })),
+    getOptionContracts: vi.fn(async () => ({ data: [] })),
     ...overrides,
   };
 }
@@ -78,7 +80,7 @@ describe('pre-call input validation (REQ-7.3)', () => {
   it('validates the optional ISO expiration on the options chain', () => {
     const s = optionsChainTool.inputSchema;
     expect(s.safeParse({ symbol: 'AAPL' }).success).toBe(true);
-    expect(s.safeParse({ symbol: 'AAPL', expiration: '2026-06-19' }).success).toBe(true);
+    expect(s.safeParse({ symbol: 'AAPL', expiration: '2030-06-21' }).success).toBe(true);
     expect(s.safeParse({ symbol: 'AAPL', expiration: 'June' }).success).toBe(false);
   });
 });
@@ -167,104 +169,176 @@ describe('options-flow handler', () => {
 });
 
 describe('options-chain handler + shared parsing (REQ-12.4)', () => {
-  it('forwards the expiration and returns a compact projection', async () => {
-    const getOptionChain = vi.fn(async () => ({
-      data: [
-        { option_symbol: 'AAPL260619C00200000', strike: 200, delta: 0.5, junk: 'y'.repeat(2000) },
-      ],
+  it('scopes to the requested expiry and returns a compact projection', async () => {
+    const getOptionContracts = vi.fn(async () => ({
+      data: [{ option_symbol: 'AAPL300621C00200000', delta: '0.5', junk: 'y'.repeat(2000) }],
     }));
-    const ctx = ctxWith(stubUw({ getOptionChain }));
+    const ctx = ctxWith(stubUw({ getOptionContracts }));
     const result = await optionsChainTool.handler(
-      { symbol: 'AAPL', expiration: '2026-06-19' },
+      { symbol: 'AAPL', expiration: '2030-06-21' },
       ctx,
     );
 
-    expect(getOptionChain).toHaveBeenCalledWith('AAPL', '2026-06-19', ctx.signal);
+    expect(getOptionContracts).toHaveBeenCalledWith('AAPL', '2030-06-21', ctx.signal);
     expect(result.status).toBe('ok');
     if (result.status === 'ok') {
-      expect(result.content).toMatchObject({ symbol: 'AAPL', expiration: '2026-06-19', count: 1 });
+      expect(result.content).toMatchObject({ symbol: 'AAPL', expiration: '2030-06-21', count: 1 });
     }
     expect(JSON.stringify(result)).not.toContain('junk');
   });
 
+  it('defaults to the nearest expiry when none is given', async () => {
+    const getExpiryBreakdown = vi.fn(async () => ({
+      // Deliberately unsorted, and carrying a past expiry that must be dropped.
+      data: [{ expires: '2031-01-17' }, { expires: '2020-01-01' }, { expires: '2030-06-21' }],
+    }));
+    const getOptionContracts = vi.fn(async () => ({ data: [{ option_symbol: 'X' }] }));
+    const ctx = ctxWith(stubUw({ getExpiryBreakdown, getOptionContracts }));
+
+    await optionsChainTool.handler({ symbol: 'AAPL' }, ctx);
+
+    expect(getOptionContracts).toHaveBeenCalledWith('AAPL', '2030-06-21', ctx.signal);
+  });
+
+  it('reports an expiry the ticker does not have, rather than "symbol not found"', async () => {
+    const getExpiryBreakdown = vi.fn(async () => ({ data: [{ expires: '2030-06-21' }] }));
+    const getOptionContracts = vi.fn(async () => ({ data: [] }));
+    const result = await optionsChainTool.handler(
+      { symbol: 'AAPL', expiration: '2030-06-22' },
+      ctxWith(stubUw({ getExpiryBreakdown, getOptionContracts })),
+    );
+
+    expect(result).toMatchObject({ status: 'error', code: 'SYMBOL_NOT_FOUND' });
+    if (result.status === 'error') expect(result.message).toContain('expire on that date');
+    expect(getOptionContracts).not.toHaveBeenCalled();
+  });
+
   it('exports parseOptionChain for the viewer (task 35) producing identical output', async () => {
-    const raw = { data: [{ option_symbol: 'X', strike: 1, bid: 2, ask: 3, junk: 'z' }] };
-    const getOptionChain = vi.fn(async () => raw);
+    const raw = { data: [{ option_symbol: 'X', nbbo_bid: '2', nbbo_ask: '3', junk: 'z' }] };
+    const getOptionContracts = vi.fn(async () => raw);
     const handlerResult = await optionsChainTool.handler(
       { symbol: 'AAPL' },
-      ctxWith(stubUw({ getOptionChain })),
+      ctxWith(stubUw({ getOptionContracts })),
     );
-    const direct = parseOptionChain('AAPL', raw);
+    const direct = parseOptionChain('AAPL', raw, '2030-06-21');
     if (handlerResult.status === 'ok') {
       expect(handlerResult.content).toEqual(direct);
     }
     expect(JSON.stringify(direct)).not.toContain('junk');
   });
 
-  it('caps the chain to 50 contracts', () => {
-    const data = Array.from({ length: 80 }, (_, i) => ({ strike: i }));
+  it('caps the chain to 50 contracts by default', () => {
+    const data = Array.from({ length: 80 }, (_, i) => ({
+      option_symbol: `AAPL300621C${String(i * 1000).padStart(8, '0')}`,
+    }));
     const out = parseOptionChain('AAPL', { data }) as { count: number; contracts: unknown[] };
     expect(out.count).toBe(50);
     expect(out.contracts).toHaveLength(50);
   });
 
-  // UW's enriched rows spell these three differently from the names the chain
-  // viewer and calculator read; the projection normalises them.
-  it('normalises UW expires/nbbo_bid/nbbo_ask onto expiry/bid/ask', () => {
-    const out = parseOptionChain('AAPL', {
+  // option-contracts rows carry NO strike/type/expiry fields — only the OCC
+  // symbol — so the projection decodes them, and prices arrive as strings.
+  it('decodes strike/type/expiry from the option symbol and numifies prices', () => {
+    const out = parseOptionChain('SPY', {
       data: [
         {
-          option_symbol: 'AAPL260619C00190000',
-          expires: '2026-06-19',
-          nbbo_bid: 4.1,
-          nbbo_ask: 4.25,
-          strike: 190,
+          option_symbol: 'SPY260814C00780000',
+          nbbo_bid: '0.38',
+          nbbo_ask: '0.39',
+          last_price: '0.39',
+          implied_volatility: '0.1064785219753081',
+          volume: 163686,
+          open_interest: 154315,
         },
       ],
     }) as { contracts: Record<string, unknown>[] };
 
-    expect(out.contracts[0]).toMatchObject({ expiry: '2026-06-19', bid: 4.1, ask: 4.25 });
-    expect(out.contracts[0].expires).toBeUndefined();
-    expect(out.contracts[0].nbbo_bid).toBeUndefined();
+    expect(out.contracts[0]).toMatchObject({
+      option_symbol: 'SPY260814C00780000',
+      option_type: 'call',
+      strike: 780,
+      expiry: '2026-08-14',
+      bid: 0.38,
+      ask: 0.39,
+      last_price: 0.39,
+      volume: 163686,
+      open_interest: 154315,
+    });
+    expect(out.contracts[0].implied_volatility).toBeCloseTo(0.10648, 5);
   });
 
-  it('prefers the plain spelling when UW sends both', () => {
-    const out = parseOptionChain('AAPL', {
-      data: [{ expiry: '2026-06-19', expires: '1999-01-01', bid: 1, nbbo_bid: 9 }],
+  // The entry-price hand-off: a real fill wins, the NBBO mid stands in when a
+  // contract has never traded.
+  it('uses last_price as the premium when the contract has traded', () => {
+    const out = parseOptionChain('SPY', {
+      data: [
+        { option_symbol: 'SPY260814C00780000', nbbo_bid: '1', nbbo_ask: '3', last_price: '2.5' },
+      ],
     }) as { contracts: Record<string, unknown>[] };
 
-    expect(out.contracts[0]).toMatchObject({ expiry: '2026-06-19', bid: 1 });
+    expect(out.contracts[0].premium).toBe(2.5);
   });
 
-  // The production 503: UW's default response is bare OCC symbol strings.
-  it('decodes bare option-symbol strings into contracts', () => {
+  it('falls back to the NBBO mid when there is no last trade', () => {
     const out = parseOptionChain('SPY', {
-      data: ['SPY251219C00500000', 'SPY251219P00450000'],
-    }) as { count: number; contracts: Record<string, unknown>[] };
+      data: [{ option_symbol: 'SPY260814C00780000', nbbo_bid: '25.19', nbbo_ask: '26.15' }],
+    }) as { contracts: Record<string, unknown>[] };
 
-    expect(out.count).toBe(2);
-    expect(out.contracts[0]).toEqual({
-      option_symbol: 'SPY251219C00500000',
-      option_type: 'call',
-      strike: 500,
-      expiry: '2025-12-19',
-    });
-    expect(out.contracts[1]).toEqual({
-      option_symbol: 'SPY251219P00450000',
-      option_type: 'put',
-      strike: 450,
-      expiry: '2025-12-19',
-    });
+    expect(out.contracts[0].premium).toBeCloseTo(25.67, 2);
+    expect(out.contracts[0].last_price).toBeUndefined();
   });
 
-  it('keeps an undecodable symbol as a bare row rather than dropping it', () => {
-    const out = parseOptionChain('SPY', { data: ['NOT-AN-OCC-SYMBOL'] }) as {
-      count: number;
+  it('omits the premium when neither a trade nor a two-sided quote exists', () => {
+    const out = parseOptionChain('SPY', {
+      data: [{ option_symbol: 'SPY260814C00780000', nbbo_bid: '1' }],
+    }) as { contracts: Record<string, unknown>[] };
+
+    expect(out.contracts[0].premium).toBeUndefined();
+  });
+
+  // A cap over the endpoint's arbitrary order yields a scatter across strikes;
+  // sorting first makes the kept slice an actual ladder.
+  it('sorts by strike before capping', () => {
+    const data = [
+      { option_symbol: 'SPY260814C00780000' },
+      { option_symbol: 'SPY260814C00100000' },
+      { option_symbol: 'SPY260814C00500000' },
+    ];
+    const out = parseOptionChain('SPY', { data }, undefined, 2) as {
       contracts: Record<string, unknown>[];
     };
 
+    expect(out.contracts.map((c) => c.strike)).toEqual([100, 500]);
+  });
+
+  it('keeps an undecodable symbol rather than dropping the row', () => {
+    const out = parseOptionChain('SPY', {
+      data: [{ option_symbol: 'NOT-AN-OCC-SYMBOL', nbbo_bid: '1', nbbo_ask: '2' }],
+    }) as { count: number; contracts: Record<string, unknown>[] };
+
     expect(out.count).toBe(1);
-    expect(out.contracts[0]).toEqual({ option_symbol: 'NOT-AN-OCC-SYMBOL' });
+    expect(out.contracts[0]).toMatchObject({ option_symbol: 'NOT-AN-OCC-SYMBOL', premium: 1.5 });
+    expect(out.contracts[0].strike).toBeUndefined();
+  });
+});
+
+describe('parseExpirations', () => {
+  it('sorts soonest-first and drops expiries already past', () => {
+    const raw = {
+      data: [{ expires: '2027-01-15' }, { expires: '2020-01-01' }, { expires: '2030-06-21' }],
+    };
+    expect(parseExpirations(raw, '2026-01-01')).toEqual(['2027-01-15', '2030-06-21']);
+  });
+
+  it('keeps an expiry falling on today', () => {
+    expect(parseExpirations({ data: [{ expires: '2026-08-12' }] }, '2026-08-12')).toEqual([
+      '2026-08-12',
+    ]);
+  });
+
+  it('tolerates a malformed payload', () => {
+    expect(parseExpirations({ data: 'nope' }, '2026-01-01')).toEqual([]);
+    expect(parseExpirations({}, '2026-01-01')).toEqual([]);
   });
 });
 

--- a/apps/api/src/features/advisor/tools/market-data.test.ts
+++ b/apps/api/src/features/advisor/tools/market-data.test.ts
@@ -288,6 +288,17 @@ describe('options-chain handler + shared parsing (REQ-12.4)', () => {
     expect(out.contracts[0].last_price).toBeUndefined();
   });
 
+  // The mid is rendered and written into the entry-price field, so it must not
+  // carry binary-float noise: (4.10 + 4.30) / 2 is 4.199999999999999 raw.
+  it('rounds the mid instead of emitting float noise', () => {
+    const out = parseOptionChain('SPY', {
+      data: [{ option_symbol: 'SPY260814C00780000', nbbo_bid: '4.10', nbbo_ask: '4.30' }],
+    }) as { contracts: Record<string, unknown>[] };
+
+    expect(out.contracts[0].premium).toBe(4.2);
+    expect(String(out.contracts[0].premium)).toBe('4.2');
+  });
+
   it('omits the premium when neither a trade nor a two-sided quote exists', () => {
     const out = parseOptionChain('SPY', {
       data: [{ option_symbol: 'SPY260814C00780000', nbbo_bid: '1' }],

--- a/apps/api/src/features/advisor/tools/market-data.ts
+++ b/apps/api/src/features/advisor/tools/market-data.ts
@@ -144,7 +144,11 @@ function asNumber(value: unknown): number | undefined {
 function premiumOf(lastPrice?: number, bid?: number, ask?: number): number | undefined {
   if (lastPrice !== undefined) return lastPrice;
   if (bid === undefined || ask === undefined) return undefined;
-  return (bid + ask) / 2;
+  // Rounded, because binary float lands the mid of 4.10 and 4.30 on
+  // 4.199999999999999 — and this number is not internal: it is rendered in the
+  // chain and written into the entry-price field the user then trades on.
+  // Options quote in pennies, so a mid needs at most a half-penny; 4dp is ample.
+  return Number(((bid + ask) / 2).toFixed(4));
 }
 
 /**

--- a/apps/api/src/features/advisor/tools/market-data.ts
+++ b/apps/api/src/features/advisor/tools/market-data.ts
@@ -125,88 +125,157 @@ function parseOptionsFlow(symbol: string, raw: unknown, limit: number): Record<s
   return { symbol, count: alerts.length, alerts };
 }
 
-/** First present (non-null) value among `keys` — UW spells some fields two ways. */
-function firstOf(row: Record<string, unknown>, keys: string[]): unknown {
-  for (const k of keys) {
-    if (row[k] !== undefined && row[k] !== null) return row[k];
-  }
-  return undefined;
+/** Parse a UW numeric field, which arrives as a decimal STRING on most rows. */
+function asNumber(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
 }
 
 /**
- * Project one enriched contract row. UW is inconsistent about three field
- * names — its `greeks=true` example spells them `expires`/`nbbo_bid`/`nbbo_ask`
- * while the parameter docs say `expiry`/NBBO — so both spellings are accepted
- * and normalised to the one name the chain viewer and calculator read.
+ * The premium the calculator uses as the entry price.
+ *
+ * `last_price` is an actual fill and wins when present. Many contracts have
+ * never traded, so the NBBO midpoint is the fallback — it is the neutral
+ * fair-value convention, sitting between what you would pay and what you would
+ * receive. Returns undefined when neither is available, which the calculator
+ * hand-off already treats as "enter the premium manually".
+ */
+function premiumOf(lastPrice?: number, bid?: number, ask?: number): number | undefined {
+  if (lastPrice !== undefined) return lastPrice;
+  if (bid === undefined || ask === undefined) return undefined;
+  return (bid + ask) / 2;
+}
+
+/**
+ * Project one `option-contracts` row (design §Component 12, REQ-12.4).
+ *
+ * The endpoint sends `option_symbol` but NO strike / type / expiry fields, so
+ * those are decoded from the OCC symbol. Prices arrive as decimal strings and
+ * are normalised to numbers here so the viewer and the calculator do not each
+ * re-parse them. An unparseable symbol keeps its priced fields rather than
+ * being dropped.
  */
 function projectContract(row: Record<string, unknown>): Record<string, unknown> {
-  const out = pick(row, [
-    'option_symbol',
-    'option_type',
-    'strike',
-    'last_price',
-    'volume',
-    'open_interest',
-    'implied_volatility',
-    'delta',
-    'gamma',
-    'theta',
-    'vega',
-  ]);
-  const aliased: Record<string, string[]> = {
-    expiry: ['expiry', 'expires'],
-    bid: ['bid', 'nbbo_bid'],
-    ask: ['ask', 'nbbo_ask'],
+  const optionSymbol = typeof row.option_symbol === 'string' ? row.option_symbol : '';
+
+  const bid = asNumber(row.nbbo_bid);
+  const ask = asNumber(row.nbbo_ask);
+  const lastPrice = asNumber(row.last_price);
+  const premium = premiumOf(lastPrice, bid, ask);
+
+  const out: Record<string, unknown> = {
+    option_symbol: optionSymbol,
+    ...pick(row, ['volume', 'open_interest']),
   };
-  for (const [name, keys] of Object.entries(aliased)) {
-    const value = firstOf(row, keys);
-    if (value !== undefined) out[name] = value;
+
+  const decoded = parseOccSymbol(optionSymbol);
+  if (decoded.ok) {
+    out.option_type = decoded.value.type;
+    out.strike = Number(decoded.value.strike);
+    out.expiry = decoded.value.expiration;
   }
+
+  if (bid !== undefined) out.bid = bid;
+  if (ask !== undefined) out.ask = ask;
+  if (lastPrice !== undefined) out.last_price = lastPrice;
+  if (premium !== undefined) out.premium = premium;
+
+  for (const greek of ['implied_volatility', 'delta', 'gamma', 'theta', 'vega'] as const) {
+    const n = asNumber(row[greek]);
+    if (n !== undefined) out[greek] = n;
+  }
+
   return out;
 }
 
 /**
- * Project one bare OCC option-symbol string — the shape UW returns when
- * `greeks=true` is not honoured. Decoding recovers strike/expiry/type so the
- * chain still renders; there is no pricing in this form, and the calculator
- * hand-off already treats a missing `last_price` as "enter the premium
- * manually". An unparseable symbol degrades to the symbol alone rather than
- * dropping the row.
+ * The expiries a ticker has contracts for, soonest first, from
+ * `expiry-breakdown`. Expiries already in the past are dropped — they cannot
+ * be traded and would otherwise become the default "nearest".
  */
-function projectBareSymbol(optionSymbol: string): Record<string, unknown> {
-  const parsed = parseOccSymbol(optionSymbol);
-  if (!parsed.ok) return { option_symbol: optionSymbol };
-  const { expiration, type, strike } = parsed.value;
-  return {
-    option_symbol: optionSymbol,
-    option_type: type,
-    strike: Number(strike),
-    expiry: expiration,
-  };
+export function parseExpirations(raw: unknown, today: string): string[] {
+  return asRows((raw as { data?: unknown }).data)
+    .map((row) => (typeof row.expires === 'string' ? row.expires : undefined))
+    .filter((e): e is string => e !== undefined && e >= today)
+    .sort();
 }
 
 /**
- * Compact options-chain projection from `{ data: [...] }`, capped to
- * `CHAIN_MAX_CONTRACTS`. Exported for the options-chain viewer (task 35,
- * REQ-12.4) so the tool and the viewer parse identically. Handles both UW
- * response forms (see `optionChainsSchema`).
+ * Compact options-chain projection from `{ data: [...] }`, capped to `limit`.
+ * Exported for the options-chain viewer (task 35, REQ-12.4) so the tool and the
+ * viewer parse identically.
+ *
+ * Contracts are sorted by strike: the endpoint's own order is arbitrary, and a
+ * cap applied to an arbitrary order yields an unusable scatter rather than a
+ * chain. The cap is a parameter because its two consumers differ — the advisor
+ * tool persists its result and must stay small, while the viewer renders one
+ * expiry and wants the whole ladder.
  */
 export function parseOptionChain(
   symbol: string,
   raw: unknown,
   expiration?: string,
+  limit: number = CHAIN_MAX_CONTRACTS,
 ): Record<string, unknown> {
-  const data = (raw as { data?: unknown }).data;
-  const rows = (Array.isArray(data) ? data : []).slice(0, CHAIN_MAX_CONTRACTS);
-  const contracts = rows.map((row) =>
-    typeof row === 'string' ? projectBareSymbol(row) : projectContract(asRecord(row)),
-  );
+  const contracts = asRows((raw as { data?: unknown }).data)
+    .map(projectContract)
+    .sort((a, b) => ((a.strike as number) ?? 0) - ((b.strike as number) ?? 0))
+    .slice(0, limit);
+
   return {
     symbol,
     ...(expiration ? { expiration } : {}),
     count: contracts.length,
     contracts,
   };
+}
+
+/** Today as an ISO date, for "is this expiry still tradeable". */
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Resolve which expiry to show, then fetch that expiry's contracts (REQ-12.4).
+ * Shared by the advisor tool and the viewer endpoint so both scope the chain
+ * identically.
+ *
+ * Two calls: the cheap expiry index, then one expiry's contracts. Both are
+ * metered and cached like any other UW call. Fetching every expiry at once is
+ * what the `option-chains` endpoint does, and it costs ~4.7 MB for a liquid
+ * ticker to render a single ladder.
+ *
+ * A requested expiry the ticker does not have is reported as SYMBOL_NOT_FOUND
+ * with an explicit message — the upstream would otherwise return an empty
+ * envelope, which the client's empty-check reports as a bare "Symbol not
+ * found." against a symbol that plainly exists.
+ */
+export async function fetchChainForExpiry(
+  uw: NonNullable<ToolContext['uw']>,
+  symbol: string,
+  expiration?: string,
+  signal?: AbortSignal,
+): Promise<{ raw: unknown; expiration: string; expirations: string[] }> {
+  const breakdown = await uw.getExpiryBreakdown(symbol, signal);
+  const expirations = parseExpirations(breakdown, todayIso());
+
+  if (expirations.length === 0) {
+    throw new MarketDataError(
+      TOOL_RESULT_CODES.SYMBOL_NOT_FOUND,
+      'No tradeable option expirations for this symbol.',
+    );
+  }
+  if (expiration !== undefined && !expirations.includes(expiration)) {
+    throw new MarketDataError(
+      TOOL_RESULT_CODES.SYMBOL_NOT_FOUND,
+      'No contracts expire on that date for this symbol.',
+    );
+  }
+
+  const chosen = expiration ?? expirations[0];
+  const raw = await uw.getOptionContracts(symbol, chosen, signal);
+  return { raw, expiration: chosen, expirations };
 }
 
 // --- Failure mapping (REQ-7.5) ----------------------------------------------
@@ -288,8 +357,11 @@ export const optionsChainTool: ToolDefinition = {
   async handler(input, ctx) {
     const { symbol, expiration } = optionsChainInputSchema.parse(input);
     try {
-      const raw = await requireUw(ctx).getOptionChain(symbol, expiration, ctx.signal);
-      return { status: 'ok', content: parseOptionChain(symbol, raw, expiration) };
+      const resolved = await fetchChainForExpiry(requireUw(ctx), symbol, expiration, ctx.signal);
+      return {
+        status: 'ok',
+        content: parseOptionChain(symbol, resolved.raw, resolved.expiration),
+      };
     } catch (error) {
       return toErrorResult(error);
     }

--- a/apps/api/src/features/advisor/tools/types.ts
+++ b/apps/api/src/features/advisor/tools/types.ts
@@ -29,7 +29,7 @@ export type ToolRequires = 'unusual-whales-key' | 'trade-data-consent' | 'none';
  * The Unusual Whales client (REQ-1.4, REQ-6.4) — re-exported from the concrete
  * implementation (task 8, `features/advisor/lib/unusual-whales.client.ts`) so
  * `ctx.uw` carries the real method surface (`getOptionsFlow(symbol, limit?)`,
- * `getOptionChain(symbol, expiration?)`) market-data handlers forward to. The
+ * `getOptionContracts(symbol, expiry)`) market-data handlers forward to. The
  * `import type` re-export above keeps this free of a runtime circular import.
  */
 

--- a/apps/docs/src/openapi/tradr-api.json
+++ b/apps/docs/src/openapi/tradr-api.json
@@ -1107,7 +1107,7 @@
     },
     "/api/advisor/options-chain": {
       "get": {
-        "description": "Backs the options-tools page chain viewer. Shares the Unusual Whales client and the `market_data_options_chain` tool's parsing (no duplicate fetch logic). When the authenticated user has no Unusual Whales key the response is `{ configured: false }` so the viewer shows an empty-state CTA to Settings, not an error. With a key the response is `{ configured: true, chain }` where `chain` is the compact projection `{ symbol, expiration?, count, contracts[] }`. Upstream failures are mapped to their reason codes on the matching HTTP status: 400 MARKET_DATA_KEY_INVALID, 429 MARKET_DATA_RATE_LIMITED / PLATFORM_RATE_LIMITED, 404 SYMBOL_NOT_FOUND, 503 MARKET_DATA_UNAVAILABLE. The plaintext key is never returned or logged.\n",
+        "description": "Backs the options-tools page chain viewer. Shares the Unusual Whales client and the `market_data_options_chain` tool's parsing (no duplicate fetch logic). When the authenticated user has no Unusual Whales key the response is `{ configured: false }` so the viewer shows an empty-state CTA to Settings, not an error.\nA chain is scoped to ONE expiry. Omit `expiration` to get the nearest tradeable one. The response is `{ configured: true, expiration, expirations[], chain }`: `expiration` is the expiry actually returned, `expirations` is every tradeable expiry (soonest first) for the picker, and `chain` is the compact projection `{ symbol, expiration?, count, contracts[] }` sorted by strike. Each contract carries `premium` — the last traded price, or the NBBO midpoint when the contract has not traded — which is what the calculator uses as an entry price.\nRequesting an `expiration` the symbol has no contracts for is 404 SYMBOL_NOT_FOUND with an explicit message. Other upstream failures map to their reason codes on the matching HTTP status: 400 MARKET_DATA_KEY_INVALID, 429 MARKET_DATA_RATE_LIMITED / PLATFORM_RATE_LIMITED, 503 MARKET_DATA_UNAVAILABLE. The plaintext key is never returned or logged.\n",
         "parameters": [
           {
             "in": "query",
@@ -1119,6 +1119,7 @@
             }
           },
           {
+            "description": "Expiry to fetch (YYYY-MM-DD). Defaults to the nearest tradeable expiry.",
             "in": "query",
             "name": "expiration",
             "schema": {
@@ -1129,13 +1130,13 @@
         ],
         "responses": {
           "200": {
-            "description": "{ configured: false } or { configured: true, chain }."
+            "description": "{ configured: false } or { configured: true, expiration, expirations, chain }."
           },
           "400": {
             "description": "Validation error or MARKET_DATA_KEY_INVALID."
           },
           "404": {
-            "description": "SYMBOL_NOT_FOUND."
+            "description": "SYMBOL_NOT_FOUND — unknown symbol, or no contracts on that expiry."
           },
           "429": {
             "description": "MARKET_DATA_RATE_LIMITED or PLATFORM_RATE_LIMITED."
@@ -1144,7 +1145,7 @@
             "description": "MARKET_DATA_UNAVAILABLE."
           }
         },
-        "summary": "Get the live options chain for a symbol from Unusual Whales.",
+        "summary": "Get one expiry's option chain for a symbol from Unusual Whales.",
         "tags": [
           "Advisor"
         ]

--- a/apps/web/src/features/calculator/components/CalculatorForm.test.tsx
+++ b/apps/web/src/features/calculator/components/CalculatorForm.test.tsx
@@ -728,9 +728,11 @@ describe('CalculatorForm — pull-quote gating + populate (REQ-5.2/5.3/5.4)', ()
 describe('CalculatorForm — option contract hand-off (REQ-6.3/6.5)', () => {
   beforeEach(resetQuoteFixtures);
 
-  it('populates entry from the contract premium (last_price) and shows the OCC symbol', async () => {
+  it('populates entry from the contract premium and shows the OCC symbol', async () => {
     const user = userEvent.setup();
-    quote.contracts.current = [{ option_symbol: 'AAPL  250620C00150000', last_price: 3.25 }];
+    quote.contracts.current = [
+      { option_symbol: 'AAPL  250620C00150000', last_price: 3.25, premium: 3.25 },
+    ];
     await mount();
     await user.click(screen.getByRole('tab', { name: 'Options' }));
     await user.click(screen.getByRole('button', { name: 'Select from options chain' }));
@@ -740,7 +742,23 @@ describe('CalculatorForm — option contract hand-off (REQ-6.3/6.5)', () => {
     expect(screen.getByText(/Selected contract:/)).toBeTruthy();
   });
 
-  it('leaves entry blank with a manual-entry note when the contract has no last_price', async () => {
+  // Most contracts on an expiry have never traded, so the API resolves the
+  // premium to the NBBO midpoint. The form must use it exactly like a fill.
+  it('populates entry from the NBBO-mid premium when the contract has not traded', async () => {
+    const user = userEvent.setup();
+    quote.contracts.current = [
+      { option_symbol: 'AAPL  250620C00150000', bid: 3.1, ask: 3.4, premium: 3.25 },
+    ];
+    await mount();
+    await user.click(screen.getByRole('tab', { name: 'Options' }));
+    await user.click(screen.getByRole('button', { name: 'Select from options chain' }));
+    await user.click(screen.getByRole('button', { name: /Use AAPL/ }));
+
+    expect(input('Entry price').value).toBe('3.25');
+    expect(screen.queryByText(/enter the premium manually/i)).toBeNull();
+  });
+
+  it('leaves entry blank with a manual-entry note when the contract has no premium', async () => {
     const user = userEvent.setup();
     quote.contracts.current = [{ option_symbol: 'AAPL  250620C00150000' }];
     await mount();

--- a/apps/web/src/features/calculator/components/CalculatorForm.tsx
+++ b/apps/web/src/features/calculator/components/CalculatorForm.tsx
@@ -273,7 +273,12 @@ export function CalculatorForm() {
   // Option contract hand-off (REQ-6.2/6.3). ORDER IS PINNED (OD#9): set `mode`
   // via a BARE non-clearing setValue (must NOT route through handleModeChange,
   // which would wipe the premium), store the validated option_symbol, then write
-  // entryPrice = the PREMIUM (contract.last_price, never the underlying spot) LAST.
+  // entryPrice = the PREMIUM (never the underlying spot) LAST.
+  //
+  // `premium` is the API's resolved entry price: the last traded price when the
+  // contract has traded, else the NBBO midpoint. Most contracts on a given
+  // expiry have never traded, so without the midpoint fallback this hand-off
+  // would almost always land on the manual-entry note.
   const handleContractSelected = (contract: OptionContract) => {
     setChainOpen(false);
     setValue('mode', 'options', { shouldValidate: false });
@@ -281,9 +286,9 @@ export function CalculatorForm() {
       const parsed = parseOccSymbol(contract.option_symbol);
       if (parsed.ok) setHandedOffOcc(contract.option_symbol);
     }
-    if (contract.last_price != null) {
+    if (contract.premium != null) {
       setManualPremiumNote(false);
-      setValue('entryPrice', String(contract.last_price), { shouldValidate: true });
+      setValue('entryPrice', String(contract.premium), { shouldValidate: true });
     } else {
       setManualPremiumNote(true);
     }

--- a/apps/web/src/features/options/components/OptionsChainViewer.test.tsx
+++ b/apps/web/src/features/options/components/OptionsChainViewer.test.tsx
@@ -12,7 +12,7 @@ import {
   createRouter,
   RouterProvider,
 } from '@tanstack/react-router';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -78,11 +78,20 @@ describe('OptionsChainViewer', () => {
       isError: false,
       data: {
         configured: true,
+        expiration: '2025-06-20',
+        expirations: ['2025-06-20', '2025-09-19'],
         chain: {
           symbol: 'AAPL',
           count: 1,
           contracts: [
-            { option_type: 'call', strike: 150, expiry: '2025-06-20', bid: 3.1, ask: 3.3 },
+            {
+              option_type: 'call',
+              strike: 150,
+              expiry: '2025-06-20',
+              bid: 3.1,
+              ask: 3.3,
+              premium: 3.2,
+            },
           ],
         },
       },
@@ -92,7 +101,53 @@ describe('OptionsChainViewer', () => {
     await waitFor(() => {
       expect(screen.getByText('150')).toBeTruthy();
     });
-    expect(screen.getByText('2025-06-20')).toBeTruthy();
+    // Scoped to the table: the expiry also appears in the picker above it.
+    const table = screen.getByRole('table');
+    expect(within(table).getByText('2025-06-20')).toBeTruthy();
+    // The premium column is what the calculator hand-off uses.
+    expect(within(table).getByText('3.2')).toBeTruthy();
+  });
+
+  it('offers every expiry in a picker and refetches on change (REQ-12.4)', async () => {
+    useOptionsChainMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        configured: true,
+        expiration: '2025-06-20',
+        expirations: ['2025-06-20', '2025-09-19'],
+        chain: { symbol: 'AAPL', count: 1, contracts: [{ strike: 150, premium: 3.2 }] },
+      },
+    });
+    renderWithClient(<OptionsChainViewer />);
+    await userEvent.type(screen.getByLabelText('Symbol'), 'AAPL');
+
+    const picker = await screen.findByLabelText('Expiration');
+    expect((picker as HTMLSelectElement).value).toBe('2025-06-20');
+
+    await userEvent.selectOptions(picker, '2025-09-19');
+    await waitFor(() => {
+      // The hook is re-invoked with the chosen expiry, which is what scopes the
+      // upstream fetch to one ladder instead of the whole chain.
+      expect(useOptionsChainMock).toHaveBeenCalledWith('AAPL', '2025-09-19');
+    });
+  });
+
+  it('hides the picker when the API sends no expiry list', async () => {
+    useOptionsChainMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        configured: true,
+        chain: { symbol: 'AAPL', count: 1, contracts: [{ strike: 150 }] },
+      },
+    });
+    renderWithClient(<OptionsChainViewer />);
+    await userEvent.type(screen.getByLabelText('Symbol'), 'AAPL');
+    await waitFor(() => {
+      expect(screen.getByText('150')).toBeTruthy();
+    });
+    expect(screen.queryByLabelText('Expiration')).toBeNull();
   });
 
   it.each([
@@ -134,6 +189,8 @@ describe('OptionsChainViewer onSelectContract (REQ-6.5/6.6)', () => {
     isError: false,
     data: {
       configured: true,
+      expiration: '2025-06-20',
+      expirations: ['2025-06-20'],
       chain: {
         symbol: 'AAPL',
         count: 2,
@@ -144,6 +201,7 @@ describe('OptionsChainViewer onSelectContract (REQ-6.5/6.6)', () => {
             strike: 150,
             expiry: '2025-06-20',
             last_price: 3.2,
+            premium: 3.2,
           },
           { option_type: 'put', strike: 140, expiry: '2025-06-20' },
         ],

--- a/apps/web/src/features/options/components/OptionsChainViewer.tsx
+++ b/apps/web/src/features/options/components/OptionsChainViewer.tsx
@@ -60,9 +60,25 @@ interface OptionsChainViewerProps {
 
 export function OptionsChainViewer({ onSelectContract }: OptionsChainViewerProps = {}) {
   const [symbolInput, setSymbolInput] = useState('');
+  const [expiry, setExpiry] = useState<string | undefined>(undefined);
   const debounced = useDebouncedValue(symbolInput.trim().toUpperCase(), 400);
 
-  const query = useOptionsChain(debounced);
+  const query = useOptionsChain(debounced, expiry);
+
+  // A chain is one expiry's ladder, so a held-over expiry from the previous
+  // symbol would ask for a date the new ticker may not list. Clearing on symbol
+  // change falls back to "nearest", which every ticker has.
+  const onSymbolChange = (value: string) => {
+    setSymbolInput(value);
+    setExpiry(undefined);
+  };
+
+  // Defaulted rather than assumed: during a rolling deploy the web bundle and
+  // the API can briefly disagree about the response shape, and a missing list
+  // should hide the picker, not blank the whole viewer.
+  const data = query.data;
+  const expirations = data?.configured === true ? (data.expirations ?? []) : [];
+  const selectedExpiry = data?.configured === true ? data.expiration : undefined;
 
   return (
     <Card data-slot="options-chain-viewer">
@@ -78,12 +94,30 @@ export function OptionsChainViewer({ onSelectContract }: OptionsChainViewerProps
             autoComplete="off"
             placeholder="AAPL"
             value={symbolInput}
-            onChange={(e) => setSymbolInput(e.target.value)}
+            onChange={(e) => onSymbolChange(e.target.value)}
           />
           <p className="text-sm text-muted-foreground">
             Enter a US ticker to view its live options chain from Unusual Whales.
           </p>
         </div>
+
+        {expirations.length > 0 ? (
+          <div className="space-y-2">
+            <Label htmlFor="options-chain-expiry">Expiration</Label>
+            <select
+              id="options-chain-expiry"
+              className="border-input bg-background h-9 w-full rounded-md border px-3 py-1 text-sm cursor-pointer"
+              value={selectedExpiry ?? ''}
+              onChange={(e) => setExpiry(e.target.value)}
+            >
+              {expirations.map((date) => (
+                <option key={date} value={date}>
+                  {date}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : null}
 
         <ChainBody symbol={debounced} query={query} onSelectContract={onSelectContract} />
       </CardContent>
@@ -188,7 +222,9 @@ function ChainTable({
             <TableHead>Expiry</TableHead>
             <TableHead>Bid</TableHead>
             <TableHead>Ask</TableHead>
-            <TableHead>Last</TableHead>
+            {/* The premium the "Use" button hands to the calculator: the last
+                traded price, or the NBBO mid when the contract has not traded. */}
+            <TableHead>Premium</TableHead>
             <TableHead>Vol</TableHead>
             <TableHead>OI</TableHead>
             {onSelectContract ? (
@@ -206,7 +242,7 @@ function ChainTable({
               <TableCell>{row.expiry ?? '—'}</TableCell>
               <TableCell>{num(row.bid)}</TableCell>
               <TableCell>{num(row.ask)}</TableCell>
-              <TableCell>{num(row.last_price)}</TableCell>
+              <TableCell>{num(row.premium)}</TableCell>
               <TableCell>{num(row.volume)}</TableCell>
               <TableCell>{num(row.open_interest)}</TableCell>
               {onSelectContract ? (

--- a/apps/web/src/features/options/hooks/useOptionsChain.ts
+++ b/apps/web/src/features/options/hooks/useOptionsChain.ts
@@ -21,6 +21,12 @@ export interface OptionContract {
   last_price?: number;
   bid?: number;
   ask?: number;
+  /**
+   * The premium to use as an entry price: the last traded price when the
+   * contract has traded, otherwise the NBBO midpoint. Absent when the contract
+   * has neither, in which case the calculator asks for it manually.
+   */
+  premium?: number;
   volume?: number;
   open_interest?: number;
   implied_volatility?: number;
@@ -38,7 +44,16 @@ export interface OptionChain {
 }
 
 /** GET response — empty state (no key) or the parsed chain. */
-export type OptionsChainResponse = { configured: false } | { configured: true; chain: OptionChain };
+export type OptionsChainResponse =
+  | { configured: false }
+  | {
+      configured: true;
+      /** The expiry this chain is for — the requested one, or the nearest. */
+      expiration: string;
+      /** Every tradeable expiry, soonest first, for the picker. */
+      expirations: string[];
+      chain: OptionChain;
+    };
 
 export const optionsChainKeys = {
   chain: (symbol: string, expiration?: string) =>

--- a/e2e/support/uw-stub-server.ts
+++ b/e2e/support/uw-stub-server.ts
@@ -97,11 +97,16 @@ function deterministicResponse(pathname: string): { status: number; body: unknow
     };
   }
 
-  // option-contracts — TWO deterministic contracts on the nearest expiry:
+  // option-contracts — THREE deterministic contracts on the nearest expiry,
+  // one per premium-resolution branch:
   //   - Row A carries a `last_price` so the calculator's option hand-off
   //     (symbol-search-quotes Task 14) can assert entry = the traded premium.
-  //   - Row B has NO `last_price`, exercising the NBBO-mid fallback: its
-  //     premium resolves to (4.10 + 4.30) / 2 = 4.20.
+  //   - Row B has NO `last_price` but a two-sided quote, exercising the
+  //     NBBO-mid fallback: its premium resolves to (4.10 + 4.30) / 2 = 4.20.
+  //   - Row C has neither, so no premium resolves and the hand-off falls
+  //     through to "enter the premium manually". Before the mid fallback that
+  //     was Row B's job; a quoted contract now always yields a premium, so the
+  //     manual path needs a contract that is genuinely unpriced.
   //
   // Rows are spelled the way the live endpoint spells them: NO strike / type /
   // expiry fields (the projection decodes those from the OCC symbol) and prices
@@ -128,6 +133,13 @@ function deterministicResponse(pathname: string): { status: number; body: unknow
               nbbo_ask: '4.30',
               volume: 320,
               open_interest: 980,
+            },
+            // Unpriced: no trade, no quote. Strike 175 shares no substring with
+            // any other rendered value, so a row filter resolves it uniquely.
+            {
+              option_symbol: `${ticker}300621C00175000`,
+              volume: 0,
+              open_interest: 44,
             },
           ],
         },

--- a/e2e/support/uw-stub-server.ts
+++ b/e2e/support/uw-stub-server.ts
@@ -7,9 +7,10 @@
  * booted with `UNUSUAL_WHALES_BASE_URL` pointed at THIS server, which serves
  * deterministic responses for the three pinned ticker endpoints:
  *
- *   GET /api/stock/{ticker}/info          → stockInfoSchema  `{ data: {...} }`
- *   GET /api/stock/{ticker}/flow-alerts   → flowAlertsSchema `{ data: [...] }`
- *   GET /api/stock/{ticker}/option-chains → optionChainsSchema `{ data: [...] }`
+ *   GET /api/stock/{ticker}/info             → stockInfoSchema  `{ data: {...} }`
+ *   GET /api/stock/{ticker}/flow-alerts      → flowAlertsSchema `{ data: [...] }`
+ *   GET /api/stock/{ticker}/expiry-breakdown → expiryBreakdownSchema `{ data: [...] }`
+ *   GET /api/stock/{ticker}/option-contracts → optionContractsSchema `{ data: [...] }`
  *
  * A ticker of `UNKNOWN` yields an empty envelope so e2e can exercise the
  * SYMBOL_NOT_FOUND path; any other ticker yields a non-empty deterministic
@@ -31,7 +32,8 @@ const DEFAULT_PORT = 4599;
 
 function deterministicResponse(pathname: string): { status: number; body: unknown } | null {
   // /api/stock/{ticker}/{resource}
-  const match = /^\/api\/stock\/([^/]+)\/(info|flow-alerts|option-chains)$/.exec(pathname);
+  const match =
+    /^\/api\/stock\/([^/]+)\/(info|flow-alerts|expiry-breakdown|option-contracts)$/.exec(pathname);
   if (!match) return null;
 
   const ticker = decodeURIComponent(match[1]).toUpperCase();
@@ -78,20 +80,34 @@ function deterministicResponse(pathname: string): { status: number; body: unknow
     };
   }
 
-  // option-chains — TWO deterministic call contracts:
-  //   - Row A carries a `last_price` (the premium) so the calculator's option
-  //     hand-off (symbol-search-quotes Task 14) can assert entry = premium.
-  //   - Row B has NO `last_price` (existing fixture, kept byte-identical) so the
-  //     hand-off's "no last trade ⇒ entry blank + manual note" case is covered,
-  //     and the advisor-tools spec's `strike 190 / expiry 2026-06-19` assertions
-  //     still resolve uniquely (Row A uses a distinct strike/expiry that share no
-  //     substring with either).
+  // expiry-breakdown — the cheap expiry index the viewer resolves "nearest"
+  // from and populates its picker with. Dates are far enough out that they stay
+  // tradeable (the API drops expiries already past).
+  if (resource === 'expiry-breakdown') {
+    return {
+      status: 200,
+      body: empty
+        ? { data: [] }
+        : {
+            data: [
+              { expires: '2030-06-21', open_interest: 1200, volume: 420, chains: 2 },
+              { expires: '2030-07-19', open_interest: 900, volume: 310, chains: 2 },
+            ],
+          },
+    };
+  }
+
+  // option-contracts — TWO deterministic contracts on the nearest expiry:
+  //   - Row A carries a `last_price` so the calculator's option hand-off
+  //     (symbol-search-quotes Task 14) can assert entry = the traded premium.
+  //   - Row B has NO `last_price`, exercising the NBBO-mid fallback: its
+  //     premium resolves to (4.10 + 4.30) / 2 = 4.20.
   //
-  // The rows are spelled the way UW's `greeks=true` example spells them
-  // (`expires` / `nbbo_bid` / `nbbo_ask`) — the previous fixture used the
-  // POST-projection names, so it agreed with the client's schema instead of
-  // testing it, and the real array-of-strings response 503'd in production
-  // against a fully green suite.
+  // Rows are spelled the way the live endpoint spells them: NO strike / type /
+  // expiry fields (the projection decodes those from the OCC symbol) and prices
+  // as decimal STRINGS. The previous fixture invented post-projection field
+  // names, so it agreed with the client instead of testing it — which is how a
+  // response shape the provider never sends stayed green all the way to prod.
   return {
     status: 200,
     body: empty
@@ -99,25 +115,17 @@ function deterministicResponse(pathname: string): { status: number; body: unknow
       : {
           data: [
             {
-              ticker,
-              option_symbol: `${ticker}260717C00200000`,
-              strike: '200',
-              expires: '2026-07-17',
-              option_type: 'call',
-              last_price: 5.25,
+              option_symbol: `${ticker}300621C00200000`,
+              last_price: '5.25',
               nbbo_bid: '5.10',
               nbbo_ask: '5.30',
               volume: 150,
               open_interest: 400,
             },
             {
-              ticker,
-              option_symbol: `${ticker}260619C00190000`,
-              strike: '190',
-              expires: '2026-06-19',
-              option_type: 'call',
+              option_symbol: `${ticker}300621C00190000`,
               nbbo_bid: '4.10',
-              nbbo_ask: '4.25',
+              nbbo_ask: '4.30',
               volume: 320,
               open_interest: 980,
             },

--- a/e2e/tests/advisor-tools.spec.ts
+++ b/e2e/tests/advisor-tools.spec.ts
@@ -8,7 +8,7 @@ import { expect, test, type APIRequestContext, type Page } from '@playwright/tes
  * (e2e/support/uw-stub-server.ts), the API with `UNUSUAL_WHALES_BASE_URL`
  * pointed at that stub, and the web dev server. UW responses are therefore
  * deterministic and NEVER hit the live host — the stub serves the three pinned
- * ticker endpoints (`/api/stock/{ticker}/{info|flow-alerts|option-chains}`),
+ * ticker endpoints (`/api/stock/{ticker}/{info|flow-alerts|expiry-breakdown|option-contracts}`),
  * with ticker `UNKNOWN` yielding an empty envelope (the SYMBOL_NOT_FOUND path).
  *
  * Auth + seed follow the established live-stack convention from
@@ -314,12 +314,15 @@ test.describe('advisor-tools', () => {
     // Save a UW key (verifies against the stub).
     await saveMarketDataKey(page, 'uw-e2e-test-key');
 
-    // Back on the options page, the same symbol now renders the stubbed chain:
-    // one deterministic call contract (strike 190, expiry 2026-06-19).
+    // Back on the options page, the same symbol now renders the stubbed chain
+    // for the NEAREST expiry (2030-06-21), with both stub contracts. Strike and
+    // expiry are decoded from the OCC symbol — the upstream sends neither.
     await page.goto('/options');
     await page.locator('#options-chain-symbol').fill('AAPL');
     await expect(page.getByText('190')).toBeVisible();
-    await expect(page.getByText('2026-06-19')).toBeVisible();
+    await expect(page.locator('#options-chain-expiry')).toHaveValue('2030-06-21');
+    // Row B never traded, so its premium is the NBBO mid: (4.10 + 4.30) / 2.
+    await expect(page.getByRole('cell', { name: '4.2', exact: true })).toBeVisible();
     // The no-key CTA is gone now that a key is configured.
     await expect(
       page.getByText('Connect an Unusual Whales key to view live options chains.'),

--- a/e2e/tests/symbol-search-quotes.spec.ts
+++ b/e2e/tests/symbol-search-quotes.spec.ts
@@ -228,31 +228,44 @@ test.describe('symbol-search-quotes', () => {
     const entry = page.locator('#entryPrice');
     await expect(entry).toHaveValue('');
 
-    // --- No-last-price row ⇒ entry stays blank + manual-entry note ---
+    // --- Unpriced row ⇒ entry stays blank + manual-entry note ---
     await page.getByRole('button', { name: 'Select from options chain' }).click();
     let dialog = page.getByRole('dialog');
     await dialog.locator('#options-chain-symbol').fill('AAPL');
-    // The strike-190 row from the UW stub has no last_price.
+    // The strike-175 row from the UW stub has neither a trade nor a quote, so
+    // no premium resolves. A row with only a quote now yields the NBBO mid.
     await dialog
       .getByRole('row')
-      .filter({ hasText: '190' })
+      .filter({ hasText: '175' })
       .getByRole('button', { name: 'Use' })
       .click();
     await expect(entry).toHaveValue('');
     await expect(page.getByText('No last trade — enter the premium manually.')).toBeVisible();
 
-    // --- Last-price row ⇒ entry = the premium (5.25) + OCC shown ---
+    // --- Quote-only row ⇒ entry = the NBBO mid (4.10 / 4.30 → 4.2) ---
     await page.getByRole('button', { name: 'Select from options chain' }).click();
     dialog = page.getByRole('dialog');
     await dialog.locator('#options-chain-symbol').fill('AAPL');
-    // The strike-200 row carries last_price 5.25 (the premium).
+    await dialog
+      .getByRole('row')
+      .filter({ hasText: '190' })
+      .getByRole('button', { name: 'Use' })
+      .click();
+    await expect(entry).toHaveValue('4.2');
+    await expect(page.getByText('No last trade — enter the premium manually.')).toHaveCount(0);
+
+    // --- Last-price row ⇒ entry = the traded premium (5.25) + OCC shown ---
+    await page.getByRole('button', { name: 'Select from options chain' }).click();
+    dialog = page.getByRole('dialog');
+    await dialog.locator('#options-chain-symbol').fill('AAPL');
+    // The strike-200 row carries last_price 5.25, which wins over its mid.
     await dialog
       .getByRole('row')
       .filter({ hasText: '5.25' })
       .getByRole('button', { name: 'Use' })
       .click();
     await expect(entry).toHaveValue('5.25');
-    await expect(page.getByText('Selected contract: AAPL260717C00200000')).toBeVisible();
+    await expect(page.getByText('Selected contract: AAPL300621C00200000')).toBeVisible();
     // The premium hand-off cleared the earlier manual-entry note.
     await expect(page.getByText('No last trade — enter the premium manually.')).toHaveCount(0);
 


### PR DESCRIPTION
Follow-up to #52. That PR fixed the 503, but probing the live API with a
working key showed the chain still wasn't usable — and turned up a
correctness bug in the endpoint it was built on.

## The `date` parameter is not an expiry

`option-chains` takes `date`, which is the **market day** ("symbols
present at the given day"), not the expiry. Verified against the live
API for SPY:

| request | rows |
| --- | --- |
| no `date` | 14,314 |
| `date=2026-08-11` (a past trading day) | 14,314 |
| `date=2026-08-14` (a real expiry) | **0** |
| `date=2027-01-15` (a real expiry) | **0** |

The handler passed the user's `expiration` straight into `date`, so any
expiration filter returned an empty envelope, which the client's
empty-check reports as `SYMBOL_NOT_FOUND` — a 404 for a symbol that
plainly exists. The web UI never sent `expiration`, so it was latent
there, but the advisor tool exposes it, and an expiry picker would have
hit it immediately.

## That endpoint can't back the feature anyway

- **No price.** Its rows carry `last_tape_time` but no `last_price`, so
  the "use its premium as the entry price" hand-off could never populate.
- **4.7 MB / ~1.2 s** for a full SPY greeks chain.
- The projection kept the **first 50 of 14,314 unordered rows** — 22
  different expiries spanning 2026-08-12 to 2028-12-15 and strikes from
  415 to 1100. A scatter, not a ladder.

## What this changes

Two endpoints that actually fit, both verified live:

| | payload | latency |
| --- | --- | --- |
| `expiry-breakdown` — the expiry list | 2.5 KB | 242 ms |
| `option-contracts?expiry=…` — one ladder | 211 KB | 337 ms |

`option-contracts` has a **real** `expiry` filter, and its rows carry
`last_price` alongside NBBO and greeks.

- The viewer defaults to the nearest expiry and offers a picker built
  from `expiry-breakdown`; the response gains `expiration` and
  `expirations[]`.
- Contracts are **sorted by strike before the cap** — a cap over an
  arbitrary order is what produced the scatter. The cap is now a
  parameter: the advisor tool persists its result and stays at 50, the
  viewer takes the whole ladder.
- Each contract gains **`premium`**: the last traded price, or the NBBO
  midpoint when the contract hasn't traded. Most contracts on an expiry
  have never traded, so without the midpoint the hand-off would almost
  always fall through to the manual-entry note — the one thing the chain
  modal exists to avoid.
- `option-contracts` sends no strike/type/expiry fields and prices as
  decimal strings, so the projection decodes the OCC symbol through the
  shared `parseOccSymbol` and normalises numbers once, instead of leaving
  the viewer and calculator to each re-parse.
- Requesting an expiry the symbol doesn't have now says so explicitly,
  rather than reporting the symbol as not found.

## Testing

The e2e stub now mirrors the real payload — no strike/type/expiry fields,
prices as strings — instead of inventing post-projection field names.
That habit is exactly what let a shape the provider never sends stay
green all the way to production, twice.

Its second contract deliberately has no `last_price`, so the NBBO-mid
fallback is exercised end to end: premium resolves to (4.10 + 4.30) / 2.

## Reviewer notes

- The `date` misuse is pre-existing, not introduced by #52 — #52
  preserved it while fixing the response-shape bug.
- Two upstream calls per chain load (expiry index, then contracts). Both
  are metered and cached like any other UW call; together they are still
  a fraction of the single 4.7 MB call they replace.
- `expiry-breakdown` returns expiries in the past for recently-expired
  contracts; those are dropped so "nearest" is always tradeable.
