### PR TITLE
feat(web): rebuild the nav as the expandable desk rail

### DIFF
--- a/apps/api/src/features/auth/auth.query.ts
+++ b/apps/api/src/features/auth/auth.query.ts
@@ -107,14 +107,16 @@ export function updateUserOnboarding(db: DB, userId: string, patch: OnboardingPa
       END`;
   }
 
-  // status and calculatorFirstUsedAt are plain scalars, so one `||` sets both.
-  // It runs after the coach-mark clause only because that clause reads the
-  // column directly; the two touch disjoint keys, so the order is immaterial.
-  const scalars: Record<string, string> = {};
+  // status, calculatorFirstUsedAt and sidebarPinned are plain scalars, so one
+  // `||` sets them all. It runs after the coach-mark clause only because that
+  // clause reads the column directly; they touch disjoint keys, so the order
+  // is immaterial.
+  const scalars: Record<string, string | boolean> = {};
   if (patch.status !== undefined) scalars.status = patch.status;
   if (patch.calculatorFirstUsedAt !== undefined) {
     scalars.calculatorFirstUsedAt = patch.calculatorFirstUsedAt;
   }
+  if (patch.sidebarPinned !== undefined) scalars.sidebarPinned = patch.sidebarPinned;
   if (Object.keys(scalars).length > 0) {
     merged = sql`${merged} || ${JSON.stringify(scalars)}::jsonb`;
   }

--- a/apps/api/src/features/auth/auth.route.ts
+++ b/apps/api/src/features/auth/auth.route.ts
@@ -441,6 +441,12 @@ userPreferencesRouter.put('/users/me/timezone', validate('json', UserTimezoneSch
  *                   items: { type: string }
  *                   description: Surface keys already dismissed, as a set.
  *                   example: []
+ *                 sidebarPinned:
+ *                   type: boolean
+ *                   description: >
+ *                     Whether the nav rail is pinned to its expanded state.
+ *                     Absent until the user (or the client's one-time seed)
+ *                     has expressed a preference.
  *       401: { description: Authentication required. }
  */
 userPreferencesRouter.get('/users/me/onboarding', async (c) => {
@@ -483,6 +489,9 @@ userPreferencesRouter.get('/users/me/onboarding', async (c) => {
  *                   the whole set is never sent. Ignored once the set holds 64
  *                   keys.
  *                 example: partial-close
+ *               sidebarPinned:
+ *                 type: boolean
+ *                 description: Pin (true) or unpin (false) the expanded nav rail.
  *     responses:
  *       200: { description: 'The merged onboarding preference, in the same shape as the GET.' }
  *       400: { description: 'Unknown field, empty body, or an invalid status or timestamp.' }

--- a/apps/api/src/features/auth/user-onboarding.test.ts
+++ b/apps/api/src/features/auth/user-onboarding.test.ts
@@ -82,6 +82,7 @@ async function getOnboarding(cookie: string) {
     status: string;
     coachMarksSeen: string[];
     calculatorFirstUsedAt?: string;
+    sidebarPinned?: boolean;
   };
 }
 
@@ -198,6 +199,43 @@ describe('PATCH /api/users/me/onboarding merges rather than replaces', () => {
       status: 'done',
       calculatorFirstUsedAt: at,
       coachMarksSeen: ['partial-close'],
+    });
+  });
+
+  it('sets sidebarPinned without disturbing the other fields, in both directions', async () => {
+    const { cookie } = await registerAndGetCookie();
+    await patchOnboarding(cookie, { status: 'active' });
+    await patchOnboarding(cookie, { coachMarkSeen: 'csv-import' });
+
+    let res = await patchOnboarding(cookie, { sidebarPinned: true });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      status: 'active',
+      coachMarksSeen: ['csv-import'],
+      sidebarPinned: true,
+    });
+
+    // Unpinning is the same merge — false must round-trip, not read as absent.
+    res = await patchOnboarding(cookie, { sidebarPinned: false });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      status: 'active',
+      coachMarksSeen: ['csv-import'],
+      sidebarPinned: false,
+    });
+  });
+
+  it('leaves sidebarPinned untouched by unrelated patches', async () => {
+    const { cookie } = await registerAndGetCookie();
+    await patchOnboarding(cookie, { sidebarPinned: true });
+
+    await patchOnboarding(cookie, { status: 'done' });
+    const res = await patchOnboarding(cookie, { coachMarkSeen: 'partial-close' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      status: 'done',
+      coachMarksSeen: ['partial-close'],
+      sidebarPinned: true,
     });
   });
 

--- a/apps/docs/src/openapi/tradr-api.json
+++ b/apps/docs/src/openapi/tradr-api.json
@@ -4432,6 +4432,10 @@
                       },
                       "type": "array"
                     },
+                    "sidebarPinned": {
+                      "description": "Whether the nav rail is pinned to its expanded state. Absent until the user (or the client's one-time seed) has expressed a preference.\n",
+                      "type": "boolean"
+                    },
                     "status": {
                       "description": "`pending` not started, `active` running, `skipped` dismissed (recoverable — set it back to start again), `done` completed.\n",
                       "enum": [
@@ -4478,6 +4482,10 @@
                     "example": "partial-close",
                     "maxLength": 64,
                     "type": "string"
+                  },
+                  "sidebarPinned": {
+                    "description": "Pin (true) or unpin (false) the expanded nav rail.",
+                    "type": "boolean"
                   },
                   "status": {
                     "enum": [

--- a/apps/web/src/components/layout/DrawerToggle.test.tsx
+++ b/apps/web/src/components/layout/DrawerToggle.test.tsx
@@ -21,10 +21,13 @@ describe('DrawerToggle', () => {
     cleanup();
   });
 
-  it('renders top-bar with h-12 and a button with correct aria attributes when isOpen is false', () => {
+  it('renders the floating toggle with a button carrying the aria contract when isOpen is false', () => {
     render(<DrawerToggle />);
-    const topbar = screen.getByTestId('drawer-topbar');
-    expect(topbar.className).toContain('h-12');
+    const wrapper = screen.getByTestId('drawer-toggle');
+    // Floating control, not a layout band: fixed at the viewport's top-right,
+    // never reserving a row of the page (the old h-12 top bar is gone).
+    expect(wrapper.className).toContain('fixed');
+    expect(wrapper.className).not.toContain('h-12');
     const button = screen.getByRole('button', { name: /open side drawer/i });
     expect(button.getAttribute('aria-expanded')).toBe('false');
     expect(button.getAttribute('aria-controls')).toBe('side-drawer');
@@ -37,15 +40,14 @@ describe('DrawerToggle', () => {
     expect(useDrawerStore.getState().isOpen).toBe(true);
   });
 
-  it('collapses the top-bar to h-0 border-b-0 and removes the button when isOpen is true', () => {
+  it('hides the toggle and removes the button when isOpen is true', () => {
     useDrawerStore.setState({ isOpen: true });
     render(<DrawerToggle />);
-    const topbar = screen.getByTestId('drawer-topbar');
-    expect(topbar.className).toContain('h-0');
-    expect(topbar.className).toContain('border-b-0');
-    expect(
-      screen.queryByRole('button', { name: /open side drawer/i }),
-    ).toBeNull();
+    const wrapper = screen.getByTestId('drawer-toggle');
+    expect(wrapper.className).toContain('opacity-0');
+    expect(wrapper.className).toContain('pointer-events-none');
+    expect(wrapper.getAttribute('aria-hidden')).toBe('true');
+    expect(screen.queryByRole('button', { name: /open side drawer/i })).toBeNull();
   });
 
   it('attaches the button to the ref provided via DrawerToggleRefContext', () => {

--- a/apps/web/src/components/layout/DrawerToggle.tsx
+++ b/apps/web/src/components/layout/DrawerToggle.tsx
@@ -6,6 +6,12 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { useDrawerStore } from '@/stores/drawer.store';
 
+// The drawer's opener, floating at the top-right of the viewport. It used to
+// sit alone in a 48px top bar that existed for nothing else — the bar is gone
+// (visual-redesign task 4) and the control now floats where the drawer slides
+// in from, until the shared PageHeader (task 5) gives it a proper slot. Fixed
+// positioning keeps it out of the document flow; z-20 sits under the drawer's
+// overlay (z-30) so the open drawer covers it.
 export function DrawerToggle() {
   const isOpen = useDrawerStore((s) => s.isOpen);
   const open = useDrawerStore((s) => s.open);
@@ -13,11 +19,11 @@ export function DrawerToggle() {
 
   return (
     <div
-      data-testid="drawer-topbar"
+      data-testid="drawer-toggle"
       aria-hidden={isOpen}
       className={cn(
-        'flex justify-end border-b items-center px-4 transition-[height] duration-200 ease-out motion-reduce:duration-0 overflow-hidden',
-        isOpen ? 'h-0 border-b-0' : 'h-12',
+        'fixed right-3 top-3 z-20 transition-opacity duration-200 ease-out motion-reduce:duration-0',
+        isOpen && 'pointer-events-none opacity-0',
       )}
     >
       {!isOpen && (
@@ -27,7 +33,7 @@ export function DrawerToggle() {
           }}
           variant="ghost"
           size="icon-sm"
-          className="cursor-pointer"
+          className="cursor-pointer text-muted-foreground"
           onClick={open}
           aria-label="Open side drawer"
           aria-expanded={false}

--- a/apps/web/src/components/layout/Sidebar.admin-link.test.tsx
+++ b/apps/web/src/components/layout/Sidebar.admin-link.test.tsx
@@ -27,6 +27,12 @@ vi.mock('@tanstack/react-router', () => ({
 }));
 
 // ThemeToggle needs a QueryClient; irrelevant to the link conditional.
+// The pin preference is a useQuery + useMutation pair under the hood; pin the
+// mock EXPANDED so the label-text assertions below read the visible nav.
+vi.mock('@/features/onboarding/hooks/useSidebarPin', () => ({
+  useSidebarPin: () => ({ pinned: true, setPinned: () => {} }),
+}));
+
 vi.mock('@/components/layout/ThemeToggle', () => ({
   ThemeToggle: () => null,
 }));
@@ -70,7 +76,7 @@ afterEach(() => {
 });
 
 describe('Sidebar — Admin link conditional', () => {
-  it('renders the Admin link for admin users, below Settings, with cursor-pointer', () => {
+  it('renders the Admin link for admin users, closing the System group, with cursor-pointer', () => {
     mockAuth.user = { email: 'admin@example.com', isAdmin: true };
     const { container } = render(<Sidebar />);
 
@@ -82,7 +88,10 @@ describe('Sidebar — Admin link conditional', () => {
     const hrefs = Array.from(container.querySelectorAll('nav a')).map((a) =>
       a.getAttribute('href'),
     );
-    expect(hrefs.indexOf('/admin')).toBe(hrefs.indexOf('/settings') + 1);
+    // The desk nav's SYSTEM group closes with Admin (Settings → Changelog →
+    // Docs → Admin), so it is the last nav entry rather than Settings + 1.
+    expect(hrefs.indexOf('/admin')).toBeGreaterThan(hrefs.indexOf('/settings'));
+    expect(hrefs.indexOf('/admin')).toBe(hrefs.length - 1);
   });
 
   it('does NOT render the Admin link for non-admin users', () => {

--- a/apps/web/src/components/layout/Sidebar.docs-link.test.tsx
+++ b/apps/web/src/components/layout/Sidebar.docs-link.test.tsx
@@ -28,6 +28,12 @@ vi.mock('@/features/changelog/hooks/useChangelog', () => ({
   hasNewReleases: () => false,
 }));
 
+// The pin preference is a useQuery + useMutation pair under the hood; pin the
+// mock EXPANDED so the label-text assertions below read the visible nav.
+vi.mock('@/features/onboarding/hooks/useSidebarPin', () => ({
+  useSidebarPin: () => ({ pinned: true, setPinned: () => {} }),
+}));
+
 vi.mock('@/components/layout/ThemeToggle', () => ({ ThemeToggle: () => null }));
 
 // The stored reporting timezone is a useQuery; stub it so the sidebar mounts

--- a/apps/web/src/components/layout/Sidebar.test.tsx
+++ b/apps/web/src/components/layout/Sidebar.test.tsx
@@ -25,12 +25,13 @@ vi.mock('@tanstack/react-router', () => ({
     children,
     className,
     search,
+    ...rest
   }: {
     to: string;
     children: React.ReactNode;
     className?: string;
     search?: unknown;
-  }) => {
+  } & Record<string, unknown>) => {
     linkSearch.set(to, search);
     return (
       <a
@@ -40,6 +41,7 @@ vi.mock('@tanstack/react-router', () => ({
           e.preventDefault();
           linkClicks.push({ to });
         }}
+        {...rest}
       >
         {children}
       </a>
@@ -84,6 +86,24 @@ vi.mock('@/features/changelog/hooks/useChangelog', async (importOriginal) => {
   };
 });
 
+// The pin preference is a useQuery + useMutation pair under the hood; stub it
+// with a controllable value. Most suites run EXPANDED (labels in the DOM) so
+// text assertions read naturally; the rail-state suite flips it.
+const pinState = vi.hoisted(() => ({
+  pinned: true,
+  calls: [] as boolean[],
+}));
+vi.mock('@/features/onboarding/hooks/useSidebarPin', () => ({
+  useSidebarPin: () => ({
+    pinned: pinState.pinned,
+    setPinned: (next: boolean) => {
+      pinState.calls.push(next);
+    },
+  }),
+}));
+
+import { useDrawerStore } from '@/stores/drawer.store';
+
 import { Sidebar } from './Sidebar';
 
 // ---------------------------------------------------------------------------
@@ -113,6 +133,9 @@ beforeEach(() => {
   localStorage.clear();
   changelogState.result = { data: undefined, isError: false };
   timezoneState.value = 'Europe/Berlin';
+  pinState.pinned = true;
+  pinState.calls = [];
+  useDrawerStore.setState({ isOpen: false });
 });
 
 function releasesData(publishedAt: string, lastViewedAt: string) {
@@ -164,18 +187,22 @@ describe('Sidebar — Performance link', () => {
     unmount(container, root);
   });
 
-  it('renders the Performance link after Calculator and before Accounts', () => {
+  it('renders the Performance link heading the Review group, after the Trade group', () => {
     const { container, root } = mountWith(<Sidebar />);
 
     const hrefs = Array.from(container.querySelectorAll('nav a')).map((a) =>
       a.getAttribute('href'),
     );
     const calcIdx = hrefs.indexOf('/calculator');
+    const importIdx = hrefs.indexOf('/import');
     const perfIdx = hrefs.indexOf('/performance');
     const acctIdx = hrefs.indexOf('/accounts');
 
+    // The desk nav groups: Performance opens REVIEW, directly after TRADE's
+    // last item (Import), with Accounts later in the same group.
     expect(calcIdx).toBeGreaterThanOrEqual(0);
-    expect(perfIdx).toBe(calcIdx + 1);
+    expect(importIdx).toBeGreaterThan(calcIdx);
+    expect(perfIdx).toBe(importIdx + 1);
     expect(acctIdx).toBeGreaterThan(perfIdx);
 
     unmount(container, root);
@@ -280,17 +307,17 @@ describe('Sidebar — Performance defaults anchor at the stored timezone', () =>
 });
 
 describe('Sidebar — Changelog link + new-updates badge', () => {
-  it('renders the Changelog link before Settings, with cursor-pointer', () => {
+  it('renders the Changelog link in the System group after Settings, with cursor-pointer', () => {
     const { container, root } = mountWith(<Sidebar />);
 
     const hrefs = Array.from(container.querySelectorAll('nav a')).map((a) =>
       a.getAttribute('href'),
     );
     expect(hrefs.indexOf('/changelog')).toBeGreaterThanOrEqual(0);
-    // Ordering, not adjacency — which is what this test's name has always
-    // claimed. The Docs link now sits between the two, and pinning `+ 1` would
-    // make every future nav insertion look like a regression in the changelog.
-    expect(hrefs.indexOf('/settings')).toBeGreaterThan(hrefs.indexOf('/changelog'));
+    // Ordering, not adjacency. The desk nav's SYSTEM group runs Settings →
+    // Changelog → Docs, so Changelog sits after Settings now; pinning `+ 1`
+    // would make every future nav insertion look like a regression here.
+    expect(hrefs.indexOf('/changelog')).toBeGreaterThan(hrefs.indexOf('/settings'));
 
     const link = Array.from(container.querySelectorAll('a')).find(
       (a) => a.getAttribute('href') === '/changelog',
@@ -338,6 +365,85 @@ describe('Sidebar — Changelog link + new-updates badge', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// The two chrome states (visual-redesign task 4): a 56px icon rail by default,
+// pinnable to the 208px labeled state, auto-collapsing while the drawer is
+// open. Accessible names never depend on the state — they are aria-labels.
+// ---------------------------------------------------------------------------
+
+describe('Sidebar — rail and expanded chrome states', () => {
+  it('unpinned renders the icon rail: no inline labels, aria-labels intact', () => {
+    pinState.pinned = false;
+    const { container, root } = mountWith(<Sidebar />);
+
+    const aside = container.querySelector('aside');
+    expect(aside?.className).toContain('w-14');
+
+    // No visible label text in the rail…
+    const dashboard = Array.from(container.querySelectorAll('a')).find(
+      (a) => a.getAttribute('href') === '/dashboard',
+    );
+    expect(dashboard?.textContent).toBe('');
+    // …but the accessible name and the hover label are both present.
+    expect(dashboard?.getAttribute('aria-label')).toBe('Dashboard');
+    expect(dashboard?.getAttribute('title')).toBe('Dashboard');
+
+    unmount(container, root);
+  });
+
+  it('pinned renders the labeled state: 208px, visible labels, group headings', () => {
+    pinState.pinned = true;
+    const { container, root } = mountWith(<Sidebar />);
+
+    const aside = container.querySelector('aside');
+    expect(aside?.className).toContain('w-52');
+
+    const dashboard = Array.from(container.querySelectorAll('a')).find(
+      (a) => a.getAttribute('href') === '/dashboard',
+    );
+    expect(dashboard?.textContent).toContain('Dashboard');
+    // No title tooltip while the label is visible.
+    expect(dashboard?.getAttribute('title')).toBeNull();
+
+    // The TRADE / REVIEW / SYSTEM group headings are in the DOM.
+    const text = container.querySelector('nav')?.textContent ?? '';
+    expect(text).toContain('Trade');
+    expect(text).toContain('Review');
+    expect(text).toContain('System');
+
+    unmount(container, root);
+  });
+
+  it('the pin control toggles the preference', () => {
+    pinState.pinned = false;
+    const { container, root } = mountWith(<Sidebar />);
+
+    const expand = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.getAttribute('aria-label') === 'Expand sidebar',
+    );
+    expect(expand).toBeDefined();
+    act(() => {
+      expand!.click();
+    });
+    expect(pinState.calls).toEqual([true]);
+
+    unmount(container, root);
+  });
+
+  it('auto-collapses to the rail while the drawer is open, even when pinned', () => {
+    pinState.pinned = true;
+    useDrawerStore.setState({ isOpen: true });
+    const { container, root } = mountWith(<Sidebar />);
+
+    const aside = container.querySelector('aside');
+    expect(aside?.className).toContain('w-14');
+    // The pin itself is untouched — collapse is derived, not written back.
+    expect(pinState.calls).toEqual([]);
+
+    unmount(container, root);
+  });
+});
+
 // jsdom computes no layout, so these assert the class contract that keeps the
 // rail pinned to the viewport instead of stretching to the height of <main> —
 // the arrangement that used to scroll the Log out button out of sight on long
@@ -373,7 +479,9 @@ describe('Sidebar — pinned to the viewport, not the page', () => {
       (b) => b.textContent === 'Log out',
     );
     expect(logout).toBeDefined();
-    expect(logout?.parentElement?.className).toContain('shrink-0');
+    // The footer wraps the session row in an inner flex div now; the
+    // uncompressible boundary is the closest shrink-0 ancestor.
+    expect(logout?.closest('.shrink-0')).not.toBeNull();
 
     unmount(container, root);
   });

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -1,24 +1,36 @@
 import { Link } from '@tanstack/react-router';
 import {
+  ArrowDownToLine,
+  BarChart3,
   BookOpen,
-  LineChart,
+  Calculator,
+  CreditCard,
+  Landmark,
+  LayoutDashboard,
+  List,
+  LogOut,
   Megaphone,
+  PanelLeftClose,
+  PanelLeftOpen,
   Receipt,
+  Settings,
   Shield,
-  Sigma,
   Sparkles,
-  Upload,
+  TrendingUp,
+  type LucideIcon,
 } from 'lucide-react';
-import { useState, useEffect } from 'react';
+import type { ReactNode } from 'react';
 
 import { ThemeToggle } from '@/components/layout/ThemeToggle';
 import { Button } from '@/components/ui/button';
 import { hasNewReleases, useChangelogReleases } from '@/features/changelog/hooks/useChangelog';
+import { useSidebarPin } from '@/features/onboarding/hooks/useSidebarPin';
 import { derivePresetRange } from '@/features/performance/utils/derivePresetRange';
 import { useAuth } from '@/hooks/useAuth';
 import { useUserTimezone } from '@/hooks/useUserTimezone';
 import { docsUrl } from '@/lib/docs';
 import { cn } from '@/lib/utils';
+import { useDrawerStore } from '@/stores/drawer.store';
 
 // Default search params for the Performance route. The route's
 // `validateSearch` requires `granularity`, `start`, and `end`; the sidebar
@@ -45,12 +57,73 @@ function buildPerformanceDefaults(tz: string): {
   return { granularity: range.granularity, start: range.start, end: range.end, tz };
 }
 
-const COLLAPSED_KEY = 'sidebar-collapsed';
+// The direction-B desk chrome: a 56px icon rail by default, pinnable to a
+// 208px labeled state. The pin is a per-user preference (useSidebarPin); the
+// side drawer opening auto-collapses the rail to icons and closing restores
+// the pin — derived (`pinned && !drawerOpen`), never juggled as state.
+const RAIL_WIDTH = 'w-14'; // 56px
+const EXPANDED_WIDTH = 'w-52'; // 208px
 
-const PERFORMANCE_NAV_CLASS = cn(
-  'cursor-pointer flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent',
-  '[&.active]:bg-primary/10 [&.active]:text-primary [&.active]:font-medium',
+// One nav item in either chrome state. The accessible name is ALWAYS the
+// aria-label — the rail state has no inline label at all (its hover label is
+// the native title tooltip; a styled flyout cannot escape the nav's scroll
+// container) — so the name is identical across both states.
+const ITEM_EXPANDED = cn(
+  'cursor-pointer flex items-center gap-2.5 rounded-md border-l-2 border-transparent px-2 py-1.5',
+  'text-sm font-medium text-muted-foreground hover:bg-accent hover:text-foreground',
+  '[&.active]:bg-secondary [&.active]:text-foreground [&.active]:border-primary [&.active]:rounded-l-none',
 );
+const ITEM_RAIL = cn(
+  'cursor-pointer relative grid h-[34px] w-[38px] place-items-center rounded-md',
+  'text-muted-foreground hover:bg-accent hover:text-foreground',
+  '[&.active]:bg-secondary [&.active]:text-foreground',
+  // The amber active tick, drawn just off the item's left edge (mock: 2px bar).
+  "[&.active]:before:absolute [&.active]:before:-left-[9px] [&.active]:before:top-2 [&.active]:before:bottom-2 [&.active]:before:w-0.5 [&.active]:before:bg-primary [&.active]:before:content-['']",
+);
+
+function itemClass(expanded: boolean): string {
+  return expanded ? ITEM_EXPANDED : ITEM_RAIL;
+}
+
+function ItemContent({
+  expanded,
+  label,
+  Icon,
+  badge,
+}: {
+  expanded: boolean;
+  label: string;
+  Icon: LucideIcon;
+  badge?: ReactNode;
+}) {
+  return (
+    <>
+      {/* The badge dot anchors to the icon, not the label — the rail state
+          renders no inline label at all. */}
+      <span className="relative">
+        <Icon className="h-4 w-4" aria-hidden="true" />
+        {badge}
+      </span>
+      {expanded && (
+        <span aria-hidden="true" className="truncate">
+          {label}
+        </span>
+      )}
+    </>
+  );
+}
+
+/** Mono uppercase group label (expanded) / hairline divider (rail). */
+function GroupLabel({ expanded, label }: { expanded: boolean; label: string }) {
+  if (!expanded) {
+    return <div aria-hidden="true" className="mx-auto my-2 w-[22px] border-t border-hairline" />;
+  }
+  return (
+    <div className="px-2 pb-1 pt-3 font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground/80">
+      {label}
+    </div>
+  );
+}
 
 export function Sidebar() {
   const { user, logout } = useAuth();
@@ -64,13 +137,18 @@ export function Sidebar() {
   // Badge data: error/loading mean no `data`, so the badge is simply absent
   // (REQ-5(a)(5)) — the hook's `retry: false` keeps failures quiet.
   const changelogReleases = useChangelogReleases();
-  const [collapsed, setCollapsed] = useState(() => {
-    return localStorage.getItem(COLLAPSED_KEY) === 'true';
-  });
+  const { pinned, setPinned } = useSidebarPin();
+  const drawerOpen = useDrawerStore((s) => s.isOpen);
 
-  useEffect(() => {
-    localStorage.setItem(COLLAPSED_KEY, String(collapsed));
-  }, [collapsed]);
+  // Auto-collapse while the drawer is open; the pin survives and the labeled
+  // state comes back on its own when the drawer closes.
+  const expanded = pinned && !drawerOpen;
+
+  const changelogBadge = hasNewReleases(changelogReleases.data) ? (
+    <span className="absolute -right-1 -top-1 h-2 w-2 rounded-full bg-primary">
+      <span className="sr-only">New updates available</span>
+    </span>
+  ) : undefined;
 
   return (
     // `sticky top-0 h-screen` decouples the rail from the page: as a plain flex
@@ -80,89 +158,117 @@ export function Sidebar() {
     // `align-items: stretch` from re-growing it.
     <aside
       className={cn(
-        'sticky top-0 flex h-screen flex-col border-r bg-card transition-[width] duration-200',
-        collapsed ? 'w-16' : 'w-60',
+        'sticky top-0 flex h-screen flex-col border-r border-hairline bg-card',
+        'transition-[width] duration-200 motion-reduce:duration-0',
+        expanded ? EXPANDED_WIDTH : RAIL_WIDTH,
       )}
     >
-      <div className="flex shrink-0 items-center justify-between border-b p-3">
-        {!collapsed && <span className="text-lg font-semibold">Tradr</span>}
-        <div className="flex items-center gap-1">
-          <ThemeToggle />
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            className="cursor-pointer"
-            onClick={() => setCollapsed((c) => !c)}
-            aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          >
-            {collapsed ? '»' : '«'}
-          </Button>
-        </div>
+      <div
+        className={cn(
+          'flex shrink-0 items-center py-3',
+          expanded ? 'justify-between px-3' : 'flex-col gap-1 px-0',
+        )}
+      >
+        {expanded ? (
+          <span className="flex items-baseline gap-1.5 text-base font-bold">
+            <span aria-hidden="true" className="text-xs text-primary">
+              ▴
+            </span>
+            Tradr
+          </span>
+        ) : (
+          <span aria-hidden="true" className="text-base text-primary">
+            ▴
+          </span>
+        )}
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="cursor-pointer text-muted-foreground"
+          onClick={() => setPinned(!pinned)}
+          aria-label={expanded ? 'Collapse sidebar' : 'Expand sidebar'}
+        >
+          {expanded ? (
+            <PanelLeftClose className="h-4 w-4" aria-hidden="true" />
+          ) : (
+            <PanelLeftOpen className="h-4 w-4" aria-hidden="true" />
+          )}
+        </Button>
       </div>
 
       {/* `min-h-0` is what lets this shrink below its content height (a flex
           child's default `min-height: auto` would otherwise push the footer
           off the bottom); `overflow-y-auto` then scrolls the links themselves
-          on a short viewport, leaving the footer pinned. */}
-      <nav className="min-h-0 flex-1 overflow-y-auto p-2">
+          on a short viewport, leaving the footer pinned. (It is also why the
+          rail's hover labels are native title tooltips — a styled flyout could
+          not escape this scroll container.) */}
+      <nav
+        className={cn(
+          'min-h-0 flex-1 overflow-y-auto py-1',
+          expanded ? 'px-2' : 'flex flex-col items-center gap-1 px-0',
+        )}
+      >
         <Link
           to="/dashboard"
-          className={cn(
-            'flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent',
-            '[&.active]:bg-primary/10 [&.active]:text-primary [&.active]:font-medium',
-          )}
+          aria-label="Dashboard"
+          title={expanded ? undefined : 'Dashboard'}
+          className={itemClass(expanded)}
         >
-          <span>▦</span>
-          {!collapsed && <span>Dashboard</span>}
+          <ItemContent expanded={expanded} label="Dashboard" Icon={LayoutDashboard} />
         </Link>
         <Link
           to="/advisor"
-          className={cn(
-            'cursor-pointer flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent',
-            '[&.active]:bg-primary/10 [&.active]:text-primary [&.active]:font-medium',
-          )}
+          aria-label="Advisor"
+          title={expanded ? undefined : 'Advisor'}
+          className={itemClass(expanded)}
         >
-          <Sparkles className="h-4 w-4" aria-hidden="true" />
-          {!collapsed && <span>Advisor</span>}
+          <ItemContent expanded={expanded} label="Advisor" Icon={Sparkles} />
         </Link>
+
+        <GroupLabel expanded={expanded} label="Trade" />
         <Link
           to="/positions"
-          className={cn(
-            'flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent',
-            '[&.active]:bg-primary/10 [&.active]:text-primary [&.active]:font-medium',
-          )}
+          aria-label="Positions"
+          title={expanded ? undefined : 'Positions'}
+          className={itemClass(expanded)}
         >
-          <span>◈</span>
-          {!collapsed && <span>Positions</span>}
-        </Link>
-        <Link
-          to="/import"
-          className={cn(
-            'cursor-pointer flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent',
-            '[&.active]:bg-primary/10 [&.active]:text-primary [&.active]:font-medium',
-          )}
-        >
-          <Upload className="h-4 w-4" aria-hidden="true" />
-          {!collapsed && <span>Import</span>}
+          <ItemContent expanded={expanded} label="Positions" Icon={TrendingUp} />
         </Link>
         <Link
           to="/calculator"
-          className={cn(
-            'cursor-pointer flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent',
-            '[&.active]:bg-primary/10 [&.active]:text-primary [&.active]:font-medium',
-          )}
+          aria-label="Calculator"
+          title={expanded ? undefined : 'Calculator'}
+          className={itemClass(expanded)}
         >
-          <span>∑</span>
-          {!collapsed && <span>Calculator</span>}
+          <ItemContent expanded={expanded} label="Calculator" Icon={Calculator} />
         </Link>
+        <Link
+          to="/options"
+          aria-label="Options"
+          title={expanded ? undefined : 'Options'}
+          className={itemClass(expanded)}
+        >
+          <ItemContent expanded={expanded} label="Options" Icon={List} />
+        </Link>
+        <Link
+          to="/import"
+          aria-label="Import"
+          title={expanded ? undefined : 'Import'}
+          className={itemClass(expanded)}
+        >
+          <ItemContent expanded={expanded} label="Import" Icon={ArrowDownToLine} />
+        </Link>
+
+        <GroupLabel expanded={expanded} label="Review" />
         {timezone ? (
           <Link
             to="/performance"
             search={() => buildPerformanceDefaults(timezone)}
-            className={PERFORMANCE_NAV_CLASS}
+            aria-label="Performance"
+            title={expanded ? undefined : 'Performance'}
+            className={itemClass(expanded)}
           >
-            <LineChart className="h-4 w-4" aria-hidden="true" />
-            {!collapsed && <span>Performance</span>}
+            <ItemContent expanded={expanded} label="Performance" Icon={BarChart3} />
           </Link>
         ) : (
           // `role` and `tabIndex` are what make the inert state perceivable:
@@ -174,71 +280,60 @@ export function Sidebar() {
           <span
             role="link"
             aria-disabled="true"
+            aria-label="Performance"
+            title={expanded ? undefined : 'Performance'}
             tabIndex={0}
-            className={cn(PERFORMANCE_NAV_CLASS, 'pointer-events-none opacity-50')}
+            className={cn(itemClass(expanded), 'pointer-events-none opacity-50')}
           >
-            <LineChart className="h-4 w-4" aria-hidden="true" />
-            {!collapsed && <span>Performance</span>}
+            <ItemContent expanded={expanded} label="Performance" Icon={BarChart3} />
           </span>
         )}
         <Link
-          to="/options"
-          className={cn(
-            'cursor-pointer flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent',
-            '[&.active]:bg-primary/10 [&.active]:text-primary [&.active]:font-medium',
-          )}
-        >
-          <Sigma className="h-4 w-4" aria-hidden="true" />
-          {!collapsed && <span>Options</span>}
-        </Link>
-        <Link
           to="/accounting/expenses"
-          className={cn(
-            'cursor-pointer flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent',
-            '[&.active]:bg-primary/10 [&.active]:text-primary [&.active]:font-medium',
-          )}
+          aria-label="Accounting"
+          title={expanded ? undefined : 'Accounting'}
+          className={itemClass(expanded)}
         >
-          <Receipt className="h-4 w-4" aria-hidden="true" />
-          {!collapsed && <span>Accounting</span>}
+          <ItemContent expanded={expanded} label="Accounting" Icon={Receipt} />
         </Link>
         <Link
           to="/accounts"
-          className={cn(
-            'flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent',
-            '[&.active]:bg-primary/10 [&.active]:text-primary [&.active]:font-medium',
-          )}
+          aria-label="Accounts"
+          title={expanded ? undefined : 'Accounts'}
+          className={itemClass(expanded)}
         >
-          <span>⊞</span>
-          {!collapsed && <span>Accounts</span>}
+          <ItemContent expanded={expanded} label="Accounts" Icon={CreditCard} />
         </Link>
         <Link
           to="/brokerages"
-          className={cn(
-            'cursor-pointer flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent',
-            '[&.active]:bg-primary/10 [&.active]:text-primary [&.active]:font-medium',
-          )}
+          aria-label="Brokerages"
+          title={expanded ? undefined : 'Brokerages'}
+          className={itemClass(expanded)}
         >
-          <span>⌂</span>
-          {!collapsed && <span>Brokerages</span>}
+          <ItemContent expanded={expanded} label="Brokerages" Icon={Landmark} />
+        </Link>
+
+        <GroupLabel expanded={expanded} label="System" />
+        <Link
+          to="/settings"
+          aria-label="Settings"
+          title={expanded ? undefined : 'Settings'}
+          className={itemClass(expanded)}
+        >
+          <ItemContent expanded={expanded} label="Settings" Icon={Settings} />
         </Link>
         <Link
           to="/changelog"
-          className={cn(
-            'cursor-pointer flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent',
-            '[&.active]:bg-primary/10 [&.active]:text-primary [&.active]:font-medium',
-          )}
+          aria-label="Changelog"
+          title={expanded ? undefined : 'Changelog'}
+          className={itemClass(expanded)}
         >
-          {/* The dot anchors to the icon (relative wrapper), not the label —
-              the collapsed w-16 rail hides all label <span>s. */}
-          <span className="relative">
-            <Megaphone className="h-4 w-4" aria-hidden="true" />
-            {hasNewReleases(changelogReleases.data) && (
-              <span className="absolute -right-1 -top-1 h-2 w-2 rounded-full bg-primary">
-                <span className="sr-only">New updates available</span>
-              </span>
-            )}
-          </span>
-          {!collapsed && <span>Changelog</span>}
+          <ItemContent
+            expanded={expanded}
+            label="Changelog"
+            Icon={Megaphone}
+            badge={changelogBadge}
+          />
         </Link>
         {/* The documentation lives on its own host, so this is an <a>, not a
             router <Link>. New tab: a reader following it is mid-task and should
@@ -247,50 +342,46 @@ export function Sidebar() {
           href={docsUrl('home')}
           target="_blank"
           rel="noreferrer"
-          title="Documentation"
-          className={cn(
-            'cursor-pointer flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent',
-          )}
+          aria-label="Docs"
+          className={itemClass(expanded)}
         >
-          <BookOpen className="h-4 w-4" aria-hidden="true" />
-          {!collapsed && <span>Docs</span>}
+          <ItemContent expanded={expanded} label="Docs" Icon={BookOpen} />
         </a>
-        <Link
-          to="/settings"
-          className={cn(
-            'cursor-pointer flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent',
-            '[&.active]:bg-primary/10 [&.active]:text-primary [&.active]:font-medium',
-          )}
-        >
-          <span>⚙</span>
-          {!collapsed && <span>Settings</span>}
-        </Link>
         {user?.isAdmin && (
           <Link
             to="/admin"
-            className={cn(
-              'cursor-pointer flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent',
-              '[&.active]:bg-primary/10 [&.active]:text-primary [&.active]:font-medium',
-            )}
+            aria-label="Admin"
+            title={expanded ? undefined : 'Admin'}
+            className={itemClass(expanded)}
           >
-            <Shield className="h-4 w-4" aria-hidden="true" />
-            {!collapsed && <span>Admin</span>}
+            <ItemContent expanded={expanded} label="Admin" Icon={Shield} />
           </Link>
         )}
       </nav>
 
-      <div className="shrink-0 border-t p-3">
-        {!collapsed && user && (
-          <p className="mb-2 truncate text-xs text-muted-foreground">{user.email}</p>
+      {/* Bottom cluster: theme + session. In the rail state everything is
+          icon-sized; the accessible names never change. */}
+      <div
+        className={cn(
+          'shrink-0 border-t border-hairline p-2',
+          expanded ? 'px-3 py-3' : 'flex flex-col items-center gap-1',
         )}
-        <Button
-          variant="ghost"
-          size={collapsed ? 'icon-sm' : 'sm'}
-          className="w-full cursor-pointer"
-          onClick={() => logout.mutate()}
-        >
-          {collapsed ? '⏻' : 'Log out'}
-        </Button>
+      >
+        {expanded && user && (
+          <p className="mb-2 truncate font-mono text-xs text-muted-foreground">{user.email}</p>
+        )}
+        <div className={cn('flex items-center', expanded ? 'justify-between' : 'flex-col gap-1')}>
+          <ThemeToggle />
+          <Button
+            variant="ghost"
+            size={expanded ? 'sm' : 'icon-sm'}
+            className="cursor-pointer text-muted-foreground"
+            onClick={() => logout.mutate()}
+            aria-label="Log out"
+          >
+            {expanded ? 'Log out' : <LogOut className="h-4 w-4" aria-hidden="true" />}
+          </Button>
+        </div>
       </div>
     </aside>
   );

--- a/apps/web/src/features/onboarding/hooks/useSidebarPin.test.ts
+++ b/apps/web/src/features/onboarding/hooks/useSidebarPin.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { OnboardingState } from '@tradr/shared';
+
+import { api } from '@/lib/api';
+
+import { LEGACY_COLLAPSED_KEY, SIDEBAR_PIN_MIRROR_KEY, useSidebarPin } from './useSidebarPin';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false, gcTime: 0 },
+    },
+  });
+}
+
+function wrapperFor(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: qc }, children);
+  };
+}
+
+/** Stub the preference GET (and PATCH echoing the merged state back). */
+function mockServer(preference: OnboardingState) {
+  const stored = { ...preference };
+  vi.spyOn(api, 'get').mockImplementation(() => Promise.resolve({ ...stored }));
+  const patchSpy = vi.spyOn(api, 'patch').mockImplementation((_path: string, body?: unknown) => {
+    Object.assign(stored, body as Partial<OnboardingState>);
+    return Promise.resolve({ ...stored });
+  });
+  return { patchSpy };
+}
+
+const BASE: OnboardingState = { status: 'pending', coachMarksSeen: [] };
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useSidebarPin', () => {
+  it('paints from the device mirror before the preference query lands', () => {
+    localStorage.setItem(SIDEBAR_PIN_MIRROR_KEY, 'true');
+    // A GET that never resolves reproduces the in-flight window.
+    vi.spyOn(api, 'get').mockImplementation(() => new Promise(() => {}));
+    vi.spyOn(api, 'patch').mockResolvedValue(BASE);
+
+    const { result } = renderHook(() => useSidebarPin(), {
+      wrapper: wrapperFor(makeQueryClient()),
+    });
+    expect(result.current.pinned).toBe(true);
+  });
+
+  it('lets the server record overwrite a stale mirror once it lands', async () => {
+    localStorage.setItem(SIDEBAR_PIN_MIRROR_KEY, 'true');
+    mockServer({ ...BASE, sidebarPinned: false });
+
+    const { result } = renderHook(() => useSidebarPin(), {
+      wrapper: wrapperFor(makeQueryClient()),
+    });
+    await waitFor(() => expect(result.current.pinned).toBe(false));
+    expect(localStorage.getItem(SIDEBAR_PIN_MIRROR_KEY)).toBe('false');
+  });
+
+  it('seeds the server once from the legacy sidebar-collapsed value, inverted', async () => {
+    // The old sidebar stored collapsed=true; the equivalent pin is false.
+    localStorage.setItem(LEGACY_COLLAPSED_KEY, 'true');
+    const { patchSpy } = mockServer(BASE);
+
+    const { result } = renderHook(() => useSidebarPin(), {
+      wrapper: wrapperFor(makeQueryClient()),
+    });
+    await waitFor(() =>
+      expect(patchSpy).toHaveBeenCalledWith('/users/me/onboarding', { sidebarPinned: false }),
+    );
+    expect(result.current.pinned).toBe(false);
+    // The legacy key is consumed — the seed can never run twice off it.
+    expect(localStorage.getItem(LEGACY_COLLAPSED_KEY)).toBeNull();
+  });
+
+  it('seeds pinned=true from a legacy expanded sidebar', async () => {
+    localStorage.setItem(LEGACY_COLLAPSED_KEY, 'false');
+    const { patchSpy } = mockServer(BASE);
+
+    const { result } = renderHook(() => useSidebarPin(), {
+      wrapper: wrapperFor(makeQueryClient()),
+    });
+    await waitFor(() =>
+      expect(patchSpy).toHaveBeenCalledWith('/users/me/onboarding', { sidebarPinned: true }),
+    );
+    expect(result.current.pinned).toBe(true);
+  });
+
+  it('does not write anything when neither the server nor a legacy value exists', async () => {
+    const { patchSpy } = mockServer(BASE);
+
+    const { result } = renderHook(() => useSidebarPin(), {
+      wrapper: wrapperFor(makeQueryClient()),
+    });
+    // Give the effect a beat to run after the query resolves.
+    await waitFor(() => expect(api.get).toHaveBeenCalled());
+    expect(result.current.pinned).toBe(false);
+    expect(patchSpy).not.toHaveBeenCalled();
+  });
+
+  it('setPinned updates the mirror and persists through the preference PATCH', async () => {
+    const { patchSpy } = mockServer(BASE);
+
+    const { result } = renderHook(() => useSidebarPin(), {
+      wrapper: wrapperFor(makeQueryClient()),
+    });
+    act(() => {
+      result.current.setPinned(true);
+    });
+    expect(result.current.pinned).toBe(true);
+    expect(localStorage.getItem(SIDEBAR_PIN_MIRROR_KEY)).toBe('true');
+    await waitFor(() =>
+      expect(patchSpy).toHaveBeenCalledWith('/users/me/onboarding', { sidebarPinned: true }),
+    );
+  });
+});

--- a/apps/web/src/features/onboarding/hooks/useSidebarPin.ts
+++ b/apps/web/src/features/onboarding/hooks/useSidebarPin.ts
@@ -1,0 +1,88 @@
+// useSidebarPin — the nav rail's pin preference (expanded vs icon rail).
+//
+// The server record (`users.onboarding.sidebarPinned`, via the ordinary
+// onboarding preference channel) is the source of truth: it is what makes the
+// pin survive re-login and follow the user across devices. localStorage keeps
+// a DEVICE MIRROR beside it, for one reason only: the preference read is a
+// round trip, and without a local first guess every page load would paint the
+// icon rail and then jump to the pinned width for pinned users. The mirror is
+// never authoritative — the server value overwrites it the moment the query
+// lands.
+//
+// SEEDING. The pre-redesign sidebar stored `sidebar-collapsed` in localStorage
+// and nowhere else. When the server has never seen a preference
+// (`sidebarPinned` absent) and that legacy key exists, its inverse is written
+// through the normal PATCH once, and the legacy key is removed — the one-time
+// migration the schema's "optional without a default" exists to allow.
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { useOnboardingPatch, useOnboardingQuery } from './useOnboarding';
+
+export const SIDEBAR_PIN_MIRROR_KEY = 'sidebar-pinned';
+export const LEGACY_COLLAPSED_KEY = 'sidebar-collapsed';
+
+function readMirror(): boolean {
+  try {
+    return localStorage.getItem(SIDEBAR_PIN_MIRROR_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function writeMirror(value: boolean): void {
+  try {
+    localStorage.setItem(SIDEBAR_PIN_MIRROR_KEY, String(value));
+  } catch {
+    /* private mode — the server record still persists the preference */
+  }
+}
+
+export function useSidebarPin(): { pinned: boolean; setPinned: (next: boolean) => void } {
+  const query = useOnboardingQuery();
+  const patch = useOnboardingPatch();
+  const patchMutate = patch.mutate;
+
+  const [pinned, setPinnedLocal] = useState<boolean>(readMirror);
+
+  useEffect(() => {
+    if (!query.data) return;
+    const server = query.data.sidebarPinned;
+    if (server !== undefined) {
+      // The server record wins; keep the device mirror in step with it.
+      setPinnedLocal(server);
+      writeMirror(server);
+      return;
+    }
+    // Never expressed server-side: seed once from the legacy localStorage key
+    // if the pre-redesign sidebar left one (`collapsed: true` ⇒ unpinned).
+    let legacy: string | null = null;
+    try {
+      legacy = localStorage.getItem(LEGACY_COLLAPSED_KEY);
+    } catch {
+      return;
+    }
+    if (legacy !== null) {
+      const seeded = legacy !== 'true';
+      setPinnedLocal(seeded);
+      writeMirror(seeded);
+      try {
+        localStorage.removeItem(LEGACY_COLLAPSED_KEY);
+      } catch {
+        /* ignore */
+      }
+      patchMutate({ sidebarPinned: seeded });
+    }
+  }, [query.data, patchMutate]);
+
+  const setPinned = useCallback(
+    (next: boolean) => {
+      setPinnedLocal(next);
+      writeMirror(next);
+      patchMutate({ sidebarPinned: next });
+    },
+    [patchMutate],
+  );
+
+  return { pinned, setPinned };
+}

--- a/e2e/tests/app-shell-fixture.spec.ts
+++ b/e2e/tests/app-shell-fixture.spec.ts
@@ -59,7 +59,7 @@ test.describe('mockAppShell', () => {
       // assertion — no list of endpoints to keep in step with the app here,
       // because the app itself decides what it asks for.
       await page.goto(url);
-      await expect(page.getByTestId('drawer-topbar')).toBeVisible();
+      await expect(page.getByTestId('drawer-toggle')).toBeVisible();
       // The shell paints well before it has finished asking for things — the
       // widgets fetch after their grid mounts. Without a wait the test can end
       // while the last requests are still in flight, and a backstop throw after
@@ -221,7 +221,7 @@ test.describe('mockAppShell', () => {
     await mockSession(page);
 
     await page.goto('/dashboard');
-    await expect(page.getByTestId('drawer-topbar')).toBeVisible();
+    await expect(page.getByTestId('drawer-toggle')).toBeVisible();
 
     // Stands in for the endpoint the fixture does not know about yet, asked for
     // late. `evaluate` returns as soon as the timer is set, so the request

--- a/e2e/tests/drawer.mobile.spec.ts
+++ b/e2e/tests/drawer.mobile.spec.ts
@@ -116,25 +116,28 @@ test.describe('drawer mobile', () => {
     await expect(page.getByTestId('side-drawer')).toHaveAttribute('data-state', 'closed');
 
     // 3) Body-scroll-lock with scroll restoration (per v4-6).
-    // Scroll the page to 250 BEFORE opening; assert the body lock captures
-    // the scroll offset and restores it on close.
-    await page.evaluate(() => window.scrollTo(0, 250));
+    // Scroll the page to 200 BEFORE opening; assert the body lock captures
+    // the scroll offset and restores it on close. (200, not 250: removing the
+    // old 48px drawer top bar shortened the page, and 250 now overshoots the
+    // maximum scroll offset at this viewport — the intent is any non-zero
+    // offset, captured and restored exactly.)
+    await page.evaluate(() => window.scrollTo(0, 200));
     // The lock reads scrollY at open-time, so the scroll must have settled.
-    await expect.poll(async () => page.evaluate(() => window.scrollY), { timeout: 2000 }).toBe(250);
+    await expect.poll(async () => page.evaluate(() => window.scrollY), { timeout: 2000 }).toBe(200);
 
     // Open via dispatchEvent (NOT .click()): the mobile DrawerToggle is inline
     // at the top of <main> (not sticky), so a real click would auto-scroll the
     // off-screen toggle into view and reset scrollY to 0 — the body lock would
-    // then capture 0 instead of 250. Dispatching the click fires the toggle's
+    // then capture 0 instead of 200. Dispatching the click fires the toggle's
     // onClick without moving the scroll position.
     await page.getByRole('button', { name: /open side drawer/i }).dispatchEvent('click');
     await expect(page.getByTestId('side-drawer')).toHaveAttribute('data-state', 'open');
     expect(await page.evaluate(() => document.body.style.position)).toBe('fixed');
-    expect(await page.evaluate(() => document.body.style.top)).toBe('-250px');
+    expect(await page.evaluate(() => document.body.style.top)).toBe('-200px');
 
     // Close drawer — body lock releases, browser restores scroll position.
     await page.keyboard.press('Escape');
     await expect(page.getByTestId('side-drawer')).toHaveAttribute('data-state', 'closed');
-    await expect.poll(async () => page.evaluate(() => window.scrollY), { timeout: 2000 }).toBe(250);
+    await expect.poll(async () => page.evaluate(() => window.scrollY), { timeout: 2000 }).toBe(200);
   });
 });

--- a/packages/shared/src/schemas/onboarding.test.ts
+++ b/packages/shared/src/schemas/onboarding.test.ts
@@ -80,6 +80,23 @@ describe('OnboardingStateSchema', () => {
     },
   );
 
+  it('omits sidebarPinned entirely when absent rather than defaulting it', () => {
+    // Absence is load-bearing: it means "never expressed", which is what lets
+    // the client seed the pin once from the legacy localStorage value without
+    // overwriting a choice made on another device.
+    const result = OnboardingStateSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.sidebarPinned).toBeUndefined();
+  });
+
+  it('round-trips sidebarPinned in both directions', () => {
+    for (const value of [true, false]) {
+      const result = OnboardingStateSchema.safeParse({ sidebarPinned: value });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.sidebarPinned).toBe(value);
+    }
+  });
+
   it('omits calculatorFirstUsedAt entirely when absent rather than nulling it', () => {
     const result = OnboardingStateSchema.safeParse({});
     expect(result.success).toBe(true);
@@ -128,6 +145,11 @@ describe('OnboardingPatchSchema', () => {
         .success,
     ).toBe(true);
     expect(OnboardingPatchSchema.safeParse({ coachMarkSeen: 'csv-import' }).success).toBe(true);
+    expect(OnboardingPatchSchema.safeParse({ sidebarPinned: false }).success).toBe(true);
+  });
+
+  it('rejects a non-boolean sidebarPinned', () => {
+    expect(OnboardingPatchSchema.safeParse({ sidebarPinned: 'true' }).success).toBe(false);
   });
 
   // The mirror image of the state schema above, and deliberately so: this

--- a/packages/shared/src/schemas/onboarding.ts
+++ b/packages/shared/src/schemas/onboarding.ts
@@ -1,8 +1,9 @@
 import { z } from 'zod';
 
 // Onboarding PREFERENCE state — whether the user has opted out of, dismissed
-// or finished the walkthrough, and which one-shot coach marks they have already
-// dismissed — stored as the `users.onboarding` jsonb column.
+// or finished the walkthrough, which one-shot coach marks they have already
+// dismissed, and whether the nav rail is pinned expanded — stored as the
+// `users.onboarding` jsonb column (the per-user UI-preference channel).
 //
 // PREFERENCE ONLY. Per-item checklist completion is NEVER stored here — it is
 // derived at read time from the user's real data (account count, position
@@ -55,6 +56,12 @@ export const OnboardingStateSchema = z.object({
   // Surface keys, treated as a set. Order is not meaningful and duplicates are
   // prevented by the server-side merge, not by the type.
   coachMarksSeen: z.array(z.string()).default([]),
+  // Whether the nav rail is pinned to its expanded (labeled) state. Optional
+  // WITHOUT a default, like `calculatorFirstUsedAt`: absence means the user
+  // has never expressed a preference, which is what lets the client seed it
+  // once from the pre-redesign `sidebar-collapsed` localStorage value without
+  // ever overwriting a choice made on another device.
+  sidebarPinned: z.boolean().optional(),
 });
 
 // The RESOLVED state: what every reader gets after parsing. Nothing is
@@ -101,10 +108,12 @@ export const OnboardingPatchSchema = z
     status: OnboardingStatusSchema.optional(),
     calculatorFirstUsedAt: z.string().datetime().optional(),
     coachMarkSeen: z.string().min(1).max(COACH_MARK_KEY_MAX_LENGTH).optional(),
+    sidebarPinned: z.boolean().optional(),
   })
   .strict()
   .refine((patch) => Object.keys(patch).length > 0, {
-    message: 'Provide at least one of status, calculatorFirstUsedAt or coachMarkSeen',
+    message:
+      'Provide at least one of status, calculatorFirstUsedAt, coachMarkSeen or sidebarPinned',
   });
 
 export type OnboardingPatch = z.infer<typeof OnboardingPatchSchema>;


### PR DESCRIPTION
Part of the app's visual redesign: the nav becomes a 56px icon rail, pinnable to a 208px labeled state with TRADE / REVIEW / SYSTEM groups. All icons unified on lucide; active items wear the secondary surface + a 2px amber tick; the theme toggle and Log out move to the rail's bottom cluster.

- **Pin persistence**: `sidebarPinned` joins the `users.onboarding` jsonb preference channel (schema + strict PATCH body + SQL scalar merge; swagger updated). Optional-without-default, so the client can seed it once from the legacy `sidebar-collapsed` localStorage value (inverted, key consumed) without ever overwriting a choice from another device. A localStorage mirror gives flash-free first paint; the server record is authoritative (`useSidebarPin`).
- **Drawer interplay**: opening the side drawer auto-collapses the rail; closing restores the pin — derived (`pinned && !drawerOpen`), never written back.
- **Top bar removed**: the 48px bar that existed only to hold the drawer toggle is gone. `DrawerToggle` floats fixed top-right with the same aria contract and focus-return ref (a shared page header will give it a proper slot next).
- **A11y**: accessible names are aria-labels, identical in both chrome states; the rail's hover labels are native `title` tooltips; the inert Performance item keeps its focusable-disabled pattern.

**Tests**: layout unit suites repaired + new rail/pin/auto-collapse coverage; `useSidebarPin` suite (mirror, server-wins, legacy seeding both directions, no-write case); shared schema + API merge coverage for `sidebarPinned`; `drawer-topbar` testid → `drawer-toggle`; drawer.mobile scroll-restore offset 250→200 (the page is shorter without the bar). Local runs green: all four design gates, lint, check-types, and the app-shell-fixture / admin-platform / visual-design-parity / dashboard / drawer / drawer.mobile / user-onboarding / changelog e2e suites.