### PR TITLE
feat(docs): re-theme Starlight to the product visual direction

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -110,9 +110,12 @@ export default defineConfig({
       pagefind: true,
       // Says which version these pages describe, on every page. Starlight 0.41
       // has no site-wide banner option, so this overrides the per-page one —
-      // see the component for why.
+      // see the component for why. SiteTitle renders the `▴ Tradr docs`
+      // wordmark, whose three differently-styled parts CSS cannot carve out of
+      // the default single-text-node title.
       components: {
         Banner: './src/components/VersionBanner.astro',
+        SiteTitle: './src/components/SiteTitle.astro',
       },
       // Excludes the generated API operation pages from the search index — see
       // the file for why. The API overview page stays indexed.

--- a/apps/docs/ec.config.mjs
+++ b/apps/docs/ec.config.mjs
@@ -1,0 +1,39 @@
+// Expressive Code (code block) theming for the docs — see docs.css for the
+// palette it plugs into: mono on near-black, one step BELOW the page
+// background, inside a hairline 10px-radius frame. The var() references
+// resolve against tokens.css per theme at render time.
+//
+// This lives in ec.config.mjs rather than Starlight's `expressiveCode` option
+// for two reasons, both found the hard way:
+//
+// - `customizeTheme` is a function, and options set in astro.config must be
+//   JSON-serializable for starlight-openapi's `<Code>` component to render —
+//   the config file is Expressive Code's own remedy (it is loaded directly at
+//   render time).
+// - starlight-openapi's config:setup rebuilds the `expressiveCode` key from
+//   scratch (it reads the key off its own fresh update object, not the user
+//   config) and Starlight merges plugin config updates shallowly, so anything
+//   set on the Starlight option is silently replaced. Options here merge at a
+//   layer that plugin cannot touch.
+//
+// `customizeTheme` (not `styleOverrides`) carries the frame backgrounds
+// because Starlight's default `useStarlightUiThemeColors` writes THEME-level
+// frame styleOverrides, which outrank config-level ones; the hook runs after
+// Starlight's own theme mutation.
+export default {
+  styleOverrides: {
+    borderRadius: '0.625rem',
+    borderColor: 'var(--hairline)',
+  },
+  customizeTheme: (theme) => {
+    theme.styleOverrides.frames = {
+      ...theme.styleOverrides.frames,
+      editorBackground: 'var(--tradr-code-bg)',
+      terminalBackground: 'var(--tradr-code-bg)',
+      editorActiveTabBackground: 'var(--tradr-code-bg)',
+    };
+    theme.colors['titleBar.activeBackground'] = 'var(--popover)';
+    theme.colors['editorGroupHeader.tabsBackground'] = 'var(--popover)';
+    return theme;
+  },
+};

--- a/apps/docs/src/components/HostedOnly.astro
+++ b/apps/docs/src/components/HostedOnly.astro
@@ -5,7 +5,7 @@
 // managed backups, wallet credits, billing, feature gating.
 //
 // Uses the `note` aside type, which the docs theme (docs.css) renders in the
-// brand amber accent. Usage in .mdx:
+// info blue status tone (callouts never spend the amber accent). Usage in .mdx:
 //   import HostedOnly from '@/components/HostedOnly.astro';
 //   <HostedOnly>Managed nightly backups run automatically.</HostedOnly>
 import { Aside } from '@astrojs/starlight/components';

--- a/apps/docs/src/components/SelfHosted.astro
+++ b/apps/docs/src/components/SelfHosted.astro
@@ -3,8 +3,8 @@
 // <Aside>, the counterpart to <HostedOnly>. Applies to a self-run instance: you
 // supply your own LLM key and run and back up your own database.
 //
-// Uses the `tip` aside type, re-themed cool-blue in docs.css (green/red stay
-// reserved for P&L data per the brand rule). Usage in .mdx:
+// Uses the `tip` aside type, re-themed success teal in docs.css (gain green /
+// loss red stay reserved for P&L data per the brand rule). Usage in .mdx:
 //   import SelfHosted from '@/components/SelfHosted.astro';
 //   <SelfHosted>Feature gating is off by default; set FEATURE_GATING to enable.</SelfHosted>
 import { Aside } from '@astrojs/starlight/components';

--- a/apps/docs/src/components/SiteTitle.astro
+++ b/apps/docs/src/components/SiteTitle.astro
@@ -1,0 +1,41 @@
+---
+// The `▴ Tradr docs` wordmark — brand triangle, product name, muted qualifier.
+//
+// Overrides Starlight's SiteTitle, which renders the whole configured title as
+// one accent-colored string. The wordmark is a designed lockup with three
+// differently-styled parts, which CSS cannot carve out of a single text node,
+// so this is a component override (astro.config `components.SiteTitle`).
+//
+// The ▴ is decorative (aria-hidden), so the link's accessible name stays
+// "Tradr docs" — the configured site title.
+const { siteTitleHref } = Astro.locals.starlightRoute;
+---
+
+<a href={siteTitleHref} class="site-title sl-flex">
+  <span class="mark" aria-hidden="true">▴</span>
+  <span class="wordmark" translate="no">Tradr <span class="qualifier">docs</span></span>
+</a>
+
+<style>
+  .site-title {
+    align-items: baseline;
+    gap: 0.5rem;
+    font-size: var(--sl-text-base);
+    font-weight: 700;
+    color: var(--fg);
+    text-decoration: none;
+    white-space: nowrap;
+    min-width: 0;
+  }
+  .wordmark {
+    overflow: hidden;
+  }
+  .mark {
+    color: var(--primary);
+    font-size: 0.75em;
+  }
+  .qualifier {
+    color: var(--muted-fg);
+    font-weight: 500;
+  }
+</style>

--- a/apps/docs/src/components/VersionBanner.astro
+++ b/apps/docs/src/components/VersionBanner.astro
@@ -23,24 +23,37 @@ declare const __TRADR_VERSION__: string;
 const version = __TRADR_VERSION__;
 ---
 
+{/* "the <a" must stay on one line: Astro drops the newline between them. */}
 <div class="version-banner">
-  These docs describe Tradr <strong>v{version}</strong>. Running an older release? Check the
-  <a href="https://github.com/madmatt112/tradr/releases">release notes</a> for what changed.
+  These docs describe Tradr <strong>v{version}</strong>. Running an older release? Check
+  the <a href="https://github.com/madmatt112/tradr/releases">release notes</a> for what changed.
 </div>
 
 <style>
+  /* Machine-adjacent strip: mono on the popover surface, left-aligned with the
+     top bar, version in the foreground weight, link in the amber text token. */
   .version-banner {
-    padding: 0.5rem var(--sl-nav-pad-x, 1rem);
-    background-color: var(--sl-color-bg-nav);
-    border-bottom: 1px solid var(--sl-color-hairline-shade);
-    color: var(--sl-color-gray-2);
-    font-size: var(--sl-text-xs);
+    padding: 0.4375rem var(--sl-nav-pad-x, 1rem);
+    background-color: var(--popover);
+    border-bottom: 1px solid var(--hairline);
+    color: var(--muted-fg);
+    font-family: var(--font-mono);
+    font-size: 0.71875rem;
     line-height: 1.5;
-    text-align: center;
     text-wrap: balance;
   }
 
+  .version-banner strong {
+    color: var(--fg);
+    font-weight: 500;
+  }
+
   .version-banner a {
-    color: var(--sl-color-text-accent);
+    color: var(--accent-text);
+    text-decoration: none;
+  }
+
+  .version-banner a:hover {
+    text-decoration: underline;
   }
 </style>

--- a/apps/docs/src/styles/docs.css
+++ b/apps/docs/src/styles/docs.css
@@ -11,9 +11,9 @@
    the var(--*) references below resolve, and — because customCss is injected
    AFTER Starlight's own styles — these overrides win at equal specificity.
 
-   Brand rule (design-system.md): amber is the sole accent; green/red are
-   RESERVED for gain/loss data. So the accent maps to amber and the "tip" aside
-   (our Self-hosted callout) is re-themed cool-blue rather than the stock green.
+   Brand rule (design-system.md): amber is the sole accent and it is SCARCE —
+   active nav, links, the one active TOC mark. Callouts spend the info/success/
+   warning status tones, never amber. Green/red are RESERVED for gain/loss data.
    Focus rings use the dedicated cool-blue --focus token, never amber.
    ============================================================================ */
 
@@ -64,6 +64,24 @@
   --sl-color-bg-inline-code: var(--secondary);
 }
 
+/* --- Chrome surfaces (both themes — these tokens swap themselves in light).
+       The top bar and sidebar sit on the page background separated by hairlines
+       rather than on a raised nav surface; links and active markers use the
+       AA-checked amber-as-text token; code blocks sit one step BELOW the page
+       background (near-black) with a hairline frame. --- */
+:root {
+  --sl-color-bg-nav: var(--bg);
+  --sl-color-bg-sidebar: var(--bg);
+  --sl-color-hairline-shade: var(--hairline);
+  --sl-color-text-accent: var(--accent-text);
+
+  --tradr-code-bg: oklch(0.13 0.005 265); /* below --bg (0.16), same cool cast */
+}
+
+:root[data-theme='light'] {
+  --tradr-code-bg: var(--secondary); /* light has no "below white" — quiet fill */
+}
+
 /* --- Focus indicator: cool-blue --focus, never amber (matches global.css) --- */
 :focus-visible {
   outline: 2px solid var(--focus);
@@ -79,14 +97,167 @@ summary {
   cursor: pointer;
 }
 
-/* --- Aside convention re-theme (see components/*.astro):
-       - `note`  = "Hosted only"  → keeps the amber accent (default note color).
-       - `tip`   = "Self-hosted"  → re-themed cool-blue so the reserved green is
-         not used for chrome. Green/red stay for P&L data only. --- */
-.starlight-aside--tip {
+/* --- Sidebar: the app's selection grammar. The active item gets the amber
+       left tick + quiet secondary fill; everything else is muted until hover.
+       Group labels become mono eyebrows, matching the eyebrow treatment across
+       surfaces. The 2px tick space is reserved on every item (transparent when
+       inactive) so activating a link never shifts its text. --- */
+.sidebar-content .top-level a.large {
+  font-size: var(--sl-text-sm);
+  font-weight: 400;
+  color: var(--muted-fg);
+}
+
+.sidebar-content summary .group-label .large {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted-fg);
+}
+
+.sidebar-content a {
+  color: var(--muted-fg);
+  border-inline-start: 2px solid transparent;
+  border-radius: 0 0.375rem 0.375rem 0;
+}
+
+.sidebar-content a:hover,
+.sidebar-content a:focus {
+  color: var(--fg);
+}
+
+.sidebar-content a[aria-current='page'],
+.sidebar-content a[aria-current='page']:hover,
+.sidebar-content a[aria-current='page']:focus {
+  color: var(--fg);
+  background-color: var(--secondary);
+  border-inline-start-color: var(--primary);
+  font-weight: 550;
+}
+
+/* Starlight draws a vertical tree line beside nested lists; the sidebar reads
+   flat under its group eyebrows instead. */
+.sidebar-content ul ul li {
+  border-inline-start-color: transparent;
+}
+
+/* --- "On this page": mono eyebrow heading; the active heading link is the ONE
+       amber mark in the content area (it inherits --sl-color-text-accent). --- */
+.right-sidebar-panel h2 {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted-fg);
+}
+
+/* --- Search pill: hairline pill in the top bar with a mono shortcut chip --- */
+site-search button[data-open-modal] {
+  color: var(--muted-fg);
+}
+
+site-search button[data-open-modal]:hover {
+  color: var(--fg);
+  border-color: var(--border);
+}
+
+site-search button[data-open-modal] > kbd {
+  background-color: transparent;
+  border: 1px solid var(--hairline);
+  padding-block: 0;
+}
+
+site-search button[data-open-modal] kbd {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+}
+
+/* --- Content links: amber with a soft underline that solidifies on hover --- */
+.sl-markdown-content a:not(:where(.not-content *)) {
+  text-underline-offset: 3px;
+  text-decoration-color: color-mix(in oklch, var(--sl-color-text-accent) 40%, transparent);
+}
+
+.sl-markdown-content a:not(:where(.not-content *)):hover {
+  text-decoration-color: var(--sl-color-text-accent);
+}
+
+/* --- Headings: tighter tracking, matching the app's display type --- */
+.sl-markdown-content :is(h1, h2, h3),
+h1#_top {
+  letter-spacing: -0.02em;
+}
+
+/* --- Link cards (docs home): raised card surface, amber affordance arrow --- */
+.sl-link-card {
+  background-color: var(--card);
+  border: 1px solid var(--hairline);
+  border-radius: 0.75rem;
+  box-shadow: none;
+}
+
+.sl-link-card .title {
+  font-size: var(--sl-text-base);
+}
+
+.sl-link-card .icon {
+  color: var(--accent-text);
+}
+
+.sl-link-card:hover {
+  background: var(--secondary);
+  border-color: var(--border);
+}
+
+/* --- Callouts: status tones only, NEVER amber (see components/*.astro):
+       - `note`    = generic + "Hosted only" → info blue
+       - `tip`     = "Self-hosted"           → success teal
+       - `caution`                           → warning
+       - `danger`                            → danger (hue-separated from loss)
+       Treatment: no fill — a 40% tone hairline + 3px tone tick, and a mono
+       uppercase title. Green/red stay reserved for P&L data. --- */
+.starlight-aside {
+  border: 1px solid color-mix(in oklch, var(--sl-color-asides-border) 40%, transparent);
+  border-inline-start: 3px solid var(--sl-color-asides-border);
+  border-radius: 0.5rem;
+  background-color: transparent;
+  padding: 0.75rem 1rem;
+  color: var(--sl-color-gray-2);
+}
+
+.starlight-aside--note {
   --sl-color-asides-text-accent: var(--info);
   --sl-color-asides-border: var(--info);
-  background-color: color-mix(in oklch, var(--info) 12%, var(--bg));
+}
+
+.starlight-aside--tip {
+  --sl-color-asides-text-accent: var(--success);
+  --sl-color-asides-border: var(--success);
+}
+
+.starlight-aside--caution {
+  --sl-color-asides-text-accent: var(--warning);
+  --sl-color-asides-border: var(--warning);
+}
+
+.starlight-aside--danger {
+  --sl-color-asides-text-accent: var(--danger-text);
+  --sl-color-asides-border: var(--danger);
+}
+
+.starlight-aside__title {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.starlight-aside__icon {
+  display: none;
 }
 
 /* --- Theme-paired screenshots (components/Screenshot.astro). Starlight's inline


### PR DESCRIPTION
## What

Re-themes the Starlight docs site to match the product's visual direction, so moving between the app, the marketing site, and the docs feels like one product. Dark is canonical; light is a first-class equal derived entirely from the existing light parity block in `tokens.css` (which is byte-for-byte unchanged — the token-sync gate stays green).

- **`▴ Tradr docs` wordmark** — new `SiteTitle` component override: amber triangle, bold name, muted qualifier. A component override because the lockup's three differently-styled parts cannot be carved out of the default single-text-node title with CSS.
- **Sidebar** — adopts the app's selection grammar: amber left tick + quiet secondary fill + heavier weight on the active item; mono uppercase group eyebrows; muted items that resolve to full foreground on hover.
- **Callouts** — status tones only, never amber: `note` ("Hosted only" + generic notes) → info blue, `tip` ("Self-hosted") → success teal, `caution` → warning, `danger` → danger. Quiet 40% tone hairline + 3px tone tick, mono uppercase titles, no fill. Gain green / loss red stay reserved for financial data.
- **Code blocks** — mono on near-black, one step below the page background, in a hairline 10px-radius frame. Options live in `ec.config.mjs`: `customizeTheme` is not JSON-serializable (which breaks starlight-openapi's `<Code>` rendering when set in `astro.config.mjs`), and starlight-openapi's shallow config update silently replaces anything set on Starlight's `expressiveCode` key — both documented in the file.
- **Search pill + "On this page"** — join the mono eyebrow treatment; the active TOC link is the one amber mark in the content area.
- **Version banner** — mono strip on the popover surface, left-aligned with the top bar. Also fixes the missing space before the release-notes link (Astro drops the newline between text and a following element).
- **Top bar / sidebar surfaces** — sit on the page background with hairline separators instead of a raised nav surface.

## Verification

- `pnpm --filter @tradr/docs build` green, including the internal link validator (135 pages).
- `pnpm lint`, `pnpm --filter @tradr/docs check-types` (astro check), and `node apps/web/scripts/check-token-sync.mjs` all green.
- Rendered pages checked in both themes at desktop and mobile widths: docs home, the Docker Compose guide (long-form reading, tables, terminal frames, callouts), Getting started (success-teal callout), and a generated API operation page (starlight-openapi + code samples).
- Generated reference pages and the OpenAPI artifact are untouched.
