### PR TITLE
chore(release): hand-written release notes + changelog preview

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,5 +265,6 @@ jobs:
       - name: Create GitHub Release (notes + SPA asset)
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
+          body_path: docs/release-notes/${{ github.ref_name }}.md
           generate_release_notes: true
           files: tradr-web-dist-${{ github.ref_name }}.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,18 @@ release:
 	git tag v$(VERSION)
 	@echo "Tagged v$(VERSION). Publish with: git push origin HEAD v$(VERSION)"
 
+# Preview the auto-generated changelog for a version that hasn't been tagged
+# yet — calls the same GitHub API endpoint release.yml's generate_release_notes
+# uses, without creating a release. Notes are computed since the latest
+# published release, up to `main`.
+.PHONY: generate-changelog
+generate-changelog:
+	@test -n "$(VERSION)" || { echo "usage: make generate-changelog VERSION=1.2.3"; exit 1; }
+	@gh api repos/{owner}/{repo}/releases/generate-notes \
+	  -f tag_name=v$(VERSION) \
+	  -f target_commitish=main \
+	  | jq -r .body
+
 # Refresh the local graphify knowledge graph against current main. Optional and
 # local-only — graphify-out/ is git-ignored and nothing in the build depends on
 # it. AST-only, so no API cost. See CLAUDE.md for what the graph is used for.

--- a/docs/release-notes/EXAMPLE.md
+++ b/docs/release-notes/EXAMPLE.md
@@ -1,0 +1,27 @@
+<!--
+Worked example of TEMPLATE.md, fully filled in. Content is fabricated for
+illustration — v0.9.0 does not exist. This file is not picked up by the
+release workflow (it doesn't match a tag name); it exists purely as a
+reference for what a completed docs/release-notes/vX.Y.Z.md should look like.
+-->
+
+Defensible cost basis, and a CSV importer for the brokers that don't have an API.
+
+Tradr v0.9.0 focuses on getting historical trades into the ledger accurately, however they were made. It adds configurable cost-basis accounting, a CSV importer for brokerages without a direct API integration, and a new dashboard widget for reviewing realized P&L by strategy. This release also closes two edges of the ledger reconciliation logic reported since v0.8.0's onboarding and options work landed, both involving same-day round trips being counted twice under certain fee-timing conditions.
+
+## Highlights
+
+- Cost-basis method (FIFO, LIFO, or specific-lot) is now configurable per account in Settings → Accounts, and is applied retroactively to realized P&L on every account, not just new fills.
+- CSV import is available for brokerages without an API integration. Map your export's columns once and Tradr will de-duplicate against any fills already synced through a connected broker, so linking a CSV import to an existing API-synced account is safe.
+- A new "Realized P&L by Strategy" dashboard widget groups closed trades by the tag assigned at entry, so a swing-trading and a scalping book kept in the same account can be evaluated separately.
+- Same-day round trips (a contract bought and sold within the same session) no longer double-count in the realized P&L ledger — the underlying issue was a fee applied before the closing fill was fully reconciled.
+- Options expiry dates are now resolved in the contract's listed timezone rather than the server's, which had been shifting some Friday expiries to Thursday for accounts running outside US market hours.
+
+## Breaking changes
+
+- **Default cost-basis method changed from FIFO to average-cost** for every account created before this release, to match what most retail brokerages report by default on a 1099. Realized P&L figures will change once the API recomputes them on first boot after upgrading — this is expected, and reflects the same number your broker would show under average-cost. If you rely on FIFO or LIFO for tax purposes, set the method explicitly under Settings → Accounts before your next filing.
+- **`GET /api/positions/:id/fills` now returns each fee as an object (`{ amount, currency }`) instead of a bare number**, to support the CSV importer's multi-currency fills. Any external tooling or scripts reading that endpoint directly will need a matching update. The HTTP API is not yet stable pre-1.0 (see the API stability note in the project's contributor docs), so this ships without a compatibility shim.
+
+## Upgrade notes
+
+On first boot after upgrading, the API recomputes realized P&L for every account under the new default cost-basis method described above. Expect a one-time startup delay proportional to how many closed positions you have — a few seconds for most self-hosted instances, longer for accounts with several thousand fills. No new required environment variables are introduced; a standard `docker compose pull && docker compose up -d` is sufficient for a Compose deployment.

