### PR TITLE
feat(ci): gate the docs token mirror against the web token source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,14 @@ jobs:
       - name: Check fonts (transfer budget + font-display + subset + reduced-motion)
         run: node apps/web/scripts/check-fonts.mjs
 
+      # CI-failing — the docs token mirror must match the web token source over
+      # the shared role map (the two files use different substrates by design:
+      # @theme --color-* vs bare --* dark-canonical, so equality is checked per
+      # role, per theme, on alias-resolved values); exits non-zero on any drift
+      # or missing role.
+      - name: Check token sync (web source vs docs mirror)
+        run: node apps/web/scripts/check-token-sync.mjs
+
   # The DB-bound half of the vitest workspace: the api + migrations projects.
   test-api:
     runs-on: ubuntu-latest

--- a/apps/web/scripts/__tests__/check-contrast.test.mjs
+++ b/apps/web/scripts/__tests__/check-contrast.test.mjs
@@ -129,3 +129,21 @@ describe('deltaEOK (OKLab Euclidean distinctness)', () => {
     expect(deltaEOK(parse('oklch(0.6 0.2 27)'), parse('oklch(0.6 0.2 150)'))).toBeGreaterThan(0.05);
   });
 });
+
+describe('extractBlockBody selector escaping', () => {
+  it('locates a block whose selector contains regex metacharacters', () => {
+    const css = `:root { --a: 1; }\n:root[data-theme='light'] { --b: 2; }\n`;
+    const body = extractBlockBody(css, ":root[data-theme='light']");
+    expect(body).not.toBeNull();
+    expect(parseDeclarations(body).get('--b')).toBe('2');
+  });
+
+  it('does not let an unescaped dot match arbitrary characters', () => {
+    // Before the escape fix, ".dark" compiled to the regex /.dark\s*\{/ and
+    // would match "xdark {" — the dot must be literal.
+    const css = `xdark { --a: 1; }\n.dark { --b: 2; }\n`;
+    const body = extractBlockBody(css, '.dark');
+    expect(parseDeclarations(body).get('--b')).toBe('2');
+    expect(parseDeclarations(body).has('--a')).toBe(false);
+  });
+});

