### PR TITLE
fix(layout): keep the sidebar and its Log out button on screen

### DIFF
--- a/apps/web/src/components/layout/Sidebar.test.tsx
+++ b/apps/web/src/components/layout/Sidebar.test.tsx
@@ -337,3 +337,44 @@ describe('Sidebar — Changelog link + new-updates badge', () => {
     unmount(container, root);
   });
 });
+
+// jsdom computes no layout, so these assert the class contract that keeps the
+// rail pinned to the viewport instead of stretching to the height of <main> —
+// the arrangement that used to scroll the Log out button out of sight on long
+// routes.
+describe('Sidebar — pinned to the viewport, not the page', () => {
+  it('sizes the rail to the viewport and sticks it to the top', () => {
+    const { container, root } = mountWith(<Sidebar />);
+
+    const aside = container.querySelector('aside');
+    expect(aside?.className).toContain('sticky');
+    expect(aside?.className).toContain('top-0');
+    expect(aside?.className).toContain('h-screen');
+
+    unmount(container, root);
+  });
+
+  it('scrolls the nav links rather than the footer off the bottom', () => {
+    const { container, root } = mountWith(<Sidebar />);
+
+    const nav = container.querySelector('nav');
+    expect(nav?.className).toContain('overflow-y-auto');
+    // Without `min-h-0` the flex child refuses to shrink below its content and
+    // pushes the footer past the bottom edge — the bug this guards.
+    expect(nav?.className).toContain('min-h-0');
+
+    unmount(container, root);
+  });
+
+  it('keeps the Log out button in a footer that cannot be compressed', () => {
+    const { container, root } = mountWith(<Sidebar />);
+
+    const logout = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Log out',
+    );
+    expect(logout).toBeDefined();
+    expect(logout?.parentElement?.className).toContain('shrink-0');
+
+    unmount(container, root);
+  });
+});

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -73,13 +73,18 @@ export function Sidebar() {
   }, [collapsed]);
 
   return (
+    // `sticky top-0 h-screen` decouples the rail from the page: as a plain flex
+    // child it stretched to the height of <main>, which puts the footer — and
+    // the Log out button in it — at the bottom of the DOCUMENT rather than the
+    // viewport, out of sight on any long route. The explicit height also stops
+    // `align-items: stretch` from re-growing it.
     <aside
       className={cn(
-        'flex flex-col border-r bg-card transition-[width] duration-200',
+        'sticky top-0 flex h-screen flex-col border-r bg-card transition-[width] duration-200',
         collapsed ? 'w-16' : 'w-60',
       )}
     >
-      <div className="flex items-center justify-between border-b p-3">
+      <div className="flex shrink-0 items-center justify-between border-b p-3">
         {!collapsed && <span className="text-lg font-semibold">Tradr</span>}
         <div className="flex items-center gap-1">
           <ThemeToggle />
@@ -95,7 +100,11 @@ export function Sidebar() {
         </div>
       </div>
 
-      <nav className="flex-1 p-2">
+      {/* `min-h-0` is what lets this shrink below its content height (a flex
+          child's default `min-height: auto` would otherwise push the footer
+          off the bottom); `overflow-y-auto` then scrolls the links themselves
+          on a short viewport, leaving the footer pinned. */}
+      <nav className="min-h-0 flex-1 overflow-y-auto p-2">
         <Link
           to="/dashboard"
           className={cn(
@@ -270,7 +279,7 @@ export function Sidebar() {
         )}
       </nav>
 
-      <div className="border-t p-3">
+      <div className="shrink-0 border-t p-3">
         {!collapsed && user && (
           <p className="mb-2 truncate text-xs text-muted-foreground">{user.email}</p>
         )}


### PR DESCRIPTION
## Problem

The left-hand nav rail was a plain flex child of `<div className="flex min-h-screen">` in `routes/_auth.tsx`. Default `align-items: stretch` grew it to the height of `<main>`, so its footer — and the **Log out** button in it — sat at the bottom of the *document* rather than the viewport. On any long route the button was simply below the fold.

## Fix

Three changes to the `<aside>` in `Sidebar.tsx`:

- `sticky top-0 h-screen` — the explicit height stops `stretch` from re-growing the rail, and sticky pins it as the page scrolls.
- `min-h-0 overflow-y-auto` on the `<nav>` — `min-h-0` is the load-bearing part: a flex child's default `min-height: auto` refuses to shrink below its content, which would push the footer off the bottom edge again on a short viewport. With it, the links scroll internally instead.
- `shrink-0` on the header and footer so neither compresses when the nav is under pressure.

`_auth.tsx` needed no change — `min-h-screen` on the parent still works with a sticky child.

## Verification

Measured in a browser against the dev seed (110 positions, 5834px page) at 1280×800, comparing the new classes against the same page with them stripped at runtime:

| scroll position | before (aside 5834px) | after (aside 800px) |
| --- | --- | --- |
| top | Log out at y=**5790** — 7 screens below the fold | y=756, visible |
| middle | y=**2873** — off-screen | y=756, visible |
| bottom | y=741, visible | y=741, visible |

Note the bottom row: that is the one scroll position where both layouts coincide, which is why it can't be used to test this.

At a 560px-tall viewport the nav content (520px) overflows its 422px box and scrolls internally, with Log out still pinned — the `min-h-0` case.

Also confirmed no ancestor carries an `overflow` that would break sticky; the only `overflow: hidden` in `index.css` is scoped to gridstack items.

## Tests

Three cases added to `Sidebar.test.tsx` locking the class contract. They assert classnames rather than geometry, since jsdom computes no layout — the real geometric check was the browser measurement above.

`check-types` clean, eslint clean, 27 tests pass across `Sidebar` + `SideDrawer`.

## Note

The mobile drawer's body scroll-lock (`SideDrawer` effect 5) sets `body.style.position = 'fixed'`, which suspends sticky while it is open. Invisible in practice — that drawer is `w-full` at z-40 and covers the rail entirely — but worth knowing.
