### PR TITLE
feat(options): anchor the chain on at-the-money, one side at a time

### DIFF
--- a/apps/api/src/features/advisor/advisor.route.ts
+++ b/apps/api/src/features/advisor/advisor.route.ts
@@ -730,12 +730,18 @@ advisorRouter.put('/trade-data-consent', setTradeDataConsentHandler);
  *       false }` so the viewer shows an empty-state CTA to Settings, not an error.
  *
  *       A chain is scoped to ONE expiry. Omit `expiration` to get the nearest tradeable
- *       one. The response is `{ configured: true, expiration, expirations[], chain }`:
- *       `expiration` is the expiry actually returned, `expirations` is every tradeable
- *       expiry (soonest first) for the picker, and `chain` is the compact projection
- *       `{ symbol, expiration?, count, contracts[] }` sorted by strike. Each contract
- *       carries `premium` — the last traded price, or the NBBO midpoint when the
+ *       one. The response is `{ configured: true, expiration, expirations[], underlying?,
+ *       chain }`: `expiration` is the expiry actually returned, `expirations` is every
+ *       tradeable expiry (soonest first) for the picker, and `chain` is the compact
+ *       projection `{ symbol, expiration?, count, contracts[] }` sorted by strike. Each
+ *       contract carries `premium` — the last traded price, or the NBBO midpoint when the
  *       contract has not traded — which is what the calculator uses as an entry price.
+ *
+ *       `underlying` is the last trade on the underlying (`price`, `market_time`,
+ *       `tape_time`), used by the viewer to anchor the ladder on at-the-money. It is
+ *       fetched separately and is OMITTED rather than fatal when that quote fails — the
+ *       chain is the payload; the anchor is not worth failing it for. A `market_time`
+ *       other than `regular` means the price is a pre/post-market print, not a live quote.
  *
  *       Requesting an `expiration` the symbol has no contracts for is 404
  *       SYMBOL_NOT_FOUND with an explicit message. Other upstream failures map to their
@@ -754,7 +760,7 @@ advisorRouter.put('/trade-data-consent', setTradeDataConsentHandler);
  *         schema: { type: string, pattern: '^\d{4}-\d{2}-\d{2}$' }
  *     responses:
  *       200:
- *         description: '{ configured: false } or { configured: true, expiration, expirations, chain }.'
+ *         description: '{ configured: false } or { configured: true, expiration, expirations, underlying?, chain }.'
  *       400: { description: 'Validation error or MARKET_DATA_KEY_INVALID.' }
  *       404: { description: 'SYMBOL_NOT_FOUND — unknown symbol, or no contracts on that expiry.' }
  *       429: { description: 'MARKET_DATA_RATE_LIMITED or PLATFORM_RATE_LIMITED.' }

--- a/apps/api/src/features/advisor/lib/unusual-whales.client.test.ts
+++ b/apps/api/src/features/advisor/lib/unusual-whales.client.test.ts
@@ -53,7 +53,10 @@ describe('createUnusualWhalesClient — request shape & auth', () => {
 
     expect(out).toEqual({ data: { ticker: 'AAPL', price: 1 } });
     const [url, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(url).toBe(`${STUB_BASE}/api/stock/AAPL/info`);
+    // NOT /info: that endpoint returns reference data (beta, issue type, avg
+    // volume) and no price at all, so the quote projection read fields that
+    // were never there. stock-state is the last-trade endpoint.
+    expect(url).toBe(`${STUB_BASE}/api/stock/AAPL/stock-state`);
     expect((init.headers as Record<string, string>).authorization).toBe(
       'Bearer plaintext-secret-key',
     );
@@ -316,7 +319,7 @@ describe('base URL is config-sourced (REQ-6.4 E2E seam)', () => {
     await client.getStockQuote('AAPL');
 
     const [url] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(url).toBe(`${config.UNUSUAL_WHALES_BASE_URL}/api/stock/AAPL/info`);
+    expect(url).toBe(`${config.UNUSUAL_WHALES_BASE_URL}/api/stock/AAPL/stock-state`);
   });
 
   it('envSchema parses an override from env → config (the value the client reads)', () => {
@@ -338,7 +341,7 @@ describe('base URL is config-sourced (REQ-6.4 E2E seam)', () => {
     await client.getStockQuote('AAPL');
 
     const [url] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(url).toBe('http://localhost:9999/api/stock/AAPL/info');
+    expect(url).toBe('http://localhost:9999/api/stock/AAPL/stock-state');
   });
 });
 

--- a/apps/api/src/features/advisor/lib/unusual-whales.client.ts
+++ b/apps/api/src/features/advisor/lib/unusual-whales.client.ts
@@ -142,7 +142,7 @@ export class MarketDataMeter {
 // compact projection; the client only guarantees the envelope is well-formed
 // and non-empty (empty → SYMBOL_NOT_FOUND, REQ-6.5).
 
-const stockInfoSchema = z.object({ data: z.record(z.unknown()) });
+const stockStateSchema = z.object({ data: z.record(z.unknown()) });
 const flowAlertsSchema = z.object({ data: z.array(z.record(z.unknown())) });
 const expiryBreakdownSchema = z.object({ data: z.array(z.record(z.unknown())) });
 const optionContractsSchema = z.object({ data: z.array(z.record(z.unknown())) });
@@ -347,13 +347,20 @@ export function createUnusualWhalesClient(deps: UnusualWhalesClientDeps): Unusua
   }
 
   return {
-    // Pinned: GET /api/stock/{ticker}/info (PublicApi.TickerController.info).
+    // Pinned: GET /api/stock/{ticker}/stock-state.
+    //
+    // NOT `/info`, which this was pointed at and which returns REFERENCE data
+    // only — announce_time, avg30_volume, next_earnings_date, issue_type. It
+    // carries no price, so every field the quote projection reads was absent
+    // and the tool returned an empty object while claiming to be a quote.
+    // `stock-state` is the last-trade endpoint: close/open/high/low/prev_close,
+    // volume, plus `tape_time` and `market_time` for recency.
     getStockQuote(symbol, signal) {
       return request(
         'getStockQuote',
-        `/api/stock/${encodeURIComponent(symbol)}/info`,
+        `/api/stock/${encodeURIComponent(symbol)}/stock-state`,
         {},
-        stockInfoSchema,
+        stockStateSchema,
         (p) => !p.data || Object.keys(p.data as Record<string, unknown>).length === 0,
         signal,
       );

--- a/apps/api/src/features/advisor/options-chain.handler.ts
+++ b/apps/api/src/features/advisor/options-chain.handler.ts
@@ -34,6 +34,7 @@ import {
   fetchChainForExpiry,
   optionsChainInputSchema,
   parseOptionChain,
+  parseStockQuote,
 } from './tools/market-data';
 
 /**
@@ -125,10 +126,28 @@ export async function getOptionsChainHandler(c: Context<AuthEnv>) {
 
   try {
     const resolved = await fetchChainForExpiry(client, symbol, expiration);
+
+    // The underlying's last trade, used to anchor the ladder on at-the-money.
+    // Fetched separately and NON-FATALLY: without it the viewer loses its ATM
+    // marker and opens at the top of the ladder, which is worse but still
+    // usable — failing the whole chain because a quote was unavailable would
+    // trade the primary payload for the garnish.
+    let underlying: Record<string, unknown> | undefined;
+    try {
+      underlying = parseStockQuote(symbol, await client.getStockQuote(symbol));
+    } catch (quoteError) {
+      logger.warn('options-chain underlying quote failed', {
+        userId,
+        symbol,
+        code: quoteError instanceof MarketDataError ? quoteError.code : 'unknown',
+      });
+    }
+
     return c.json({
       configured: true,
       expiration: resolved.expiration,
       expirations: resolved.expirations,
+      ...(underlying ? { underlying } : {}),
       chain: parseOptionChain(symbol, resolved.raw, resolved.expiration, VIEWER_MAX_CONTRACTS),
     });
   } catch (error) {

--- a/apps/api/src/features/advisor/tools/market-data.test.ts
+++ b/apps/api/src/features/advisor/tools/market-data.test.ts
@@ -86,9 +86,24 @@ describe('pre-call input validation (REQ-7.3)', () => {
 });
 
 describe('stock-quote handler', () => {
+  // A real `stock-state` row: decimal STRINGS, last trade in `close`, plus the
+  // session/tape stamps. The previous fixture invented `{ticker, price,
+  // volume}` — a shape the upstream never sent — so the projection agreed with
+  // it while returning an empty object against the live API.
   it('forwards ctx.signal and returns a compact projection (REQ-7.4)', async () => {
     const getStockQuote = vi.fn(async () => ({
-      data: { ticker: 'AAPL', price: 200, volume: 1000, junk_field: 'x'.repeat(5000) },
+      data: {
+        close: '772.5',
+        open: '772.52',
+        high: '773.32',
+        low: '772.11',
+        prev_close: '772.49',
+        volume: 6675723,
+        total_volume: 33075019,
+        market_time: 'postmarket',
+        tape_time: '2026-08-12T22:04:48Z',
+        junk_field: 'x'.repeat(5000),
+      },
     }));
     const ctx = ctxWith(stubUw({ getStockQuote }));
     const result = await stockQuoteTool.handler({ symbol: 'AAPL' }, ctx);
@@ -96,10 +111,34 @@ describe('stock-quote handler', () => {
     expect(getStockQuote).toHaveBeenCalledWith('AAPL', ctx.signal);
     expect(result).toEqual({
       status: 'ok',
-      content: { symbol: 'AAPL', ticker: 'AAPL', price: 200, volume: 1000 },
+      content: {
+        symbol: 'AAPL',
+        price: 772.5,
+        open: 772.52,
+        high: 773.32,
+        low: 772.11,
+        prev_close: 772.49,
+        volume: 6675723,
+        total_volume: 33075019,
+        market_time: 'postmarket',
+        tape_time: '2026-08-12T22:04:48Z',
+      },
     });
     // Wide junk fields are dropped — the persisted result stays compact.
     expect(JSON.stringify(result)).not.toContain('junk_field');
+  });
+
+  // The bug this guards: pointed at /info, every one of these fields was
+  // absent, so the tool answered "here is your quote" with just the symbol.
+  it('returns a price, not a bare symbol', async () => {
+    const getStockQuote = vi.fn(async () => ({ data: { close: '772.5' } }));
+    const result = await stockQuoteTool.handler(
+      { symbol: 'AAPL' },
+      ctxWith(stubUw({ getStockQuote })),
+    );
+    if (result.status === 'ok') {
+      expect((result.content as { price?: number }).price).toBe(772.5);
+    }
   });
 
   it('maps a MarketDataError to its tool_result code + bucket (REQ-7.5)', async () => {

--- a/apps/api/src/features/advisor/tools/market-data.ts
+++ b/apps/api/src/features/advisor/tools/market-data.ts
@@ -81,25 +81,39 @@ function asRows(value: unknown): Record<string, unknown>[] {
   return Array.isArray(value) ? value.map(asRecord) : [];
 }
 
-/** Compact stock-quote projection from `{ data: {...} }`. */
-function parseStockQuote(symbol: string, raw: unknown): Record<string, unknown> {
+/**
+ * Compact stock-quote projection from `stock-state`'s `{ data: {...} }`.
+ *
+ * Field names follow that endpoint, not the old `/info` guess: the last trade
+ * is `close` (surfaced as `price`, which is what the tool's description
+ * promises), and `tape_time` / `market_time` say how fresh it is and which
+ * session it came from — a `close` stamped `postmarket` is not a live quote.
+ * Prices arrive as decimal strings.
+ */
+export function parseStockQuote(symbol: string, raw: unknown): Record<string, unknown> {
   const data = asRecord((raw as { data?: unknown }).data);
-  return {
-    symbol,
-    ...pick(data, [
-      'ticker',
-      'price',
-      'close',
-      'open',
-      'high',
-      'low',
-      'volume',
-      'market_cap',
-      'prev_close',
-      'change',
-      'change_percent',
-    ]),
-  };
+  const out: Record<string, unknown> = { symbol };
+
+  const price = asNumber(data.close);
+  if (price !== undefined) out.price = price;
+
+  for (const [field, key] of [
+    ['open', 'open'],
+    ['high', 'high'],
+    ['low', 'low'],
+    ['prev_close', 'prev_close'],
+    ['volume', 'volume'],
+    ['total_volume', 'total_volume'],
+  ] as const) {
+    const n = asNumber(data[key]);
+    if (n !== undefined) out[field] = n;
+  }
+
+  for (const key of ['market_time', 'tape_time'] as const) {
+    if (typeof data[key] === 'string') out[key] = data[key];
+  }
+
+  return out;
 }
 
 /** Compact options-flow projection from `{ data: [...] }`, capped to `limit`. */

--- a/apps/docs/src/openapi/tradr-api.json
+++ b/apps/docs/src/openapi/tradr-api.json
@@ -1107,7 +1107,7 @@
     },
     "/api/advisor/options-chain": {
       "get": {
-        "description": "Backs the options-tools page chain viewer. Shares the Unusual Whales client and the `market_data_options_chain` tool's parsing (no duplicate fetch logic). When the authenticated user has no Unusual Whales key the response is `{ configured: false }` so the viewer shows an empty-state CTA to Settings, not an error.\nA chain is scoped to ONE expiry. Omit `expiration` to get the nearest tradeable one. The response is `{ configured: true, expiration, expirations[], chain }`: `expiration` is the expiry actually returned, `expirations` is every tradeable expiry (soonest first) for the picker, and `chain` is the compact projection `{ symbol, expiration?, count, contracts[] }` sorted by strike. Each contract carries `premium` — the last traded price, or the NBBO midpoint when the contract has not traded — which is what the calculator uses as an entry price.\nRequesting an `expiration` the symbol has no contracts for is 404 SYMBOL_NOT_FOUND with an explicit message. Other upstream failures map to their reason codes on the matching HTTP status: 400 MARKET_DATA_KEY_INVALID, 429 MARKET_DATA_RATE_LIMITED / PLATFORM_RATE_LIMITED, 503 MARKET_DATA_UNAVAILABLE. The plaintext key is never returned or logged.\n",
+        "description": "Backs the options-tools page chain viewer. Shares the Unusual Whales client and the `market_data_options_chain` tool's parsing (no duplicate fetch logic). When the authenticated user has no Unusual Whales key the response is `{ configured: false }` so the viewer shows an empty-state CTA to Settings, not an error.\nA chain is scoped to ONE expiry. Omit `expiration` to get the nearest tradeable one. The response is `{ configured: true, expiration, expirations[], underlying?, chain }`: `expiration` is the expiry actually returned, `expirations` is every tradeable expiry (soonest first) for the picker, and `chain` is the compact projection `{ symbol, expiration?, count, contracts[] }` sorted by strike. Each contract carries `premium` — the last traded price, or the NBBO midpoint when the contract has not traded — which is what the calculator uses as an entry price.\n`underlying` is the last trade on the underlying (`price`, `market_time`, `tape_time`), used by the viewer to anchor the ladder on at-the-money. It is fetched separately and is OMITTED rather than fatal when that quote fails — the chain is the payload; the anchor is not worth failing it for. A `market_time` other than `regular` means the price is a pre/post-market print, not a live quote.\nRequesting an `expiration` the symbol has no contracts for is 404 SYMBOL_NOT_FOUND with an explicit message. Other upstream failures map to their reason codes on the matching HTTP status: 400 MARKET_DATA_KEY_INVALID, 429 MARKET_DATA_RATE_LIMITED / PLATFORM_RATE_LIMITED, 503 MARKET_DATA_UNAVAILABLE. The plaintext key is never returned or logged.\n",
         "parameters": [
           {
             "in": "query",
@@ -1130,7 +1130,7 @@
         ],
         "responses": {
           "200": {
-            "description": "{ configured: false } or { configured: true, expiration, expirations, chain }."
+            "description": "{ configured: false } or { configured: true, expiration, expirations, underlying?, chain }."
           },
           "400": {
             "description": "Validation error or MARKET_DATA_KEY_INVALID."

--- a/apps/web/src/features/calculator/components/CalculatorForm.tsx
+++ b/apps/web/src/features/calculator/components/CalculatorForm.tsx
@@ -514,7 +514,13 @@ export function CalculatorForm() {
                     Pick a contract to use its premium as the entry price.
                   </DialogDescription>
                 </DialogHeader>
-                <OptionsChainViewer onSelectContract={handleContractSelected} />
+                {/* `direction` opens the chain on the side being shopped —
+                    long buys calls, short buys puts — rather than asking again
+                    for a choice already made above. */}
+                <OptionsChainViewer
+                  onSelectContract={handleContractSelected}
+                  direction={direction}
+                />
               </DialogContent>
             </Dialog>
             {handedOffOcc && (

--- a/apps/web/src/features/options/components/OptionsChainViewer.test.tsx
+++ b/apps/web/src/features/options/components/OptionsChainViewer.test.tsx
@@ -99,7 +99,7 @@ describe('OptionsChainViewer', () => {
     renderWithClient(<OptionsChainViewer />);
     await userEvent.type(screen.getByLabelText('Symbol'), 'AAPL');
     await waitFor(() => {
-      expect(screen.getByText('150')).toBeTruthy();
+      expect(screen.getByText('150.00')).toBeTruthy();
     });
     // The expiry lives in the picker now, not repeated down every row — it is
     // constant for a chain, so a column of it was pure noise.
@@ -107,7 +107,7 @@ describe('OptionsChainViewer', () => {
     expect(within(table).queryByText('2025-06-20')).toBeNull();
     expect((screen.getByLabelText('Expiration') as HTMLSelectElement).value).toBe('2025-06-20');
     // The premium column is what the calculator hand-off uses.
-    expect(within(table).getByText('3.2')).toBeTruthy();
+    expect(within(table).getByText('3.20')).toBeTruthy();
   });
 
   it('offers every expiry in a picker and refetches on change (REQ-12.4)', async () => {
@@ -162,9 +162,9 @@ describe('OptionsChainViewer', () => {
     // 10 strikes either side of ATM, one row per strike — not 302 rows.
     const rows = within(table).getAllByRole('row').slice(1);
     expect(rows).toHaveLength(21);
-    expect(within(table).getByText('772')).toBeTruthy();
+    expect(within(table).getByText('772.00')).toBeTruthy();
     // Far strikes are out of the window entirely.
-    expect(within(table).queryByText('700')).toBeNull();
+    expect(within(table).queryByText('700.00')).toBeNull();
     expect(screen.getByRole('button', { name: /Show more strikes/ })).toBeTruthy();
   });
 
@@ -222,12 +222,12 @@ describe('OptionsChainViewer', () => {
     await userEvent.type(screen.getByLabelText('Symbol'), 'SPY');
 
     const table = await screen.findByRole('table');
-    expect(within(table).getByText('2.5')).toBeTruthy();
-    expect(within(table).queryByText('1.5')).toBeNull();
+    expect(within(table).getByText('2.50')).toBeTruthy();
+    expect(within(table).queryByText('1.50')).toBeNull();
 
     await userEvent.click(screen.getByRole('button', { name: 'Calls' }));
     await waitFor(() => {
-      expect(within(screen.getByRole('table')).getByText('1.5')).toBeTruthy();
+      expect(within(screen.getByRole('table')).getByText('1.50')).toBeTruthy();
     });
   });
 
@@ -291,7 +291,7 @@ describe('OptionsChainViewer', () => {
     renderWithClient(<OptionsChainViewer />);
     await userEvent.type(screen.getByLabelText('Symbol'), 'AAPL');
     await waitFor(() => {
-      expect(screen.getByText('150')).toBeTruthy();
+      expect(screen.getByText('150.00')).toBeTruthy();
     });
     expect(screen.queryByLabelText('Expiration')).toBeNull();
   });
@@ -361,7 +361,7 @@ describe('OptionsChainViewer onSelectContract (REQ-6.5/6.6)', () => {
     renderWithClient(<OptionsChainViewer onSelectContract={onSelectContract} />);
     await userEvent.type(screen.getByLabelText('Symbol'), 'AAPL');
     await waitFor(() => {
-      expect(screen.getByText('150')).toBeTruthy();
+      expect(screen.getByText('150.00')).toBeTruthy();
     });
 
     // Exactly one "Use" button — the row lacking option_symbol renders none.
@@ -379,7 +379,7 @@ describe('OptionsChainViewer onSelectContract (REQ-6.5/6.6)', () => {
     renderWithClient(<OptionsChainViewer />);
     await userEvent.type(screen.getByLabelText('Symbol'), 'AAPL');
     await waitFor(() => {
-      expect(screen.getByText('150')).toBeTruthy();
+      expect(screen.getByText('150.00')).toBeTruthy();
     });
     expect(screen.queryByRole('button', { name: 'Use' })).toBeNull();
   });

--- a/apps/web/src/features/options/components/OptionsChainViewer.test.tsx
+++ b/apps/web/src/features/options/components/OptionsChainViewer.test.tsx
@@ -101,9 +101,11 @@ describe('OptionsChainViewer', () => {
     await waitFor(() => {
       expect(screen.getByText('150')).toBeTruthy();
     });
-    // Scoped to the table: the expiry also appears in the picker above it.
+    // The expiry lives in the picker now, not repeated down every row — it is
+    // constant for a chain, so a column of it was pure noise.
     const table = screen.getByRole('table');
-    expect(within(table).getByText('2025-06-20')).toBeTruthy();
+    expect(within(table).queryByText('2025-06-20')).toBeNull();
+    expect((screen.getByLabelText('Expiration') as HTMLSelectElement).value).toBe('2025-06-20');
     // The premium column is what the calculator hand-off uses.
     expect(within(table).getByText('3.2')).toBeTruthy();
   });
@@ -133,13 +135,157 @@ describe('OptionsChainViewer', () => {
     });
   });
 
+  // The defect this replaced: a flat 400-row list of both sides, ordered from
+  // the lowest strike, so the view opened on deep-ITM calls and worthless puts
+  // and at-the-money was far below the fold.
+  it('opens centred on at-the-money and hides the far strikes', async () => {
+    const contracts = [];
+    for (let strike = 700; strike <= 850; strike += 1) {
+      contracts.push({ option_type: 'call', strike, option_symbol: `SPY${strike}C`, premium: 1 });
+      contracts.push({ option_type: 'put', strike, option_symbol: `SPY${strike}P`, premium: 1 });
+    }
+    useOptionsChainMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        configured: true,
+        expiration: '2030-06-21',
+        expirations: ['2030-06-21'],
+        underlying: { price: 772.5, market_time: 'regular' },
+        chain: { symbol: 'SPY', count: contracts.length, contracts },
+      },
+    });
+    renderWithClient(<OptionsChainViewer />);
+    await userEvent.type(screen.getByLabelText('Symbol'), 'SPY');
+
+    const table = await screen.findByRole('table');
+    // 10 strikes either side of ATM, one row per strike — not 302 rows.
+    const rows = within(table).getAllByRole('row').slice(1);
+    expect(rows).toHaveLength(21);
+    expect(within(table).getByText('772')).toBeTruthy();
+    // Far strikes are out of the window entirely.
+    expect(within(table).queryByText('700')).toBeNull();
+    expect(screen.getByRole('button', { name: /Show more strikes/ })).toBeTruthy();
+  });
+
+  it('marks the at-the-money row and shades in-the-money rows', async () => {
+    useOptionsChainMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        configured: true,
+        expiration: '2030-06-21',
+        expirations: ['2030-06-21'],
+        underlying: { price: 772.5, market_time: 'regular' },
+        chain: {
+          symbol: 'SPY',
+          count: 3,
+          contracts: [
+            { option_type: 'call', strike: 770, option_symbol: 'SPY770C' },
+            { option_type: 'call', strike: 775, option_symbol: 'SPY775C' },
+          ],
+        },
+      },
+    });
+    renderWithClient(<OptionsChainViewer />);
+    await userEvent.type(screen.getByLabelText('Symbol'), 'SPY');
+
+    const table = await screen.findByRole('table');
+    const rows = within(table).getAllByRole('row').slice(1);
+    // 770 is below spot → ITM call, and nearest spot → ATM.
+    expect(rows[0].getAttribute('data-itm')).toBe('true');
+    expect(rows[0].getAttribute('data-atm')).toBe('true');
+    // 775 is above spot → OTM.
+    expect(rows[1].getAttribute('data-itm')).toBeNull();
+  });
+
+  it('opens on puts for a short and lets the toggle switch sides', async () => {
+    useOptionsChainMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        configured: true,
+        expiration: '2030-06-21',
+        expirations: ['2030-06-21'],
+        underlying: { price: 100, market_time: 'regular' },
+        chain: {
+          symbol: 'SPY',
+          count: 2,
+          contracts: [
+            { option_type: 'call', strike: 100, option_symbol: 'C', premium: 1.5 },
+            { option_type: 'put', strike: 100, option_symbol: 'P', premium: 2.5 },
+          ],
+        },
+      },
+    });
+    renderWithClient(<OptionsChainViewer direction="short" />);
+    await userEvent.type(screen.getByLabelText('Symbol'), 'SPY');
+
+    const table = await screen.findByRole('table');
+    expect(within(table).getByText('2.5')).toBeTruthy();
+    expect(within(table).queryByText('1.5')).toBeNull();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Calls' }));
+    await waitFor(() => {
+      expect(within(screen.getByRole('table')).getByText('1.5')).toBeTruthy();
+    });
+  });
+
+  it('surfaces the underlying price and flags a non-regular session', async () => {
+    useOptionsChainMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        configured: true,
+        expiration: '2030-06-21',
+        expirations: ['2030-06-21'],
+        underlying: { price: 772.5, market_time: 'postmarket' },
+        chain: {
+          symbol: 'SPY',
+          count: 1,
+          contracts: [{ option_type: 'call', strike: 770, option_symbol: 'C' }],
+        },
+      },
+    });
+    renderWithClient(<OptionsChainViewer />);
+    await userEvent.type(screen.getByLabelText('Symbol'), 'SPY');
+
+    const banner = await screen.findByText(/772\.5/);
+    expect(banner).toBeTruthy();
+    // A postmarket print is not a live quote — say so rather than imply it is.
+    expect(screen.getByText(/Postmarket/)).toBeTruthy();
+  });
+
+  it('renders the whole side unwindowed when no spot price came back', async () => {
+    const contracts = [];
+    for (let strike = 100; strike <= 140; strike += 1) {
+      contracts.push({ option_type: 'call', strike, option_symbol: `C${strike}` });
+    }
+    useOptionsChainMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        configured: true,
+        expiration: '2030-06-21',
+        expirations: ['2030-06-21'],
+        chain: { symbol: 'SPY', count: contracts.length, contracts },
+      },
+    });
+    renderWithClient(<OptionsChainViewer />);
+    await userEvent.type(screen.getByLabelText('Symbol'), 'SPY');
+
+    const table = await screen.findByRole('table');
+    expect(within(table).getAllByRole('row').slice(1)).toHaveLength(41);
+    expect(screen.queryByRole('button', { name: /Show more strikes/ })).toBeNull();
+  });
+
   it('hides the picker when the API sends no expiry list', async () => {
     useOptionsChainMock.mockReturnValue({
       isLoading: false,
       isError: false,
       data: {
         configured: true,
-        chain: { symbol: 'AAPL', count: 1, contracts: [{ strike: 150 }] },
+        chain: { symbol: 'AAPL', count: 1, contracts: [{ option_type: 'call', strike: 150 }] },
       },
     });
     renderWithClient(<OptionsChainViewer />);

--- a/apps/web/src/features/options/components/OptionsChainViewer.tsx
+++ b/apps/web/src/features/options/components/OptionsChainViewer.tsx
@@ -12,6 +12,7 @@
 import { Link } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 
+import { Numeric } from '@/components/Numeric';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -50,10 +51,6 @@ function errorCodeOf(err: unknown): string | undefined {
     return e.error?.code ?? e.code;
   }
   return undefined;
-}
-
-function num(value: number | undefined): string {
-  return value === undefined || value === null ? '—' : String(value);
 }
 
 interface OptionsChainViewerProps {
@@ -299,7 +296,7 @@ function UnderlyingBanner({
   return (
     <p className="text-sm" data-slot="underlying-spot">
       <span className="font-medium">{symbol}</span>{' '}
-      <span className="tabular-nums">{underlying.price}</span>
+      <Numeric value={underlying.price} direction="none" precision={2} />
       {stale ? (
         <span className="text-muted-foreground">
           {' '}
@@ -398,17 +395,31 @@ function ChainTable({
                 data-atm={atm ? 'true' : undefined}
                 className={itm ? 'bg-muted/50' : undefined}
               >
-                <TableCell className="tabular-nums font-medium">
-                  {num(row.strike)}
+                {/* Every figure goes through `Numeric` — the DOM enforcement
+                    point for financial values. `direction="none"` because a
+                    strike or a premium has no gain/loss sense; the signed,
+                    coloured treatment belongs to P&L, not to a price. */}
+                <TableCell className="font-medium">
+                  <Numeric value={row.strike ?? null} direction="none" precision={2} />
                   {atm ? (
                     <span className="text-muted-foreground ml-2 text-xs font-normal">ATM</span>
                   ) : null}
                 </TableCell>
-                <TableCell className="tabular-nums">{num(row.bid)}</TableCell>
-                <TableCell className="tabular-nums">{num(row.ask)}</TableCell>
-                <TableCell className="tabular-nums">{num(row.premium)}</TableCell>
-                <TableCell className="tabular-nums">{num(row.volume)}</TableCell>
-                <TableCell className="tabular-nums">{num(row.open_interest)}</TableCell>
+                <TableCell>
+                  <Numeric value={row.bid ?? null} direction="none" precision={2} />
+                </TableCell>
+                <TableCell>
+                  <Numeric value={row.ask ?? null} direction="none" precision={2} />
+                </TableCell>
+                <TableCell>
+                  <Numeric value={row.premium ?? null} direction="none" precision={2} />
+                </TableCell>
+                <TableCell>
+                  <Numeric value={row.volume ?? null} kind="integer" direction="none" />
+                </TableCell>
+                <TableCell>
+                  <Numeric value={row.open_interest ?? null} kind="integer" direction="none" />
+                </TableCell>
                 {onSelectContract ? (
                   <TableCell>
                     {row.option_symbol ? (

--- a/apps/web/src/features/options/components/OptionsChainViewer.tsx
+++ b/apps/web/src/features/options/components/OptionsChainViewer.tsx
@@ -26,6 +26,13 @@ import {
 } from '@/components/ui/table';
 
 import { useOptionsChain, type OptionContract } from '../hooks/useOptionsChain';
+import {
+  buildChainWindow,
+  DEFAULT_STRIKE_RADIUS,
+  isInTheMoney,
+  sideForDirection,
+  type ChainSide,
+} from '../lib/chain-view';
 
 function useDebouncedValue<T>(value: T, delayMs: number): T {
   const [debounced, setDebounced] = useState(value);
@@ -56,29 +63,41 @@ interface OptionsChainViewerProps {
    * omitted, the chain renders display-only (unchanged prop-less mount).
    */
   onSelectContract?: (contract: OptionContract) => void;
+  /**
+   * The trade direction already chosen upstream in the sizing widget. It picks
+   * which side of the chain opens — bullish shops calls, bearish shops puts —
+   * so the picker does not ask a question the user has answered.
+   */
+  direction?: string;
 }
 
-export function OptionsChainViewer({ onSelectContract }: OptionsChainViewerProps = {}) {
+export function OptionsChainViewer({ onSelectContract, direction }: OptionsChainViewerProps = {}) {
   const [symbolInput, setSymbolInput] = useState('');
   const [expiry, setExpiry] = useState<string | undefined>(undefined);
+  const [side, setSide] = useState<ChainSide>(() => sideForDirection(direction));
+  const [radius, setRadius] = useState(DEFAULT_STRIKE_RADIUS);
   const debounced = useDebouncedValue(symbolInput.trim().toUpperCase(), 400);
 
   const query = useOptionsChain(debounced, expiry);
 
   // A chain is one expiry's ladder, so a held-over expiry from the previous
   // symbol would ask for a date the new ticker may not list. Clearing on symbol
-  // change falls back to "nearest", which every ticker has.
+  // change falls back to "nearest", which every ticker has. The widened strike
+  // range resets too — it was widened to find something on the OLD ladder.
   const onSymbolChange = (value: string) => {
     setSymbolInput(value);
     setExpiry(undefined);
+    setRadius(DEFAULT_STRIKE_RADIUS);
   };
 
   // Defaulted rather than assumed: during a rolling deploy the web bundle and
   // the API can briefly disagree about the response shape, and a missing list
   // should hide the picker, not blank the whole viewer.
   const data = query.data;
-  const expirations = data?.configured === true ? (data.expirations ?? []) : [];
-  const selectedExpiry = data?.configured === true ? data.expiration : undefined;
+  const configured = data?.configured === true ? data : undefined;
+  const expirations = configured?.expirations ?? [];
+  const selectedExpiry = configured?.expiration;
+  const spot = configured?.underlying?.price;
 
   return (
     <Card data-slot="options-chain-viewer">
@@ -102,36 +121,91 @@ export function OptionsChainViewer({ onSelectContract }: OptionsChainViewerProps
         </div>
 
         {expirations.length > 0 ? (
-          <div className="space-y-2">
-            <Label htmlFor="options-chain-expiry">Expiration</Label>
-            <select
-              id="options-chain-expiry"
-              className="border-input bg-background h-9 w-full rounded-md border px-3 py-1 text-sm cursor-pointer"
-              value={selectedExpiry ?? ''}
-              onChange={(e) => setExpiry(e.target.value)}
-            >
-              {expirations.map((date) => (
-                <option key={date} value={date}>
-                  {date}
-                </option>
-              ))}
-            </select>
+          <div className="flex flex-wrap items-end gap-4">
+            <div className="min-w-40 flex-1 space-y-2">
+              <Label htmlFor="options-chain-expiry">Expiration</Label>
+              <select
+                id="options-chain-expiry"
+                className="border-input bg-background h-9 w-full rounded-md border px-3 py-1 text-sm cursor-pointer"
+                value={selectedExpiry ?? ''}
+                onChange={(e) => {
+                  setExpiry(e.target.value);
+                  setRadius(DEFAULT_STRIKE_RADIUS);
+                }}
+              >
+                {expirations.map((date) => (
+                  <option key={date} value={date}>
+                    {date}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <Label id="options-chain-side-label">Side</Label>
+              <div
+                role="group"
+                aria-labelledby="options-chain-side-label"
+                className="flex h-9 overflow-hidden rounded-md border"
+              >
+                {/* Labels are real text, not a CSS `capitalize` of the value:
+                    the accessible name comes from the DOM, so styling it would
+                    leave screen readers announcing "calls". */}
+                {SIDE_OPTIONS.map(({ value, label }) => (
+                  <button
+                    key={value}
+                    type="button"
+                    aria-pressed={side === value}
+                    onClick={() => setSide(value)}
+                    className={`cursor-pointer px-4 text-sm ${
+                      side === value ? 'bg-primary text-primary-foreground' : 'bg-background'
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </div>
           </div>
         ) : null}
 
-        <ChainBody symbol={debounced} query={query} onSelectContract={onSelectContract} />
+        <ChainBody
+          symbol={debounced}
+          query={query}
+          side={side}
+          spot={spot}
+          radius={radius}
+          onWiden={() => setRadius((r) => r + WIDEN_STEP)}
+          onSelectContract={onSelectContract}
+        />
       </CardContent>
     </Card>
   );
 }
 
+/** How many extra strikes each side "show more" reveals. */
+const WIDEN_STEP = 20;
+
+const SIDE_OPTIONS = [
+  { value: 'call', label: 'Calls' },
+  { value: 'put', label: 'Puts' },
+] as const satisfies readonly { value: ChainSide; label: string }[];
+
 function ChainBody({
   symbol,
   query,
+  side,
+  spot,
+  radius,
+  onWiden,
   onSelectContract,
 }: {
   symbol: string;
   query: ReturnType<typeof useOptionsChain>;
+  side: ChainSide;
+  spot?: number;
+  radius: number;
+  onWiden: () => void;
   onSelectContract?: (contract: OptionContract) => void;
 }) {
   if (symbol === '') {
@@ -167,7 +241,73 @@ function ChainBody({
     );
   }
 
-  return <ChainTable contracts={chain.contracts} onSelectContract={onSelectContract} />;
+  const view = buildChainWindow(chain.contracts, side, spot, radius);
+  if (view.rows.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground" aria-live="polite">
+        No {side}s on this expiration for {chain.symbol}.
+      </p>
+    );
+  }
+
+  const hidden = view.hiddenBelow + view.hiddenAbove;
+
+  return (
+    <div className="space-y-3">
+      <UnderlyingBanner symbol={chain.symbol} underlying={data.underlying} />
+      <ChainTable
+        rows={view.rows}
+        side={side}
+        spot={spot}
+        atmStrike={view.atmStrike}
+        onSelectContract={onSelectContract}
+      />
+      {hidden > 0 ? (
+        <div className="text-center">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="cursor-pointer"
+            onClick={onWiden}
+          >
+            Show more strikes ({hidden} hidden)
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The underlying's last trade. Brokers put spot at the top of the chain because
+ * every strike is read relative to it. `market_time` is surfaced rather than
+ * hidden: a `postmarket` or `premarket` print is a stale reference, and a user
+ * sizing a position off it should know that.
+ */
+function UnderlyingBanner({
+  symbol,
+  underlying,
+}: {
+  symbol: string;
+  underlying?: { price?: number; market_time?: string; tape_time?: string };
+}) {
+  if (underlying?.price === undefined) return null;
+  const session = underlying.market_time;
+  const stale = session !== undefined && session !== 'regular';
+
+  return (
+    <p className="text-sm" data-slot="underlying-spot">
+      <span className="font-medium">{symbol}</span>{' '}
+      <span className="tabular-nums">{underlying.price}</span>
+      {stale ? (
+        <span className="text-muted-foreground">
+          {' '}
+          · {session.replace(/^\w/, (c) => c.toUpperCase())}
+        </span>
+      ) : null}
+    </p>
+  );
 }
 
 function NoKeyState() {
@@ -205,11 +345,26 @@ function ChainError({ code }: { code?: string }) {
   );
 }
 
+/**
+ * One side of the ladder, ascending by strike.
+ *
+ * Type and Expiry columns are gone: the side is chosen by the toggle and the
+ * expiry by the picker, so both were constant down every row — pure noise in a
+ * table that has to stay narrow enough to scan. In-the-money rows are shaded
+ * and the at-the-money row is marked, which is how a broker chain tells you
+ * where you are without reading a single number.
+ */
 function ChainTable({
-  contracts,
+  rows,
+  side,
+  spot,
+  atmStrike,
   onSelectContract,
 }: {
-  contracts: OptionContract[];
+  rows: OptionContract[];
+  side: ChainSide;
+  spot?: number;
+  atmStrike?: number;
   onSelectContract?: (contract: OptionContract) => void;
 }) {
   return (
@@ -217,9 +372,7 @@ function ChainTable({
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead>Type</TableHead>
             <TableHead>Strike</TableHead>
-            <TableHead>Expiry</TableHead>
             <TableHead>Bid</TableHead>
             <TableHead>Ask</TableHead>
             {/* The premium the "Use" button hands to the calculator: the last
@@ -235,33 +388,45 @@ function ChainTable({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {contracts.map((row, i) => (
-            <TableRow key={row.option_symbol ?? i}>
-              <TableCell>{row.option_type ?? '—'}</TableCell>
-              <TableCell>{num(row.strike)}</TableCell>
-              <TableCell>{row.expiry ?? '—'}</TableCell>
-              <TableCell>{num(row.bid)}</TableCell>
-              <TableCell>{num(row.ask)}</TableCell>
-              <TableCell>{num(row.premium)}</TableCell>
-              <TableCell>{num(row.volume)}</TableCell>
-              <TableCell>{num(row.open_interest)}</TableCell>
-              {onSelectContract ? (
-                <TableCell>
-                  {row.option_symbol ? (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="cursor-pointer"
-                      onClick={() => onSelectContract(row)}
-                    >
-                      Use
-                    </Button>
+          {rows.map((row, i) => {
+            const itm = isInTheMoney(row, side, spot);
+            const atm = atmStrike !== undefined && row.strike === atmStrike;
+            return (
+              <TableRow
+                key={row.option_symbol ?? i}
+                data-itm={itm ? 'true' : undefined}
+                data-atm={atm ? 'true' : undefined}
+                className={itm ? 'bg-muted/50' : undefined}
+              >
+                <TableCell className="tabular-nums font-medium">
+                  {num(row.strike)}
+                  {atm ? (
+                    <span className="text-muted-foreground ml-2 text-xs font-normal">ATM</span>
                   ) : null}
                 </TableCell>
-              ) : null}
-            </TableRow>
-          ))}
+                <TableCell className="tabular-nums">{num(row.bid)}</TableCell>
+                <TableCell className="tabular-nums">{num(row.ask)}</TableCell>
+                <TableCell className="tabular-nums">{num(row.premium)}</TableCell>
+                <TableCell className="tabular-nums">{num(row.volume)}</TableCell>
+                <TableCell className="tabular-nums">{num(row.open_interest)}</TableCell>
+                {onSelectContract ? (
+                  <TableCell>
+                    {row.option_symbol ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="cursor-pointer"
+                        onClick={() => onSelectContract(row)}
+                      >
+                        Use
+                      </Button>
+                    ) : null}
+                  </TableCell>
+                ) : null}
+              </TableRow>
+            );
+          })}
         </TableBody>
       </Table>
     </div>

--- a/apps/web/src/features/options/hooks/useOptionsChain.ts
+++ b/apps/web/src/features/options/hooks/useOptionsChain.ts
@@ -43,6 +43,17 @@ export interface OptionChain {
   contracts: OptionContract[];
 }
 
+/**
+ * The underlying's last trade, used to anchor the ladder on at-the-money.
+ * Absent when the quote could not be fetched — the chain still renders.
+ */
+export interface Underlying {
+  price?: number;
+  /** Session the trade came from; anything but `regular` is not a live quote. */
+  market_time?: string;
+  tape_time?: string;
+}
+
 /** GET response — empty state (no key) or the parsed chain. */
 export type OptionsChainResponse =
   | { configured: false }
@@ -52,6 +63,7 @@ export type OptionsChainResponse =
       expiration: string;
       /** Every tradeable expiry, soonest first, for the picker. */
       expirations: string[];
+      underlying?: Underlying;
       chain: OptionChain;
     };
 

--- a/apps/web/src/features/options/lib/chain-view.test.ts
+++ b/apps/web/src/features/options/lib/chain-view.test.ts
@@ -1,0 +1,112 @@
+// Unit tests for the chain ladder view-model. Pure — no rendering.
+//
+// The behaviour under test is what the previous flat list got wrong: it showed
+// both sides interleaved, ordered from the lowest strike, capped at an
+// arbitrary 400 rows, with no notion of where spot was. Every case below pins
+// one half of that fix.
+
+import { describe, expect, it } from 'vitest';
+
+import type { OptionContract } from '../hooks/useOptionsChain';
+
+import {
+  buildChainWindow,
+  DEFAULT_STRIKE_RADIUS,
+  isInTheMoney,
+  sideForDirection,
+} from './chain-view';
+
+/** A ladder of calls and puts at every strike, deliberately unordered. */
+function ladder(from: number, to: number, step = 1): OptionContract[] {
+  const rows: OptionContract[] = [];
+  for (let strike = to; strike >= from; strike -= step) {
+    rows.push({ option_type: 'put', strike, option_symbol: `X${strike}P` });
+    rows.push({ option_type: 'call', strike, option_symbol: `X${strike}C` });
+  }
+  return rows;
+}
+
+describe('sideForDirection', () => {
+  it('opens calls for a long and puts for a short', () => {
+    expect(sideForDirection('long')).toBe('call');
+    expect(sideForDirection('short')).toBe('put');
+  });
+
+  it('falls back to calls when the direction is unknown', () => {
+    expect(sideForDirection(undefined)).toBe('call');
+  });
+});
+
+describe('buildChainWindow', () => {
+  it('keeps only the requested side, so a strike appears once', () => {
+    const view = buildChainWindow(ladder(100, 110), 'call', 105, 50);
+    expect(view.rows.every((r) => r.option_type === 'call')).toBe(true);
+    expect(new Set(view.rows.map((r) => r.strike)).size).toBe(view.rows.length);
+  });
+
+  it('sorts ascending by strike regardless of upstream order', () => {
+    const view = buildChainWindow(ladder(100, 105), 'call', 102, 50);
+    const strikes = view.rows.map((r) => r.strike);
+    expect(strikes).toEqual([...strikes].slice().sort((a, b) => (a ?? 0) - (b ?? 0)));
+  });
+
+  // The core fix: open where the money is, not at the bottom of the ladder.
+  it('centres the window on the strike nearest spot', () => {
+    const view = buildChainWindow(ladder(700, 800), 'call', 772, 2);
+    expect(view.atmStrike).toBe(772);
+    expect(view.rows.map((r) => r.strike)).toEqual([770, 771, 772, 773, 774]);
+  });
+
+  it('reports how many strikes it hid on each side', () => {
+    const view = buildChainWindow(ladder(700, 800), 'call', 772, 2);
+    // 101 strikes total; 5 shown, 70 below the window and 26 above.
+    expect(view.hiddenBelow).toBe(70);
+    expect(view.hiddenAbove).toBe(26);
+    expect(view.hiddenBelow + view.rows.length + view.hiddenAbove).toBe(101);
+  });
+
+  it('widens symmetrically as the radius grows', () => {
+    const narrow = buildChainWindow(ladder(700, 800), 'call', 772, 2);
+    const wide = buildChainWindow(ladder(700, 800), 'call', 772, 10);
+    expect(wide.rows.length).toBeGreaterThan(narrow.rows.length);
+    expect(wide.atmStrike).toBe(narrow.atmStrike);
+  });
+
+  it('clamps the window at the ends of the ladder', () => {
+    const view = buildChainWindow(ladder(100, 105), 'call', 100, 10);
+    expect(view.hiddenBelow).toBe(0);
+    expect(view.rows[0].strike).toBe(100);
+  });
+
+  // Guessing a midpoint would silently hide the strikes the user came for.
+  it('returns the whole side unwindowed when spot is unknown', () => {
+    const view = buildChainWindow(ladder(700, 800), 'call', undefined, 2);
+    expect(view.rows).toHaveLength(101);
+    expect(view.atmStrike).toBeUndefined();
+    expect(view.hiddenBelow + view.hiddenAbove).toBe(0);
+  });
+
+  it('handles a side with no contracts', () => {
+    const callsOnly = [{ option_type: 'call', strike: 100 }];
+    const view = buildChainWindow(callsOnly, 'put', 100);
+    expect(view.rows).toEqual([]);
+  });
+
+  it('defaults to a bounded radius rather than the whole ladder', () => {
+    const view = buildChainWindow(ladder(600, 900), 'call', 772);
+    expect(view.rows.length).toBe(DEFAULT_STRIKE_RADIUS * 2 + 1);
+  });
+});
+
+describe('isInTheMoney', () => {
+  it('is strike-below-spot for calls and strike-above-spot for puts', () => {
+    expect(isInTheMoney({ strike: 770 }, 'call', 772)).toBe(true);
+    expect(isInTheMoney({ strike: 775 }, 'call', 772)).toBe(false);
+    expect(isInTheMoney({ strike: 775 }, 'put', 772)).toBe(true);
+    expect(isInTheMoney({ strike: 770 }, 'put', 772)).toBe(false);
+  });
+
+  it('shades nothing when spot is unknown', () => {
+    expect(isInTheMoney({ strike: 770 }, 'call', undefined)).toBe(false);
+  });
+});

--- a/apps/web/src/features/options/lib/chain-view.ts
+++ b/apps/web/src/features/options/lib/chain-view.ts
@@ -1,0 +1,103 @@
+// Pure view-model for the options chain ladder.
+//
+// Brokers converge on the same two rules for presenting a chain, and the flat
+// list this replaces broke both: one row per STRIKE (not per contract), and the
+// view anchored on at-the-money rather than starting at the lowest strike. A
+// liquid ticker has hundreds of strikes per expiry, and the interesting ones
+// are the handful either side of spot; opening on deep-ITM calls and worthless
+// puts means scrolling past everything that matters.
+//
+// Kept pure and separate from the component so the windowing is unit-testable
+// without rendering.
+
+import type { OptionContract } from '../hooks/useOptionsChain';
+
+/** Which side of the chain is shown. The picker shows one side at a time. */
+export type ChainSide = 'call' | 'put';
+
+/** Strikes shown either side of at-the-money before "show more". */
+export const DEFAULT_STRIKE_RADIUS = 10;
+
+export interface ChainWindow {
+  /** Contracts to render, ascending by strike. */
+  rows: OptionContract[];
+  /** The strike nearest spot, or undefined when spot is unknown. */
+  atmStrike?: number;
+  /** How many rows the window hides below / above, for the "show more" copy. */
+  hiddenBelow: number;
+  hiddenAbove: number;
+}
+
+/**
+ * A trade direction maps to the side of the chain a user is shopping: a bullish
+ * trade buys calls, a bearish one buys puts. The picker opens on that side
+ * because the direction is already chosen upstream in the sizing widget — the
+ * broker-standard both-sides layout answers a question this surface has already
+ * asked. The toggle still allows the other side.
+ */
+export function sideForDirection(direction: string | undefined): ChainSide {
+  return direction === 'short' ? 'put' : 'call';
+}
+
+/** Index of the strike closest to `spot`; ties resolve to the lower strike. */
+function nearestIndex(rows: OptionContract[], spot: number): number {
+  let best = 0;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  rows.forEach((row, i) => {
+    const strike = row.strike;
+    if (strike === undefined) return;
+    const distance = Math.abs(strike - spot);
+    if (distance < bestDistance) {
+      best = i;
+      bestDistance = distance;
+    }
+  });
+  return best;
+}
+
+/**
+ * Take one side of the chain and return the rows to render around at-the-money.
+ *
+ * With no spot price the ladder cannot be anchored, so the whole side is
+ * returned rather than an arbitrary slice — a wrong guess at "the middle" would
+ * silently hide the strikes the user came for.
+ */
+export function buildChainWindow(
+  contracts: OptionContract[],
+  side: ChainSide,
+  spot: number | undefined,
+  radius: number = DEFAULT_STRIKE_RADIUS,
+): ChainWindow {
+  const rows = contracts
+    .filter((c) => c.option_type === side)
+    .slice()
+    .sort((a, b) => (a.strike ?? 0) - (b.strike ?? 0));
+
+  if (spot === undefined || rows.length === 0) {
+    return { rows, hiddenBelow: 0, hiddenAbove: 0 };
+  }
+
+  const atm = nearestIndex(rows, spot);
+  const start = Math.max(0, atm - radius);
+  const end = Math.min(rows.length, atm + radius + 1);
+
+  return {
+    rows: rows.slice(start, end),
+    atmStrike: rows[atm]?.strike,
+    hiddenBelow: start,
+    hiddenAbove: rows.length - end,
+  };
+}
+
+/**
+ * Is this contract in the money? Drives the row shading brokers use to make
+ * the ITM/OTM boundary visible at a glance.
+ */
+export function isInTheMoney(
+  contract: OptionContract,
+  side: ChainSide,
+  spot: number | undefined,
+): boolean {
+  if (spot === undefined || contract.strike === undefined) return false;
+  return side === 'call' ? contract.strike < spot : contract.strike > spot;
+}

--- a/e2e/support/uw-stub-server.ts
+++ b/e2e/support/uw-stub-server.ts
@@ -33,7 +33,9 @@ const DEFAULT_PORT = 4599;
 function deterministicResponse(pathname: string): { status: number; body: unknown } | null {
   // /api/stock/{ticker}/{resource}
   const match =
-    /^\/api\/stock\/([^/]+)\/(info|flow-alerts|expiry-breakdown|option-contracts)$/.exec(pathname);
+    /^\/api\/stock\/([^/]+)\/(info|stock-state|flow-alerts|expiry-breakdown|option-contracts)$/.exec(
+      pathname,
+    );
   if (!match) return null;
 
   const ticker = decodeURIComponent(match[1]).toUpperCase();
@@ -54,6 +56,33 @@ function deterministicResponse(pathname: string): { status: number; body: unknow
               last: '187.32',
               market_cap: '2950000000000',
               sector: 'Technology',
+            },
+          },
+    };
+  }
+
+  // stock-state — the last-trade endpoint the quote tool and the chain's ATM
+  // anchor both read.
+  //
+  // Spot is deliberately 192.50, between this stub's 190 and 200 strikes: 175
+  // and 190 are then ITM calls, 200 is OTM, and 190 is unambiguously the ATM
+  // row. A spot unrelated to the strikes would still render, but would anchor
+  // the ladder somewhere meaningless and make the ITM shading untestable.
+  if (resource === 'stock-state') {
+    return {
+      status: 200,
+      body: empty
+        ? { data: {} }
+        : {
+            data: {
+              close: '192.50',
+              open: '191.80',
+              high: '193.10',
+              low: '191.42',
+              prev_close: '191.95',
+              volume: 6675723,
+              market_time: 'regular',
+              tape_time: '2030-06-20T18:00:00Z',
             },
           },
     };

--- a/e2e/tests/advisor-tools.spec.ts
+++ b/e2e/tests/advisor-tools.spec.ts
@@ -315,14 +315,22 @@ test.describe('advisor-tools', () => {
     await saveMarketDataKey(page, 'uw-e2e-test-key');
 
     // Back on the options page, the same symbol now renders the stubbed chain
-    // for the NEAREST expiry (2030-06-21), with both stub contracts. Strike and
-    // expiry are decoded from the OCC symbol — the upstream sends neither.
+    // for the NEAREST expiry (2030-06-21). Strike and expiry are decoded from
+    // the OCC symbol — the upstream sends neither.
     await page.goto('/options');
     await page.locator('#options-chain-symbol').fill('AAPL');
     await expect(page.getByText('190')).toBeVisible();
     await expect(page.locator('#options-chain-expiry')).toHaveValue('2030-06-21');
     // Row B never traded, so its premium is the NBBO mid: (4.10 + 4.30) / 2.
     await expect(page.getByRole('cell', { name: '4.2', exact: true })).toBeVisible();
+    // The ladder is anchored on the underlying's last trade (stub: 192.50), so
+    // strike 190 is the ATM row and is in the money for a call.
+    await expect(page.locator('[data-slot="underlying-spot"]')).toContainText('192.5');
+    await expect(page.locator('tr[data-atm="true"]')).toContainText('190');
+    await expect(page.locator('tr[data-itm="true"]').first()).toBeVisible();
+    // Side and expiry live in controls, not as a column repeated down every row.
+    await expect(page.getByRole('button', { name: 'Calls' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Expiry' })).toHaveCount(0);
     // The no-key CTA is gone now that a key is configured.
     await expect(
       page.getByText('Connect an Unusual Whales key to view live options chains.'),

--- a/e2e/tests/advisor-tools.spec.ts
+++ b/e2e/tests/advisor-tools.spec.ts
@@ -319,10 +319,11 @@ test.describe('advisor-tools', () => {
     // the OCC symbol — the upstream sends neither.
     await page.goto('/options');
     await page.locator('#options-chain-symbol').fill('AAPL');
-    await expect(page.getByText('190')).toBeVisible();
+    // Figures render through the `Numeric` primitive, so a strike is "190.00".
+    await expect(page.getByText('190.00')).toBeVisible();
     await expect(page.locator('#options-chain-expiry')).toHaveValue('2030-06-21');
     // Row B never traded, so its premium is the NBBO mid: (4.10 + 4.30) / 2.
-    await expect(page.getByRole('cell', { name: '4.2', exact: true })).toBeVisible();
+    await expect(page.getByRole('cell', { name: '4.20', exact: true })).toBeVisible();
     // The ladder is anchored on the underlying's last trade (stub: 192.50), so
     // strike 190 is the ATM row and is in the money for a call.
     await expect(page.locator('[data-slot="underlying-spot"]')).toContainText('192.5');


### PR DESCRIPTION
The chain rendered every contract for the expiry as a flat list — both
sides interleaved, ascending from the lowest strike, capped at 400 rows.
For SPY that opens on deep-ITM calls and worthless puts, with the strikes
anyone would actually trade far below the fold, and an Expiry column
repeating the same date down every row.

## What brokers do

Two rules are near-universal ([Trading Technologies](https://library.tradingtechnologies.com/trade/opc-overview.html),
[IBKR](https://www.interactivebrokers.com/campus/trading-lessons/ibkr-desktop-using-option-chains/),
[thinkorswim](https://toslc.thinkorswim.com/center/howToTos/thinkManual/Trade/All-Products)):
**one row per strike**, and the view **anchored on at-the-money**, with
only a handful of strikes shown by default.

This follows both, with one deliberate departure. The broker-standard
calls-left/puts-right straddle exists so a trader can compare the two
sides at a strike — a choice this surface has already made, because the
sizing widget picks Long or Short *before* the picker opens. So the side
is defaulted from `direction` (long → calls, short → puts) with a toggle,
rather than spending half the width on a ruled-out side.

- ~±10 strikes around ATM, with **show more strikes (N hidden)**
- ITM rows shaded, the ATM row marked (`data-itm` / `data-atm`)
- **Type and Expiry columns dropped** — both constant once the side and
  expiry are chosen above the table
- Underlying's last trade shown above the ladder

## The second bug this surfaced

Anchoring needs spot, and `getStockQuote` was pinned to `/info` — which
returns reference data only:

```
announce_time = None   avg30_volume = '48653042...'   next_earnings_date = None
```

No price. Every field the quote projection read (`price`, `close`,
`open`, `high`, `low`, `volume`, `prev_close`, `change`) was absent, so
`market_data_stock_quote` has been answering "here is your quote" with a
bare symbol. Repointed at `stock-state`:

```
close = '772.5'   open = '772.52'   high = '773.32'   low = '772.11'
prev_close = '772.49'   volume = 6675723
market_time = 'postmarket'   tape_time = '2026-08-12T22:04:48Z'
```

`market_time` is surfaced next to the price rather than hidden — a
postmarket print is not a live quote, and it's the reference a user is
about to size a position against.

## Degradation

The underlying fetch is **non-fatal**. When it fails the whole side
renders unwindowed with no ATM marker. Guessing a midpoint would silently
hide the strikes the user came for, and failing the chain because a quote
was unavailable would trade the payload for the garnish.

## Testing

Windowing, ITM classification and the side default live in a pure
`lib/chain-view.ts`, unit-tested without rendering (13 cases).

The quote fixture invented `{ticker, price, volume}` — a shape `/info`
never returned — which is precisely why a tool that returns nothing has
been green all along. It now carries a real `stock-state` row. The e2e
stub serves that endpoint with a spot (192.50) coherent with its strikes
(175 / 190 / 200), so the ATM anchor and ITM shading are actually
exercised rather than rendered against an unrelated price.

Local: 429 API tests, 113 web tests, typecheck and lint clean. The one
API failure is the pre-existing `startup.test.ts` timeout, confirmed on a
clean checkout earlier today.

## Design notes

The internal design docs that pinned the old endpoints and the
`last_price` hand-off have been corrected alongside this change, so they
record the verified endpoints and why the original choices were wrong.
Those live outside this repo.