--- a/apps/web/scripts/__tests__/check-token-sync.test.mjs
+++ b/apps/web/scripts/__tests__/check-token-sync.test.mjs
@@ -1,0 +1,127 @@
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  ROLE_MAP,
+  THEME_INDEPENDENT,
+  compareTokenMaps,
+  loadTokenMaps,
+} from '../check-token-sync.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+// Build a fully-populated synthetic pair (source + mirror CSS) where every
+// mapped role gets a distinct per-theme placeholder value, so a test can
+// perturb exactly one thing and assert exactly one finding.
+function makeCssPair({ appOverrides = {}, mirrorOverrides = {} } = {}) {
+  const value = (role, theme) => `oklch(0.5 0.1 ${theme === 'light' ? 100 : 200}) /*${role}*/`;
+
+  const decl = (role, v) => `  ${role}: ${v};`;
+  const pick = (overrides, role, fallback) =>
+    Object.prototype.hasOwnProperty.call(overrides, role) ? overrides[role] : fallback;
+
+  const appLight = [];
+  const appDark = [];
+  const mirrorDark = [];
+  const mirrorLight = [];
+
+  for (const [appRole, mirrorRole] of ROLE_MAP) {
+    const light = value(appRole, 'light');
+    const dark = value(appRole, 'dark');
+    const al = pick(appOverrides, `light:${appRole}`, light);
+    const ad = pick(appOverrides, `dark:${appRole}`, dark);
+    const ml = pick(mirrorOverrides, `light:${mirrorRole}`, light);
+    const md = pick(mirrorOverrides, `dark:${mirrorRole}`, dark);
+    if (al !== null) appLight.push(decl(appRole, al));
+    if (ad !== null) appDark.push(decl(appRole, ad));
+    if (ml !== null) mirrorLight.push(decl(mirrorRole, ml));
+    if (md !== null) mirrorDark.push(decl(mirrorRole, md));
+  }
+  for (const [appRole, mirrorRole] of THEME_INDEPENDENT) {
+    const v = '0.25rem';
+    const av = pick(appOverrides, `shared:${appRole}`, v);
+    const mv = pick(mirrorOverrides, `shared:${mirrorRole}`, v);
+    if (av !== null) appLight.push(decl(appRole, av));
+    if (mv !== null) mirrorDark.push(decl(mirrorRole, mv));
+  }
+
+  const sourceCss = `@theme {\n${appLight.join('\n')}\n}\n.dark {\n${appDark.join('\n')}\n}\n`;
+  const mirrorCss = `:root {\n${mirrorDark.join('\n')}\n}\n:root[data-theme='light'] {\n${mirrorLight.join('\n')}\n}\n`;
+  return { sourceCss, mirrorCss };
+}
+
+function run(pair) {
+  return compareTokenMaps(loadTokenMaps(pair.sourceCss, pair.mirrorCss));
+}
+
+describe('compareTokenMaps over synthetic fixtures', () => {
+  it('a fully-synced pair yields zero findings and one OK per mapped role per theme', () => {
+    const result = run(makeCssPair());
+    expect(result.findings).toEqual([]);
+    expect(result.oks).toHaveLength(ROLE_MAP.length * 2 + THEME_INDEPENDENT.length);
+  });
+
+  it('flags a value drift with both role names and both values', () => {
+    const result = run(
+      makeCssPair({ mirrorOverrides: { 'dark:--primary': 'oklch(0.9 0.2 78)' } }),
+    );
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]).toContain('DRIFT');
+    expect(result.findings[0]).toContain('--color-primary');
+    expect(result.findings[0]).toContain('--primary');
+    expect(result.findings[0]).toContain('oklch(0.9 0.2 78)');
+  });
+
+  it('flags a role missing from the mirror', () => {
+    const result = run(makeCssPair({ mirrorOverrides: { 'dark:--hairline': null } }));
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]).toMatch(/\[dark\] MISSING --hairline in the docs mirror/);
+  });
+
+  it('flags a role missing from the web source', () => {
+    const result = run(
+      makeCssPair({ appOverrides: { 'light:--color-gain': null } }),
+    );
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]).toMatch(/\[light\] MISSING --color-gain in the web source/);
+  });
+
+  it('treats whitespace-only differences as equal', () => {
+    const result = run(
+      makeCssPair({
+        appOverrides: { 'shared:--radius-sm': '0.25rem' },
+        mirrorOverrides: { 'shared:--radius-sm': ' 0.25rem ' },
+      }),
+    );
+    expect(result.findings).toEqual([]);
+  });
+
+  it('resolves var() aliases before comparing', () => {
+    const base = makeCssPair();
+    // Point the mirror's dark --danger through an alias to the same value the
+    // app declares literally; the alias target lives in the same block.
+    const literal = 'oklch(0.5 0.1 200) /*--color-destructive*/';
+    const mirrorCss = base.mirrorCss.replace(
+      `  --danger: ${literal};`,
+      `  --danger-base: ${literal};\n  --danger: var(--danger-base);`,
+    );
+    expect(mirrorCss).not.toEqual(base.mirrorCss);
+    const result = compareTokenMaps(loadTokenMaps(base.sourceCss, mirrorCss));
+    expect(result.findings).toEqual([]);
+  });
+});
+
+describe('the real files stay in sync', () => {
+  it('index.css and the docs tokens.css mirror agree on every mapped role', () => {
+    const sourceCss = readFileSync(resolve(here, '..', '..', 'src', 'index.css'), 'utf8');
+    const mirrorCss = readFileSync(
+      resolve(here, '..', '..', '..', 'docs', 'src', 'styles', 'tokens.css'),
+      'utf8',
+    );
+    const result = compareTokenMaps(loadTokenMaps(sourceCss, mirrorCss));
+    expect(result.findings).toEqual([]);
+  });
+});