--- a/docs/release-notes/TEMPLATE.md
+++ b/docs/release-notes/TEMPLATE.md
@@ -1,0 +1,40 @@
+<!--
+Release notes for vX.Y.Z.
+
+This is the human-written prose that release.yml prepends above the
+auto-generated "## What's Changed" PR list (body_path + generate_release_notes
+on the softprops/action-gh-release step). It is framing, not a duplicate of
+that list — keep it short, and skip anything the list already says perfectly
+well on its own.
+
+To use: copy this file to docs/release-notes/vX.Y.Z.md, fill it in, delete
+this comment block and any section you don't need, then `make release`.
+This file itself is never picked up by the workflow (it doesn't match a tag).
+-->
+
+<one-sentence tagline for the release>
+
+<2-4 sentence overview. Written for someone who hasn't read the commits —
+explain why this release happened and what it's for, not what changed line by
+line. If there's nothing worth saying beyond the PR list, skip this file
+entirely for the release; generate_release_notes alone is a fine release.>
+
+## Highlights
+
+- <the 1-3 things a user would actually notice, described as an outcome
+  ("options chain now anchors on ATM"), not a commit message>
+
+## Breaking changes
+
+<!-- Omit this section if there are none. Tradr is pre-1.0 — breaking
+API/schema changes are expected and don't need shims (see CLAUDE.md) — so
+just be plain about what changed and what a self-hoster needs to do, if
+anything. -->
+
+- **<what changed>** — <what to do about it, or "no action needed">
+
+## Upgrade notes
+
+<!-- Only if upgrading takes more than `docker compose pull && up -d` — a new
+required env var, a migration that can't run online, a config rename, etc.
+Omit if there's nothing beyond the normal pull-and-restart. -->

--- a/docs/release-notes/v0.8.0.md
+++ b/docs/release-notes/v0.8.0.md
@@ -1,0 +1,18 @@
+Onboarding walkthrough for new users, options contract lookups that work, and an opt-in /metrics endpoint.
+
+Tradr v0.8.0 adds a guided tour that orients a new user to the platform's features and functions. It also offers demo data that lets the user explore a fully populated Tradr. Options contract lookups now actually fetch data if you have an Unusual Whales API key configured in your in-app user settings, and the options contract browser UI component works nicely too. Finally, for self-hosters who want it, a /metrics endpoint is now instrumented with various Prometheus-type metrics. Set the envvar METRICS_ENABLED=true to turn it on (it runs on port 9464 by default, overrideable via METRICS_PORT).
+
+## Highlights
+
+- Feature: Guided walkthrough (with checklist) and optional demo data to test-drive a populated Tradr experience.
+- Feature: Metrics a la Prometheus have been added. Tradr will expose a metrics endpoint at /metrics on METRICS_PORT (default 9464) if METRICS_ENABLED=true. Scrape with Prometheus.
+- Feature: Options contract lookup is now available if you have an Unusual Whales API key enabled in your user settings in-app.
+- Fixes: Multiple fixes in the application and build chain.
+
+## Breaking changes
+
+No breaking changes.
+
+## Upgrade notes
+
+No explicit upgrade required. Any database schema migrations occur during API boot.


### PR DESCRIPTION
## Summary
- Add `make generate-changelog VERSION=x.y.z` to preview GitHub's auto-generated release notes for an unreleased version (via `gh api .../releases/generate-notes`, no release created).
- Wire `body_path` into the release workflow's GitHub Release step so a per-version `docs/release-notes/vX.Y.Z.md`, when present, is prepended above the auto-generated "What's Changed" list.
- Add `docs/release-notes/TEMPLATE.md` (reusable boilerplate) and `EXAMPLE.md` (fabricated, fully filled-in reference) — neither is picked up by the workflow since neither matches a tag name.
- Add `docs/release-notes/v0.8.0.md` with the actual notes for the next release.

## Test plan
- [x] `make generate-changelog VERSION=0.8.0` produces the expected auto-generated changelog against the current `main`
- [x] `.github/workflows/release.yml` diff reviewed — `body_path` sits correctly under the release step's `with:` block alongside the existing `generate_release_notes: true`
- [ ] First real release with a populated `vX.Y.Z.md` confirms GitHub prepends it correctly above the auto-generated list