### PR TITLE
fix(web): route the bare origin instead of 404ing on it

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as RegisterRouteImport } from './routes/register'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
 import { Route as AuthRouteImport } from './routes/_auth'
+import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthSettingsRouteImport } from './routes/_auth.settings'
 import { Route as AuthPerformanceRouteImport } from './routes/_auth.performance'
 import { Route as AuthOptionsRouteImport } from './routes/_auth.options'
@@ -68,6 +69,11 @@ const ForgotPasswordRoute = ForgotPasswordRouteImport.update({
 } as any)
 const AuthRoute = AuthRouteImport.update({
   id: '/_auth',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthSettingsRoute = AuthSettingsRouteImport.update({
@@ -198,7 +204,7 @@ const AuthAccountingExpensesRoute = AuthAccountingExpensesRouteImport.update({
 } as any)
 
 export interface FileRoutesByFullPath {
-  '/': typeof AuthRouteWithChildren
+  '/': typeof IndexRoute
   '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
   '/register': typeof RegisterRoute
@@ -231,7 +237,7 @@ export interface FileRoutesByFullPath {
   '/positions/': typeof AuthPositionsIndexRoute
 }
 export interface FileRoutesByTo {
-  '/': typeof AuthRouteWithChildren
+  '/': typeof IndexRoute
   '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
   '/register': typeof RegisterRoute
@@ -265,6 +271,7 @@ export interface FileRoutesByTo {
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
   '/_auth': typeof AuthRouteWithChildren
   '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
@@ -366,6 +373,7 @@ export interface FileRouteTypes {
     | '/positions'
   id:
     | '__root__'
+    | '/'
     | '/_auth'
     | '/forgot-password'
     | '/login'
@@ -400,6 +408,7 @@ export interface FileRouteTypes {
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
+  IndexRoute: typeof IndexRoute
   AuthRoute: typeof AuthRouteWithChildren
   ForgotPasswordRoute: typeof ForgotPasswordRoute
   LoginRoute: typeof LoginRoute
@@ -450,6 +459,13 @@ declare module '@tanstack/react-router' {
       path: ''
       fullPath: '/'
       preLoaderRoute: typeof AuthRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_auth/settings': {
@@ -709,6 +725,7 @@ const AuthRouteChildren: AuthRouteChildren = {
 const AuthRouteWithChildren = AuthRoute._addFileChildren(AuthRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
+  IndexRoute: IndexRoute,
   AuthRoute: AuthRouteWithChildren,
   ForgotPasswordRoute: ForgotPasswordRoute,
   LoginRoute: LoginRoute,

--- a/apps/web/src/routes/__tests__/root-index-route.test.tsx
+++ b/apps/web/src/routes/__tests__/root-index-route.test.tsx
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from '@tanstack/react-router';
+import { render, screen, cleanup, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+
+import {
+  api,
+  markSessionConfirmed,
+  markSessionEnded,
+  markSessionStarted,
+  setRouter,
+} from '@/lib/api';
+
+import { Route as RootRoute } from '../__root';
+import { Route as IndexRoute } from '../index';
+import { Route as LoginRoute } from '../login';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() }, Toaster: () => null }));
+
+// THE BARE ORIGIN IS A ROUTE, and it is not the 404 page.
+//
+// `/` matched nothing in the route tree, so opening https://app.tradr.cloud fell
+// through to __root's notFoundComponent and an anonymous visitor was told the
+// address they had typed was wrong. These cases pin the front door open in both
+// directions, and pin the way it asks who you are: through `useSessionPresence`,
+// where a 401 means "nobody", rather than through a redirect into `_auth` whose
+// me-query would 401 and be read by lib/api as an expiry.
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// The real root and the real `/` component, so what an unmatched-until-now
+// address renders is what the app renders (the not-found test's pattern).
+function buildRouter(initialPath: string) {
+  const rootOptions = RootRoute.options as any;
+  const rootRoute = createRootRoute({
+    component: rootOptions.component,
+    notFoundComponent: rootOptions.notFoundComponent,
+  });
+
+  const index = createRoute({
+    getParentRoute: () => rootRoute as any,
+    path: '/',
+    component: (IndexRoute.options as any).component,
+  });
+  const login = createRoute({
+    getParentRoute: () => rootRoute as any,
+    path: '/login',
+    component: (LoginRoute.options as any).component,
+  });
+  const dashboard = createRoute({
+    getParentRoute: () => rootRoute as any,
+    path: '/dashboard',
+    component: () => <div>dashboard-stub</div>,
+  });
+
+  const routeTree = rootRoute.addChildren([index, login, dashboard]);
+
+  return createRouter({
+    routeTree: routeTree as any,
+    history: createMemoryHistory({ initialEntries: [initialPath] }),
+  });
+}
+
+function renderAt(initialPath: string) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const router = buildRouter(initialPath);
+  // main.tsx hands the real router to lib/api, so the 401 interception navigates
+  // rather than assigning window.location — without this the redirect the
+  // anonymous case forbids would be invisible to it.
+  setRouter(router);
+  render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router as any} />
+    </QueryClientProvider>,
+  );
+  return { router };
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+// One tick for the me-query's answer, one for the navigation it provokes.
+async function settle() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+let fetchSpy: MockInstance;
+
+function mockSession(respond: () => Response) {
+  fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => respond());
+}
+
+beforeEach(() => {
+  // lib/api's redirect latch and session flag are module-scoped and a fresh page
+  // load is what normally resets them. This pair is that reset through the
+  // module's own exports: started re-arms the latch, ended clears the session.
+  markSessionStarted();
+  markSessionEnded();
+});
+
+afterEach(() => {
+  cleanup();
+  fetchSpy.mockRestore();
+  setRouter(null);
+});
+
+describe('the bare origin while logged out', () => {
+  beforeEach(() => {
+    mockSession(
+      () =>
+        new Response(JSON.stringify({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+  });
+
+  it('sends the visitor to the login page instead of a not-found page', async () => {
+    const { router } = renderAt('/');
+    await settle();
+
+    expect(router.state.location.pathname).toBe('/login');
+    expect(screen.getByText('Log in', { selector: '[data-slot="card-title"]' })).toBeTruthy();
+    expect(screen.queryByText('Page not found')).toBeNull();
+  });
+
+  it('does not announce an expiry to someone who never had a session', async () => {
+    const { router } = renderAt('/');
+    await settle();
+
+    expect(router.state.location.href).not.toContain('expired');
+    expect(screen.queryByText('Session expired. Please log in again.')).toBeNull();
+  });
+
+  it('leaves the expiry redirect intact for the session that follows', async () => {
+    const { router } = renderAt('/');
+    await settle();
+
+    // The presence check's own 401 must not consume lib/api's one-shot latch, or
+    // the front door would cost the next real expiry its one announcement.
+    // `markSessionConfirmed` stands in for the session the visitor then signs
+    // into: it declares a session WITHOUT re-arming the latch, which is what
+    // leaves a burnt one visible here.
+    markSessionConfirmed();
+    await expect(api.get('/positions')).rejects.toThrow('Unauthorized');
+    await settle();
+
+    expect(router.state.location.href).toContain('expired');
+  });
+});
+
+describe('the bare origin while signed in', () => {
+  beforeEach(() => {
+    mockSession(
+      () =>
+        new Response(
+          JSON.stringify({
+            id: 'u1',
+            email: 'trader@example.com',
+            createdAt: new Date().toISOString(),
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    );
+  });
+
+  it('sends the user to the dashboard', async () => {
+    const { router } = renderAt('/');
+    await settle();
+
+    expect(router.state.location.pathname).toBe('/dashboard');
+    expect(screen.queryByText('Page not found')).toBeNull();
+  });
+});

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,0 +1,48 @@
+import { createFileRoute, Navigate } from '@tanstack/react-router';
+
+import { useSessionPresence } from '@/hooks/useAuth';
+
+/**
+ * `/` — the address people actually type, and the one the route tree never had.
+ *
+ * Every page in the app lives under a named path: `/login`, `/register`, or one
+ * of the `_auth` routes. The bare origin matched none of them, so opening
+ * https://app.tradr.cloud fell through to __root's `notFoundComponent` — which
+ * dispatches a signed-in user to the dashboard, but tells an anonymous visitor
+ * their address is wrong. It wasn't; the front door just had no route behind it.
+ *
+ * SO THE FRONT DOOR IS A DISPATCHER, NOT A REDIRECT. It cannot simply send
+ * everyone to `/dashboard` and let `_auth` sort them out: that layout asks
+ * through `useAuth`, whose me-query 401s for a visitor with no session, and
+ * lib/api's global interception answers every 401 by navigating to
+ * `/login?expired=true`. The 404 page has already been through this (see
+ * __root's note) — arriving with no session is not the same as one running out.
+ *
+ * `useSessionPresence` is the question asked the way this page needs it asked: a
+ * 401 is the answer "nobody", not an expiry, so an anonymous visitor reaches
+ * /login with nothing announced and the interception's one-shot latch unburnt.
+ *
+ * The navigations replace rather than push, or Back from /login returns to `/`
+ * and is redirected straight out again.
+ */
+function IndexRoute() {
+  const { isLoading, isAuthenticated } = useSessionPresence();
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-muted-foreground">Loading...</div>
+      </div>
+    );
+  }
+
+  if (isAuthenticated) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return <Navigate to="/login" replace />;
+}
+
+export const Route = createFileRoute('/')({
+  component: IndexRoute,
+});


### PR DESCRIPTION
## The bug

Opening the app at its own origin showed the not-found page to anyone
without a session:

> **Page not found** — We couldn't find that page. Check the address, or sign
> in to pick up where you left off.

`/` matched nothing in the route tree. Every page lives under `/login`,
`/register`, or `_auth/*`, so the bare origin fell through to `__root`'s
`notFoundComponent`. A signed-in user was dispatched onward by that page and
never noticed; an anonymous visitor was told the address they typed was wrong.
It wasn't — the front door had no route behind it.

## The fix

A new `routes/index.tsx` dispatches `/`: signed in to `/dashboard`, anonymous
to `/login`. Both navigations `replace`, or Back from `/login` returns to `/`
and is redirected straight out again.

## Why it doesn't just redirect to `/dashboard`

That was the one-liner, and it reintroduces a bug this codebase has already
fixed once. `_auth` asks who you are through `useAuth`, whose me-query 401s for
a visitor with no session, and `lib/api`'s global interception answers every
401 by navigating to `/login?expired=true`. Sending everyone to `/dashboard`
would therefore have greeted first-time visitors with a notice that a session
they never had just expired.

So `/` asks through `useSessionPresence` instead — the permissive variant where
a 401 is the answer "nobody" rather than an expiry, on its own query key so it
cannot hand its opt-out to the session query. That is the same distinction the
404 page draws, and for the same reason; see the note in `__root.tsx`.

## Tests

`routes/__tests__/root-index-route.test.tsx`, modeled on the existing
`not-found-anonymous` test — the real root and the real `/` component under an
in-memory router, with `lib/api` wired to it so a redirect is visible:

- anonymous at `/` lands on the login page, not a not-found page
- ...and is told nothing about an expiry
- ...and the presence check does not burn `lib/api`'s one-shot expiry latch, so
  the next real expiry still has its one announcement to make
- signed in at `/` lands on the dashboard

`routeTree.gen.ts` is regenerated.