--- a/apps/web/scripts/check-contrast.mjs
+++ b/apps/web/scripts/check-contrast.mjs
@@ -49,7 +49,7 @@ const REPORT_MODE = false;
 // (which has no following `{`) is not mistaken for the `.dark` block. We then
 // pull `--name: value;` declarations out of each body.
 function extractBlockBody(css, header) {
-  const headerRe = new RegExp(`${header.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\$&')}\\s*\\{`);
+  const headerRe = new RegExp(`${header.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\{`);
   const m = headerRe.exec(css);
   if (!m) return null;
   const open = css.indexOf('{', m.index);

--- a/apps/web/scripts/check-token-sync.mjs
+++ b/apps/web/scripts/check-token-sync.mjs
@@ -1,0 +1,211 @@
+// Cross-file design-token drift gate.
+//
+// `apps/web/src/index.css` is the design-token SOURCE; the docs stylesheet
+// `apps/docs/src/styles/tokens.css` is a MIRROR of the shared brand roles.
+// The two files use different substrates by design — the app declares
+// `--color-*` roles in a Tailwind v4 `@theme` block (light canonical) with a
+// `.dark` re-valuing block; the mirror declares bare `--*` roles on `:root`
+// (dark canonical) with a `:root[data-theme='light']` parity block — so
+// byte-comparison is impossible and equality is checked over an explicit role
+// map, per theme, on alias-resolved, whitespace-normalized value strings.
+//
+// Deliberately NOT compared (divergence is documented, not drift):
+// - font stacks (the mirror carries different fallback chains)
+// - the type scale (`--text-body` etc. — marketing/docs run larger)
+// - `--color-accent`/`--color-input`/`--color-ring` and the non-primary
+//   `-foreground` pairs (app-only shadcn roles with no mirror analogue)
+// - mirror-only extras (`--accent-text`, `--danger-text`, the spacing ladder,
+//   marketing gradients) — they have no app-side source to drift from
+//
+// The marketing site holds a third copy of the mirror in a separate
+// repository; that one is covered by the documented sync ritual, not by this
+// gate.
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { extractBlockBody, parseDeclarations, resolveAliases } from './check-contrast.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const sourcePath = resolve(here, '..', 'src', 'index.css');
+const mirrorPath = resolve(here, '..', '..', 'docs', 'src', 'styles', 'tokens.css');
+
+// [app role, mirror role] — compared in BOTH themes.
+export const ROLE_MAP = [
+  ['--color-background', '--bg'],
+  ['--color-card', '--card'],
+  ['--color-popover', '--popover'],
+  ['--color-secondary', '--secondary'],
+  ['--color-muted', '--muted'],
+  ['--color-border', '--border'],
+  ['--color-hairline', '--hairline'],
+  ['--color-foreground', '--fg'],
+  ['--color-muted-foreground', '--muted-fg'],
+  ['--color-primary', '--primary'],
+  ['--color-primary-foreground', '--primary-fg'],
+  ['--color-focus', '--focus'],
+  ['--color-gain', '--gain'],
+  ['--color-loss', '--loss'],
+  ['--color-flat', '--flat'],
+  ['--color-success', '--success'],
+  ['--color-warning', '--warning'],
+  ['--color-info', '--info'],
+  ['--color-destructive', '--danger'],
+];
+
+// Theme-independent roles: declared once per file (app `@theme`, mirror
+// `:root`), never re-valued per theme.
+export const THEME_INDEPENDENT = [
+  ['--radius-sm', '--radius-sm'],
+  ['--radius-md', '--radius-md'],
+  ['--radius-lg', '--radius-lg'],
+  ['--radius-xl', '--radius-xl'],
+];
+
+function normalize(value) {
+  return value === undefined ? undefined : value.replace(/\s+/g, ' ').trim();
+}
+
+// Pure comparison over parsed maps; returns findings so tests can drive it
+// with synthetic fixtures. `raw` maps gate presence (a role must be DECLARED
+// in its theme block, not merely inherited); `resolved` maps gate equality.
+export function compareTokenMaps({ app, mirror }) {
+  const findings = [];
+  const oks = [];
+
+  const themes = [
+    {
+      theme: 'light',
+      appRaw: app.lightRaw,
+      appValues: app.lightResolved,
+      mirrorRaw: mirror.lightRaw,
+      mirrorValues: mirror.lightResolved,
+    },
+    {
+      theme: 'dark',
+      appRaw: app.darkRaw,
+      appValues: app.darkResolved,
+      mirrorRaw: mirror.darkRaw,
+      mirrorValues: mirror.darkResolved,
+    },
+  ];
+
+  for (const { theme, appRaw, appValues, mirrorRaw, mirrorValues } of themes) {
+    for (const [appRole, mirrorRole] of ROLE_MAP) {
+      if (!appRaw.has(appRole)) {
+        findings.push(`[${theme}] MISSING ${appRole} in the web source`);
+        continue;
+      }
+      if (!mirrorRaw.has(mirrorRole)) {
+        findings.push(`[${theme}] MISSING ${mirrorRole} in the docs mirror (source ${appRole})`);
+        continue;
+      }
+      const a = normalize(appValues.get(appRole));
+      const b = normalize(mirrorValues.get(mirrorRole));
+      if (a !== b) {
+        findings.push(`[${theme}] DRIFT ${appRole} = ${a} but mirror ${mirrorRole} = ${b}`);
+      } else {
+        oks.push(`[${theme}] OK ${appRole} == ${mirrorRole} (${a})`);
+      }
+    }
+  }
+
+  for (const [appRole, mirrorRole] of THEME_INDEPENDENT) {
+    if (!app.lightRaw.has(appRole)) {
+      findings.push(`[shared] MISSING ${appRole} in the web source`);
+      continue;
+    }
+    if (!mirror.darkRaw.has(mirrorRole)) {
+      findings.push(`[shared] MISSING ${mirrorRole} in the docs mirror (source ${appRole})`);
+      continue;
+    }
+    const a = normalize(app.lightResolved.get(appRole));
+    const b = normalize(mirror.darkResolved.get(mirrorRole));
+    if (a !== b) {
+      findings.push(`[shared] DRIFT ${appRole} = ${a} but mirror ${mirrorRole} = ${b}`);
+    } else {
+      oks.push(`[shared] OK ${appRole} == ${mirrorRole} (${a})`);
+    }
+  }
+
+  return { findings, oks };
+}
+
+// Parse both files into the per-theme raw + resolved maps compareTokenMaps
+// expects. The app's `.dark` and the mirror's light block are partial
+// re-valuings, so each is merged over its base before alias resolution —
+// mirroring how the cascade resolves a token used under that theme.
+export function loadTokenMaps(sourceCss, mirrorCss) {
+  const appTheme = extractBlockBody(sourceCss, '@theme');
+  const appDark = extractBlockBody(sourceCss, '.dark');
+  if (appTheme === null) throw new Error('could not locate @theme block in index.css');
+  if (appDark === null) throw new Error('could not locate .dark block in index.css');
+
+  const mirrorRoot = extractBlockBody(mirrorCss, ':root');
+  const mirrorLight = extractBlockBody(mirrorCss, ":root[data-theme='light']");
+  if (mirrorRoot === null) throw new Error('could not locate :root block in tokens.css');
+  if (mirrorLight === null) {
+    throw new Error("could not locate :root[data-theme='light'] block in tokens.css");
+  }
+
+  const appLightRaw = parseDeclarations(appTheme);
+  const appDarkRaw = parseDeclarations(appDark);
+  const appDarkMerged = new Map(appLightRaw);
+  for (const [k, v] of appDarkRaw) appDarkMerged.set(k, v);
+
+  const mirrorDarkRaw = parseDeclarations(mirrorRoot);
+  const mirrorLightRaw = parseDeclarations(mirrorLight);
+  const mirrorLightMerged = new Map(mirrorDarkRaw);
+  for (const [k, v] of mirrorLightRaw) mirrorLightMerged.set(k, v);
+
+  return {
+    app: {
+      lightRaw: appLightRaw,
+      darkRaw: appDarkRaw,
+      lightResolved: resolveAliases(appLightRaw),
+      darkResolved: resolveAliases(appDarkMerged),
+    },
+    mirror: {
+      lightRaw: mirrorLightRaw,
+      darkRaw: mirrorDarkRaw,
+      lightResolved: resolveAliases(mirrorLightMerged),
+      darkResolved: resolveAliases(mirrorDarkRaw),
+    },
+  };
+}
+
+function main() {
+  let sourceCss;
+  let mirrorCss;
+  try {
+    sourceCss = readFileSync(sourcePath, 'utf8');
+    mirrorCss = readFileSync(mirrorPath, 'utf8');
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      console.error(`::error::token file missing: ${err.path}`);
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  let result;
+  try {
+    result = compareTokenMaps(loadTokenMaps(sourceCss, mirrorCss));
+  } catch (err) {
+    console.error(`::error::${err.message}`);
+    process.exit(1);
+  }
+
+  for (const line of result.oks) console.log(`[sync] ${line}`);
+
+  if (result.findings.length === 0) {
+    console.log(`\ntoken-sync gate OK — ${result.oks.length} roles matched, 0 findings`);
+    process.exit(0);
+  }
+  console.log(`\ntoken-sync findings (${result.findings.length}):`);
+  for (const f of result.findings) console.error(`::error::[sync] ${f}`);
+  process.exit(1);
+}
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) main();


### PR DESCRIPTION
Stacked on #62. Adds the CI gate that keeps the docs token mirror honest.

## What's in it

- **`check-token-sync.mjs`** — the fifth design gate in the `checks` job. It
  compares `apps/web/src/index.css` (the token source) against
  `apps/docs/src/styles/tokens.css` (the mirror) over an explicit role map,
  per theme, on alias-resolved, whitespace-normalized values. The two files
  use different substrates by design — `@theme --color-*` light-canonical vs
  bare `--*` dark-canonical — so byte comparison cannot work; the map is the
  contract. 42 roles covered; deliberate divergences (font fallback stacks,
  the marketing type scale, app-only shadcn roles, mirror-only extras) are
  excluded and documented in the script header.
- **`extractBlockBody` escape fix** in `check-contrast.mjs` — its
  metacharacter class closed early, making the selector escape a no-op.
  Harmless for `@theme`/`.dark` by luck; fatal for bracketed selectors like
  `:root[data-theme='light']`, which the new gate needs. Regression tests pin
  both the bracketed selector and the literal-dot behavior.
- **Tests** — synthetic-fixture coverage for drift / missing-role /
  whitespace / `var()` aliasing, plus a real-files test asserting the repo's
  actual token pair stays in sync.

## Notes

- Depends on #62 (the mirror heal + `--color-hairline`); without it the gate
  fails on the recorded drift, which is the point.
- Gates run green locally: contrast, design-lint, token-sync; `web-scripts`
  vitest project 58/58.
