### PR TITLE
fix(docker): let native modules build from source when the prebuild 404s

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -18,6 +18,22 @@ WORKDIR /repo
 # Pin pnpm to the workspace packageManager version (root package.json).
 RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 
+# Toolchain for building native modules FROM SOURCE.
+#
+# bcrypt fetches a prebuilt `.node` from a GitHub release in its postinstall,
+# and node-pre-gyp does not retry that download. Without a toolchain its
+# source-compile fallback cannot run, so a single dropped connection fails the
+# whole build — which is what took CI and this image down repeatedly.
+#
+# Retrying the download is not sufficient on its own: EVERY install step that
+# resolves bcrypt runs that postinstall (the workspace install below as well as
+# the /native install later), so the fallback has to actually work rather than
+# each call site needing its own retry. This costs build time only — the
+# builder stage is discarded and the runner copies just node_modules.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends python3 make g++ \
+  && rm -rf /var/lib/apt/lists/*
+
 # Copy the whole repo (the bundle inlines @tradr/* workspace source, so we
 # need the full monorepo, not just apps/api). .dockerignore keeps the context
 # slim (no node_modules, no .git, no .env).

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -13,6 +13,22 @@ WORKDIR /repo
 # Pin pnpm to the workspace packageManager version (root package.json, task 5).
 RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 
+# Toolchain for building native modules FROM SOURCE.
+#
+# The install below is workspace-wide, so it resolves the api's `bcrypt` even
+# though the SPA never calls it. bcrypt fetches a prebuilt `.node` from a GitHub
+# release in its postinstall; node-pre-gyp does not retry that download, and
+# without a toolchain the source-compile fallback cannot run — so one dropped
+# connection failed `target web`, which is exactly how this image broke.
+#
+# Scoping the install to the web package would avoid bcrypt entirely, but the
+# bundle-size gate compares this build's artifact against a full-workspace
+# install, so narrowing it here could move the bundle. Making the fallback work
+# is the change that does not touch what gets built.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends python3 make g++ \
+  && rm -rf /var/lib/apt/lists/*
+
 # Copy the whole monorepo (Vite resolves @tradr/shared from workspace source).
 # .dockerignore keeps the context slim (no node_modules, no .git, no .env).
 COPY . .


### PR DESCRIPTION
The bcrypt failure again, on `main`, after #53 — this time in
`[web builder 5/6] RUN pnpm install --frozen-lockfile`, with `target web`
failing to solve. #53's retry never fired, because it wasn't on this step.

## Why #53 wasn't enough

#53 hardened the `/native` npm install and argued the `pnpm install`
steps were safe because "the npm registry retries internally". That
reasoning was wrong.

bcrypt's prebuilt `.node` is downloaded from a **GitHub release by its
postinstall script** — not fetched from the npm registry — so pnpm's
registry retry never applies. Every install step that resolves bcrypt
runs that postinstall, and **both** images do a full workspace install,
so the web image builds bcrypt too despite the SPA never calling it.

That left three vulnerable steps and hardened one:

| step | image | covered by #53 |
| --- | --- | --- |
| `pnpm install --frozen-lockfile` | api | no |
| `pnpm install --frozen-lockfile` | **web** | no ← failed here |
| `npm install` (`/native`) | api | yes |

## The fix

Retrying each call site is the wrong shape — it has to be repeated
everywhere the dependency graph reaches a native module, and this is the
second time that whack-a-mole has missed. Install the build toolchain
(`python3`, `make`, `g++`) in both builder stages so node-pre-gyp's
source-compile fallback can actually run.

A dropped download then costs build time instead of the build. The
existing `/native` retry stays — it keeps the fast path on the published
binary — but it's no longer the only thing between a network blip and a
red pipeline.

Cost is build time only: both builder stages are discarded, and the
runners copy just `node_modules` / the SPA bundle.

## Verification

Forced the failure mode rather than assuming the fallback works.
`--build-from-source` makes node-pre-gyp **skip the download entirely**,
which is what an unreachable release looks like:

```
RUN npm install bcrypt@5.1.1 --build-from-source
RUN node -e "...hashSync/compareSync round-trip..."
→ compiled-from-source bcrypt round-trip: true
```

Then `docker compose build` for both images: clean.

## Note

Scoping the web install to its own package would avoid bcrypt entirely
and build faster. I didn't, because `Dockerfile.web` states its build
inputs must match the bundle-size gate's, which measures an artifact
produced by a full-workspace install — narrowing it could move the
bundle. Worth considering separately, with the gate in view.
