### PR TITLE
feat(web): add the hairline token; heal the docs token mirror

### DIFF
--- a/apps/docs/src/styles/tokens.css
+++ b/apps/docs/src/styles/tokens.css
@@ -56,6 +56,15 @@
   --info: oklch(0.72 0.14 250);
   --danger: oklch(0.58 0.21 12); /* = destructive; hue-separated from loss */
 
+  /* Danger-as-TEXT. Same role split as --accent-text, and for the same
+     reason: --danger is tuned as a destructive SURFACE/border and measures
+     only 4.05:1 as text on --bg here, under AA's 4.5:1. Light is the theme
+     that needs no correction (--danger is already 5.47:1 on white), so the
+     lighter value lives in this dark block and the light block aliases
+     back. Measured: 5.19:1 on --bg, 4.84:1 on --card. Same red family
+     (hue 12), still hue-separated from --loss. */
+  --danger-text: oklch(0.64 0.21 12);
+
   /* --- Radii --- */
   --radius-sm: 0.25rem;
   --radius-md: 0.375rem;
@@ -128,6 +137,7 @@
   --warning: oklch(0.49 0.15 70);
   --info: oklch(0.5 0.2 258);
   --danger: oklch(0.55 0.22 12);
+  --danger-text: var(--danger); /* already 5.47:1 on white — no correction needed */
   --glow-amber: radial-gradient(60% 50% at 50% 0%, oklch(0.74 0.15 75 / 0.1), transparent 70%);
 }
 

--- a/apps/web/scripts/check-contrast.mjs
+++ b/apps/web/scripts/check-contrast.mjs
@@ -156,6 +156,7 @@ function composite(fg, alpha, bg) {
 // ---- token roles ----------------------------------------------------------
 // Net-new `@theme` roles (visual-design Task 2) for the R1.4 both-theme check.
 const NET_NEW_ROLES = [
+  '--color-hairline',
   '--color-gain',
   '--color-loss',
   '--color-flat',

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -61,6 +61,12 @@
   --color-border: oklch(0.64 0 0);
   --color-input: oklch(0.64 0 0);
 
+  /* --- Hairline: decorative elevation lines only (visual-redesign). Sits
+         BELOW the >=3:1 separator floor by design - never a meaningful
+         separator; --color-border keeps that job. Values mirror the shared
+         token files (tokens.css --hairline). --- */
+  --color-hairline: oklch(0.9 0 0);
+
   /* --- Brand accent: terminal amber (R2.1) --- */
   --color-primary: oklch(0.74 0.15 75);
   --color-primary-foreground: oklch(0.2 0.02 75);
@@ -148,6 +154,9 @@
      background (0.30 on 0.16 bg is only ~1.42:1). */
   --color-border: oklch(0.5 0.006 265);
   --color-input: oklch(0.5 0.006 265);
+
+  /* --- Hairline (dark) --- */
+  --color-hairline: oklch(0.3 0.006 265);
 
   /* --- Brand accent (dark) --- */
   --color-primary: oklch(0.78 0.15 78);


### PR DESCRIPTION
Groundwork for the visual refresh: one new design token and one healed mirror.

## What's in it

- **`--color-hairline`** — a decorative elevation-line token, added to both
  theme blocks in `apps/web/src/index.css` (light `oklch(0.9 0 0)`, dark
  `oklch(0.3 0.006 265)`). It is deliberately *below* the 3:1 separator
  floor: hairlines are texture, not meaningful separators — `--color-border`
  keeps that job. Registered in `check-contrast.mjs`'s both-theme role list
  so a future edit can't define it in one theme only.
- **Docs token mirror healed** — `apps/docs/src/styles/tokens.css` gains the
  `--danger-text` role it was missing (the docs copy was forked before that
  role landed in the shared token set). The mirror matches its source
  byte-for-byte again.

## Notes

- No component uses the new token yet; consumers arrive with the re-skin PRs.
- All three design gates pass (`check-contrast`, `check-design-lint`,
  `check-fonts`); web builds clean.
