### PR TITLE
feat(web): desk page-header grammar; deep-link-safe /performance

### DIFF
--- a/apps/web/src/components/layout/PageHeader.test.tsx
+++ b/apps/web/src/components/layout/PageHeader.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { PageHeader, ScopeChip } from './PageHeader';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('PageHeader', () => {
+  it('renders the page name as the h1 with the mark hidden from the name', () => {
+    render(<PageHeader page="Positions" />);
+    // The ▴ is aria-hidden decoration; lowercase is CSS-only, so the
+    // accessible name stays the properly-cased label.
+    const heading = screen.getByRole('heading', { level: 1, name: 'Positions' });
+    expect(heading.textContent).toContain('▴');
+    expect(heading.className).toContain('lowercase');
+  });
+
+  it('renders chips beside the heading and the right cluster when given', () => {
+    render(
+      <PageHeader
+        page="Positions"
+        chips={<ScopeChip>all accounts</ScopeChip>}
+        right={<span>110 total</span>}
+      />,
+    );
+    expect(screen.getByText('all accounts')).toBeDefined();
+    expect(screen.getByText('110 total')).toBeDefined();
+  });
+
+  it('omits the right cluster entirely when nothing is passed', () => {
+    const { container } = render(<PageHeader page="Settings" />);
+    expect(container.querySelectorAll('header > div')).toHaveLength(1);
+  });
+});
+
+describe('ScopeChip', () => {
+  it('is a real button with cursor-pointer when interactive', () => {
+    const onClick = vi.fn();
+    render(
+      <ScopeChip onClick={onClick} aria-label="Change account scope">
+        all accounts ▾
+      </ScopeChip>,
+    );
+    const chip = screen.getByRole('button', { name: 'Change account scope' });
+    expect(chip.className).toContain('cursor-pointer');
+    chip.click();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a static span when not interactive', () => {
+    render(<ScopeChip>USD</ScopeChip>);
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.getByText('USD').tagName).toBe('SPAN');
+  });
+});

--- a/apps/web/src/components/layout/PageHeader.tsx
+++ b/apps/web/src/components/layout/PageHeader.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from 'react';
+
+import { cn } from '@/lib/utils';
+
+// The desk page-header grammar (visual-redesign 2.3): a mono `▴ page-name`
+// strip that replaces the old shouting h1 rows. The name renders lowercase
+// (CSS) over a properly-cased label so the accessible name stays natural.
+//
+// `chips` holds scope pickers BOUND TO EXISTING filters/settings only — the
+// header never grows its own backend scoping. `right` is the strip's trailing
+// cluster (page stats, actions).
+export function PageHeader({
+  page,
+  chips,
+  right,
+  className,
+}: {
+  /** Properly-cased page name ("Positions"); rendered lowercase. */
+  page: string;
+  /** Scope chips bound to the page's own existing filters/settings. */
+  chips?: ReactNode;
+  /** Trailing cluster: counts, stats, or the page's primary action. */
+  right?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <header
+      className={cn(
+        'mb-4 flex flex-wrap items-center justify-between gap-x-4 gap-y-2',
+        'border-b border-hairline pb-2.5',
+        className,
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-2.5">
+        <h1 className="flex items-baseline gap-1.5 font-mono text-sm font-semibold lowercase">
+          <span aria-hidden="true" className="text-primary">
+            ▴
+          </span>
+          {page}
+        </h1>
+        {chips}
+      </div>
+      {right != null && (
+        <div className="flex items-center gap-3 font-mono text-xs text-muted-foreground">
+          {right}
+        </div>
+      )}
+    </header>
+  );
+}
+
+// A chip-shaped scope control. Interactive when `onClick` is given (a real
+// <button>, pointer cursor per CLAUDE.md); otherwise a static display chip.
+export function ScopeChip({
+  children,
+  onClick,
+  className,
+  'aria-label': ariaLabel,
+}: {
+  children: ReactNode;
+  onClick?: () => void;
+  className?: string;
+  'aria-label'?: string;
+}) {
+  const look = cn(
+    'inline-flex items-center gap-1.5 rounded-full border border-hairline px-2.5 py-0.5',
+    'font-mono text-xs text-muted-foreground',
+    className,
+  );
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label={ariaLabel}
+        className={cn(look, 'cursor-pointer hover:border-border hover:text-foreground')}
+      >
+        {children}
+      </button>
+    );
+  }
+  return <span className={look}>{children}</span>;
+}

--- a/apps/web/src/components/layout/Sidebar.test.tsx
+++ b/apps/web/src/components/layout/Sidebar.test.tsx
@@ -49,13 +49,6 @@ vi.mock('@tanstack/react-router', () => ({
   },
 }));
 
-// The stored reporting timezone. The real hook is a useQuery and would throw
-// without a provider; `value: undefined` reproduces the in-flight window.
-const timezoneState = vi.hoisted(() => ({ value: undefined as string | undefined }));
-vi.mock('@/hooks/useUserTimezone', () => ({
-  useUserTimezone: () => timezoneState.value,
-}));
-
 // useAuth pulls in TanStack Query + Router internals; stub it with a static
 // shape so the sidebar mounts standalone.
 vi.mock('@/hooks/useAuth', () => ({
@@ -132,7 +125,6 @@ beforeEach(() => {
   linkSearch.clear();
   localStorage.clear();
   changelogState.result = { data: undefined, isError: false };
-  timezoneState.value = 'Europe/Berlin';
   pinState.pinned = true;
   pinState.calls = [];
   useDrawerStore.setState({ isOpen: false });
@@ -238,69 +230,24 @@ describe('Sidebar — Performance link', () => {
 });
 
 // ---------------------------------------------------------------------------
-// The default performance window is anchored at the user's STORED reporting
-// timezone, never at the browser's: a per-device guess would hand the same user
-// a different window — and different figures inside it — on every machine.
+// The Performance route derives its own monthly-preset defaults at the route
+// boundary now (visual-redesign 2.4), so the nav item is a PLAIN link: no
+// seeded search window, no inert state while the stored timezone loads.
 // ---------------------------------------------------------------------------
 
-describe('Sidebar — Performance defaults anchor at the stored timezone', () => {
-  it('seeds the search params with the stored zone', () => {
-    timezoneState.value = 'Asia/Tokyo';
+describe('Sidebar — Performance link is plain', () => {
+  it('seeds no search params', () => {
     const { container, root } = mountWith(<Sidebar />);
 
-    const search = linkSearch.get('/performance');
-    expect(typeof search).toBe('function');
-    const params = (
-      search as () => { granularity: string; start: string; end: string; tz: string }
-    )();
-
-    expect(params.tz).toBe('Asia/Tokyo');
-    // The rest of the monthly preset still comes through unchanged.
-    expect(params.granularity).toBe('month');
-    expect(params.start).toMatch(/^\d{4}-\d{2}-\d{2}T/);
-    expect(params.end).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(linkSearch.get('/performance')).toBeUndefined();
 
     unmount(container, root);
   });
 
-  it('derives a different window for a different stored zone', () => {
-    timezoneState.value = 'Pacific/Kiritimati';
-    const first = mountWith(<Sidebar />);
-    const kiritimati = (linkSearch.get('/performance') as () => { start: string })();
-    unmount(first.container, first.root);
-
-    timezoneState.value = 'Pacific/Midway';
-    const second = mountWith(<Sidebar />);
-    const midway = (linkSearch.get('/performance') as () => { start: string })();
-    unmount(second.container, second.root);
-
-    // +14 vs -11 puts the month boundaries on different UTC instants — proof
-    // the zone actually reaches `derivePresetRange` rather than being ignored.
-    expect(kiritimati.start).not.toBe(midway.start);
-  });
-
-  it('renders an inert Performance item while the stored zone is in flight', () => {
-    timezoneState.value = undefined;
+  it('renders no inert placeholder — the link is always navigable', () => {
     const { container, root } = mountWith(<Sidebar />);
 
-    // No destination exists yet, so there must be no navigable link…
-    const performanceLink = Array.from(container.querySelectorAll('a')).find(
-      (a) => a.getAttribute('href') === '/performance',
-    );
-    expect(performanceLink).toBeUndefined();
-    expect(linkSearch.has('/performance')).toBe(false);
-
-    // …but the nav item stays in place so the rail does not reflow.
-    const inert = container.querySelector('nav span[aria-disabled="true"]');
-    expect(inert).not.toBeNull();
-    expect(inert?.textContent).toContain('Performance');
-
-    // The inert state has to be perceivable and reachable, not just visually
-    // dimmed: `aria-disabled` on a role-less span is announced to nobody, and
-    // with no tab stop a keyboard user skips the item without learning it
-    // exists.
-    expect(inert?.getAttribute('role')).toBe('link');
-    expect(inert?.getAttribute('tabindex')).toBe('0');
+    expect(container.querySelector('nav span[aria-disabled="true"]')).toBeNull();
 
     unmount(container, root);
   });

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -25,37 +25,10 @@ import { ThemeToggle } from '@/components/layout/ThemeToggle';
 import { Button } from '@/components/ui/button';
 import { hasNewReleases, useChangelogReleases } from '@/features/changelog/hooks/useChangelog';
 import { useSidebarPin } from '@/features/onboarding/hooks/useSidebarPin';
-import { derivePresetRange } from '@/features/performance/utils/derivePresetRange';
 import { useAuth } from '@/hooks/useAuth';
-import { useUserTimezone } from '@/hooks/useUserTimezone';
 import { docsUrl } from '@/lib/docs';
 import { cn } from '@/lib/utils';
 import { useDrawerStore } from '@/stores/drawer.store';
-
-// Default search params for the Performance route. The route's
-// `validateSearch` requires `granularity`, `start`, and `end`; the sidebar
-// is the entry point so it has to seed sensible defaults. We use the
-// `monthly` preset (12m window) anchored at the user's STORED reporting
-// timezone.
-//
-// `tz` is a parameter rather than something this function derives: it comes
-// from `useUserTimezone()`, and a hook cannot be read from module scope. The
-// caller reads it inside the component and passes it down.
-function buildPerformanceDefaults(tz: string): {
-  granularity: 'day' | 'week' | 'month' | 'year';
-  start: string;
-  end: string;
-  tz: string;
-} {
-  const range = derivePresetRange(
-    'monthly',
-    { earliestClosedAt: null, mostRecentClosedAt: null, totalClosedPositions: 0 },
-    new Date(),
-    tz,
-    0,
-  );
-  return { granularity: range.granularity, start: range.start, end: range.end, tz };
-}
 
 // The direction-B desk chrome: a 56px icon rail by default, pinnable to a
 // 208px labeled state. The pin is a per-user preference (useSidebarPin); the
@@ -127,13 +100,6 @@ function GroupLabel({ expanded, label }: { expanded: boolean; label: string }) {
 
 export function Sidebar() {
   const { user, logout } = useAuth();
-  // The stored reporting timezone anchors the Performance route's default
-  // window. `undefined` until the preference query settles — and unlike the
-  // widgets there is no query here to disable, only a destination to seed, so
-  // the item is inert until there is a correct destination. Linking with the
-  // browser's zone (or a client-side 'UTC') is exactly the per-device bucketing
-  // the stored preference exists to replace.
-  const timezone = useUserTimezone();
   // Badge data: error/loading mean no `data`, so the badge is simply absent
   // (REQ-5(a)(5)) — the hook's `retry: false` keeps failures quiet.
   const changelogReleases = useChangelogReleases();
@@ -260,34 +226,17 @@ export function Sidebar() {
         </Link>
 
         <GroupLabel expanded={expanded} label="Review" />
-        {timezone ? (
-          <Link
-            to="/performance"
-            search={() => buildPerformanceDefaults(timezone)}
-            aria-label="Performance"
-            title={expanded ? undefined : 'Performance'}
-            className={itemClass(expanded)}
-          >
-            <ItemContent expanded={expanded} label="Performance" Icon={BarChart3} />
-          </Link>
-        ) : (
-          // `role` and `tabIndex` are what make the inert state perceivable:
-          // `aria-disabled` on a bare <span> is announced to nobody, and
-          // without a tab stop a keyboard user skips the item entirely and
-          // never learns it is there. Focusable-but-disabled (rather than
-          // removed from the tab order) is the pattern that keeps the nav's
-          // tab sequence stable across the in-flight window.
-          <span
-            role="link"
-            aria-disabled="true"
-            aria-label="Performance"
-            title={expanded ? undefined : 'Performance'}
-            tabIndex={0}
-            className={cn(itemClass(expanded), 'pointer-events-none opacity-50')}
-          >
-            <ItemContent expanded={expanded} label="Performance" Icon={BarChart3} />
-          </span>
-        )}
+        {/* A plain link: the Performance route derives its own monthly-preset
+            defaults at the boundary now, so the nav no longer seeds a search
+            window or sits inert while the stored timezone loads. */}
+        <Link
+          to="/performance"
+          aria-label="Performance"
+          title={expanded ? undefined : 'Performance'}
+          className={itemClass(expanded)}
+        >
+          <ItemContent expanded={expanded} label="Performance" Icon={BarChart3} />
+        </Link>
         <Link
           to="/accounting/expenses"
           aria-label="Accounting"

--- a/apps/web/src/features/accounting/components/ExchangeRatesPage.tsx
+++ b/apps/web/src/features/accounting/components/ExchangeRatesPage.tsx
@@ -10,6 +10,7 @@ import {
   type PreviewRateChangeResponse,
 } from '@tradr/shared/schemas/accounting';
 
+import { PageHeader } from '@/components/layout/PageHeader';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -168,8 +169,8 @@ export function ExchangeRatesPage({ initialBase, initialQuote }: ExchangeRatesPa
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold">Exchange Rates</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
+        <PageHeader page="Exchange Rates" className="mb-2" />
+        <p className="text-sm text-muted-foreground">
           Manage the rates used to convert account balances into your display currency.
         </p>
       </div>

--- a/apps/web/src/features/accounts/components/AccountList.tsx
+++ b/apps/web/src/features/accounts/components/AccountList.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import type { Account } from '@tradr/shared';
 
+import { PageHeader } from '@/components/layout/PageHeader';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import {
   AlertDialog,
@@ -92,18 +93,17 @@ export function AccountList() {
 
   return (
     <>
-      <div className="mb-4 flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Accounts</h1>
-        {/* The walkthrough's account set opens here, so this button is its first
-            step's anchor — the same `data-tour` contract the positions list and
-            the account dialog already use. It is the one control that starts a
-            second account, and unlike the dashboard's welcome screen it is on
-            this page for every user, which is what lets that set run more than
-            once. */}
-        <Button className="cursor-pointer" data-tour="account-new" onClick={beginCreate}>
-          New Account
-        </Button>
-      </div>
+      {/* The walkthrough's account set opens here, so the New Account button is
+          its first step's anchor — the same `data-tour` contract the positions
+          list and the account dialog already use. */}
+      <PageHeader
+        page="Accounts"
+        right={
+          <Button className="cursor-pointer" data-tour="account-new" onClick={beginCreate}>
+            New Account
+          </Button>
+        }
+      />
 
       {atCap && (
         <Alert

--- a/apps/web/src/features/admin/components/AdminPage.tsx
+++ b/apps/web/src/features/admin/components/AdminPage.tsx
@@ -13,6 +13,7 @@ import { Link } from '@tanstack/react-router';
 import { ShieldOff } from 'lucide-react';
 
 import { EmptyState } from '@/components/EmptyState';
+import { PageHeader } from '@/components/layout/PageHeader';
 import { useAuth } from '@/hooks/useAuth';
 
 import { useAdminStats } from '../hooks/useAdminStats';
@@ -53,6 +54,7 @@ export function AdminPage() {
 
   return (
     <div className="space-y-8">
+      <PageHeader page="Admin" className="mb-0" />
       <section aria-labelledby="admin-stats-heading">
         <h2 id="admin-stats-heading" className="mb-4 text-lg font-semibold">
           Stats

--- a/apps/web/src/features/advisor/pages/AdvisorPage.tsx
+++ b/apps/web/src/features/advisor/pages/AdvisorPage.tsx
@@ -229,8 +229,12 @@ export function AdvisorPage({ conversationId, isNew = false }: AdvisorPageProps)
         >
           <PanelLeft className="size-4" />
         </Button>
-        <h1 className="flex items-center gap-2 text-lg font-medium">
-          <Sparkles className="size-5" /> Advisor
+        {/* The desk header grammar (task 8 re-skins the rest of this row). */}
+        <h1 className="flex items-baseline gap-1.5 font-mono text-sm font-semibold lowercase">
+          <span aria-hidden="true" className="text-primary">
+            ▴
+          </span>
+          Advisor
         </h1>
         <Button
           type="button"

--- a/apps/web/src/features/brokerages/components/BrokerageList.tsx
+++ b/apps/web/src/features/brokerages/components/BrokerageList.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import type { Brokerage } from '@tradr/shared';
 
+import { PageHeader } from '@/components/layout/PageHeader';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -60,18 +61,20 @@ export function BrokerageList() {
 
   return (
     <>
-      <div className="mb-4 flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Brokerages</h1>
-        <Button
-          className="cursor-pointer"
-          onClick={() => {
-            setEditBrokerage(null);
-            setDialogOpen(true);
-          }}
-        >
-          New Brokerage
-        </Button>
-      </div>
+      <PageHeader
+        page="Brokerages"
+        right={
+          <Button
+            className="cursor-pointer"
+            onClick={() => {
+              setEditBrokerage(null);
+              setDialogOpen(true);
+            }}
+          >
+            New Brokerage
+          </Button>
+        }
+      />
 
       {!brokerages?.length ? (
         <div className="py-12 text-center text-muted-foreground">

--- a/apps/web/src/features/calculator/components/CalculatorPage.tsx
+++ b/apps/web/src/features/calculator/components/CalculatorPage.tsx
@@ -1,10 +1,12 @@
+import { PageHeader } from '@/components/layout/PageHeader';
+
 import { CalculatorForm } from './CalculatorForm';
 
 export function CalculatorPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold">Trade Calculator</h1>
+        <PageHeader page="Trade Calculator" className="mb-2" />
         <p className="text-sm text-muted-foreground">
           Plan position size and risk/reward before placing a trade.
         </p>

--- a/apps/web/src/features/changelog/pages/ChangelogPage.tsx
+++ b/apps/web/src/features/changelog/pages/ChangelogPage.tsx
@@ -8,6 +8,7 @@
 import { useEffect, useRef } from 'react';
 
 import { EmptyState } from '@/components/EmptyState';
+import { PageHeader } from '@/components/layout/PageHeader';
 import { Skeleton } from '@/components/ui/skeleton';
 
 import { ReleaseCard } from '../components/ReleaseCard';
@@ -77,7 +78,7 @@ export function ChangelogPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-semibold">Changelog</h1>
+      <PageHeader page="Changelog" />
       {body}
     </div>
   );

--- a/apps/web/src/features/csv-import/components/ImportPage.tsx
+++ b/apps/web/src/features/csv-import/components/ImportPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import type { CsvPreviewRequest, RowShape } from '@tradr/shared';
 
+import { PageHeader } from '@/components/layout/PageHeader';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -123,20 +124,23 @@ export function ImportPage() {
   return (
     <div className="mx-auto max-w-3xl space-y-6 p-6">
       <div>
-        <div className="flex items-center gap-2">
-          <h1 className="text-2xl font-semibold">Import trades from CSV</h1>
-          {/* The coach mark is gated on the SAME figure the disclosure
-              below is: a user whose plan's lifetime CSV imports are all spent
-              cannot import, and `csv-import.service.ts` refuses the commit, so
-              introducing the feature to them would be pointing at a door that
-              is shut. `undefined` while the tier read is in flight counts as
-              unavailable rather than available — better a mark one round trip
-              late than one that appears and is then withdrawn. */}
-          <CoachMark
-            surface="csv-import"
-            available={tierState !== undefined && csvRemaining !== 0}
-          />
-        </div>
+        {/* The coach mark is gated on the SAME figure the disclosure below
+            is: a user whose plan's lifetime CSV imports are all spent cannot
+            import, and `csv-import.service.ts` refuses the commit, so
+            introducing the feature to them would be pointing at a door that is
+            shut. `undefined` while the tier read is in flight counts as
+            unavailable rather than available — better a mark one round trip
+            late than one that appears and is then withdrawn. */}
+        <PageHeader
+          page="Import trades from CSV"
+          className="mb-2"
+          chips={
+            <CoachMark
+              surface="csv-import"
+              available={tierState !== undefined && csvRemaining !== 0}
+            />
+          }
+        />
         <p className="text-sm text-muted-foreground">
           Imports are additive — they add positions and fills to the target account. Fees come from
           the CSV unless no fees column is mapped.{' '}

--- a/apps/web/src/features/expenses/components/ExpensesPage.tsx
+++ b/apps/web/src/features/expenses/components/ExpensesPage.tsx
@@ -9,6 +9,7 @@ import {
 import type { Expense } from '@tradr/shared/schemas/expense';
 
 import { EmptyState } from '@/components/EmptyState';
+import { PageHeader } from '@/components/layout/PageHeader';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -130,13 +131,13 @@ export function ExpensesPage() {
 
   return (
     <div className="space-y-6">
+      <div>
+        <PageHeader page="Expenses" className="mb-2" />
+        <p className="text-sm text-muted-foreground">
+          Track deductible expenses for your tax summary.
+        </p>
+      </div>
       <div className="flex flex-wrap items-end justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold">Expenses</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Track deductible expenses for your tax summary.
-          </p>
-        </div>
         <div className="flex items-end gap-3">
           <div className="space-y-1">
             <label htmlFor="expense-year" className="text-xs text-muted-foreground">

--- a/apps/web/src/features/expenses/components/FeeRollupPage.tsx
+++ b/apps/web/src/features/expenses/components/FeeRollupPage.tsx
@@ -3,6 +3,7 @@ import { ReceiptText } from 'lucide-react';
 import { Fragment, useMemo, useState } from 'react';
 
 import { EmptyState } from '@/components/EmptyState';
+import { PageHeader } from '@/components/layout/PageHeader';
 import {
   Select,
   SelectContent,
@@ -96,13 +97,13 @@ export function FeeRollupPage() {
 
   return (
     <div className="space-y-6">
+      <div>
+        <PageHeader page="Fee Rollup" className="mb-2" />
+        <p className="text-sm text-muted-foreground">
+          Recorded fill fees aggregated by account and currency for the selected year.
+        </p>
+      </div>
       <div className="flex flex-wrap items-end justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold">Fee Rollup</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Recorded fill fees aggregated by account and currency for the selected year.
-          </p>
-        </div>
         <div className="flex items-end gap-3">
           <div className="space-y-1">
             <label htmlFor="fee-rollup-year" className="text-xs text-muted-foreground">

--- a/apps/web/src/features/expenses/components/TaxSummaryPage.tsx
+++ b/apps/web/src/features/expenses/components/TaxSummaryPage.tsx
@@ -8,6 +8,7 @@ import {
 import type { TaxJurisdiction } from '@tradr/shared/schemas/expense';
 
 import { EmptyState } from '@/components/EmptyState';
+import { PageHeader } from '@/components/layout/PageHeader';
 import {
   Accordion,
   AccordionContent,
@@ -132,13 +133,13 @@ export function TaxSummaryPage() {
 
   return (
     <div className="space-y-6">
+      <div>
+        <PageHeader page="Tax Summary" className="mb-2" />
+        <p className="text-sm text-muted-foreground">
+          Realised P&amp;L, tracked expenses, and flagged positions for the selected year.
+        </p>
+      </div>
       <div className="flex flex-wrap items-end justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold">Tax Summary</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Realised P&amp;L, tracked expenses, and flagged positions for the selected year.
-          </p>
-        </div>
         <div className="flex items-end gap-3">
           <div className="space-y-1">
             <label htmlFor="tax-summary-year" className="text-xs text-muted-foreground">

--- a/apps/web/src/features/options/components/OptionsPage.tsx
+++ b/apps/web/src/features/options/components/OptionsPage.tsx
@@ -1,3 +1,4 @@
+import { PageHeader } from '@/components/layout/PageHeader';
 import { CoachMark } from '@/features/onboarding/components/CoachMark';
 
 import { BlackScholesCard } from './BlackScholesCard';
@@ -8,16 +9,17 @@ export function OptionsPage() {
   return (
     <div className="space-y-6">
       <div>
-        <div className="flex items-center gap-2">
-          <h1 className="text-2xl font-bold">Options Tools</h1>
-          {/* No `available` gate, because there is no predicate to
-              consult: the Black-Scholes and OCC cards are pure client-side
-              computation and are present in every deployment. The chain viewer
-              IS gated (on the market-data key, which it reports as
-              `configured: false` and handles itself), which is why the copy
-              names only the two cards that are always there. */}
-          <CoachMark surface="options-tools" />
-        </div>
+        {/* No `available` gate on the coach mark, because there is no
+            predicate to consult: the Black-Scholes and OCC cards are pure
+            client-side computation and are present in every deployment. The
+            chain viewer IS gated (on the market-data key, which it reports as
+            `configured: false` and handles itself), which is why the copy
+            names only the two cards that are always there. */}
+        <PageHeader
+          page="Options Tools"
+          className="mb-2"
+          chips={<CoachMark surface="options-tools" />}
+        />
         <p className="text-sm text-muted-foreground">
           Price options with Black-Scholes, look up OCC option symbols, and view live chains.
         </p>

--- a/apps/web/src/features/performance/utils/buildPerformanceDefaults.ts
+++ b/apps/web/src/features/performance/utils/buildPerformanceDefaults.ts
@@ -1,0 +1,26 @@
+import { derivePresetRange } from './derivePresetRange';
+
+// Default search params for the Performance route: the `monthly` preset (12m
+// window) anchored at the user's STORED reporting timezone. Lived in the
+// Sidebar while the nav link had to seed a complete search; the route now
+// derives its own defaults at the boundary (visual-redesign 2.4), so this is
+// performance-feature code.
+//
+// `tz` is a parameter rather than something this function derives: it comes
+// from `useUserTimezone()`, and a hook cannot be read from module scope. The
+// caller reads it inside a component and passes it down.
+export function buildPerformanceDefaults(tz: string): {
+  granularity: 'day' | 'week' | 'month' | 'year';
+  start: string;
+  end: string;
+  tz: string;
+} {
+  const range = derivePresetRange(
+    'monthly',
+    { earliestClosedAt: null, mostRecentClosedAt: null, totalClosedPositions: 0 },
+    new Date(),
+    tz,
+    0,
+  );
+  return { granularity: range.granularity, start: range.start, end: range.end, tz };
+}

--- a/apps/web/src/features/positions/components/PositionList.tsx
+++ b/apps/web/src/features/positions/components/PositionList.tsx
@@ -1,6 +1,7 @@
 import { Link, useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 
+import { PageHeader } from '@/components/layout/PageHeader';
 import { Numeric } from '@/components/Numeric';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -57,32 +58,34 @@ export function PositionList() {
 
   return (
     <>
-      <div className="mb-4 flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Positions</h1>
-        {hasAccounts ? (
-          // `data-tour` is the walkthrough's anchor for the log-a-position
-          // step. Only on the enabled branch: a tour that reached this step has
-          // an account, and highlighting a disabled button would be a dead end.
-          <Button
-            data-tour="position-new"
-            className="cursor-pointer"
-            onClick={() => handleDialogOpenChange(true)}
-          >
-            New Position
-          </Button>
-        ) : (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span>
-                <Button className="cursor-pointer" disabled>
-                  New Position
-                </Button>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>Create an account first</TooltipContent>
-          </Tooltip>
-        )}
-      </div>
+      <PageHeader
+        page="Positions"
+        right={
+          hasAccounts ? (
+            // `data-tour` is the walkthrough's anchor for the log-a-position
+            // step. Only on the enabled branch: a tour that reached this step has
+            // an account, and highlighting a disabled button would be a dead end.
+            <Button
+              data-tour="position-new"
+              className="cursor-pointer"
+              onClick={() => handleDialogOpenChange(true)}
+            >
+              New Position
+            </Button>
+          ) : (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <Button className="cursor-pointer" disabled>
+                    New Position
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>Create an account first</TooltipContent>
+            </Tooltip>
+          )
+        }
+      />
 
       <Tabs value={statusFilter} onValueChange={setStatusFilter} className="mb-4">
         <TabsList>

--- a/apps/web/src/routes/_auth.performance.test.tsx
+++ b/apps/web/src/routes/_auth.performance.test.tsx
@@ -59,8 +59,11 @@ function buildResponse(): PerformanceResponse {
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const runLoader = (params: PerformanceQueryInput): Promise<unknown> =>
-  (Route.options as any).loader({ deps: { params } });
+const runLoader = (params: Partial<PerformanceQueryInput>): Promise<unknown> =>
+  (Route.options as any).loader({ deps: { search: params } });
+
+const runValidateSearch = (raw: Record<string, unknown>): unknown =>
+  ((Route.options as any).validateSearch as { parse: (v: unknown) => unknown }).parse(raw);
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 /** Every path `api.get` was called with, in order. */
@@ -116,5 +119,32 @@ describe('performance route loader — respects the rejected-timezone record', (
 
     expect(requestedPaths()).toHaveLength(1);
     expect(requestedPaths()[0]).toContain('tz=Europe%2FLondon');
+  });
+});
+
+// A bare `/performance` used to crash to the root error boundary: the strict
+// query schema requires granularity/start/end and TanStack Router turns a
+// validateSearch throw into a SearchParamError. The route is deep-link-safe
+// now — partial searches parse, garbage degrades to "absent", and the loader
+// prefetches nothing until the component derives a complete window.
+describe('performance route — deep-link-safe search (visual-redesign 2.4)', () => {
+  it('parses an empty search instead of throwing', () => {
+    expect(runValidateSearch({})).toEqual({});
+  });
+
+  it('degrades a mangled granularity to absent instead of crashing', () => {
+    expect(runValidateSearch({ granularity: 'fortnight' })).toEqual({});
+  });
+
+  it('keeps partial params that are usable', () => {
+    expect(runValidateSearch({ currency: 'USD' })).toEqual({ currency: 'USD' });
+  });
+
+  it('prefetches nothing for an incomplete window', async () => {
+    getMock.mockResolvedValue(buildResponse());
+
+    await runLoader({ currency: 'USD' });
+
+    expect(requestedPaths()).toHaveLength(0);
   });
 });

--- a/apps/web/src/routes/_auth.performance.tsx
+++ b/apps/web/src/routes/_auth.performance.tsx
@@ -1,13 +1,58 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useEffect } from 'react';
+import { z } from 'zod';
 
 import type { PerformanceQueryInput, PerformanceResponse } from '@tradr/shared';
-import { PerformanceQuerySchema } from '@tradr/shared/schemas/performance';
+import { GranularitySchema } from '@tradr/shared/schemas/performance';
 
+import { PageHeader } from '@/components/layout/PageHeader';
+import { Skeleton } from '@/components/ui/skeleton';
 import { PerformancePage } from '@/features/performance/components/PerformancePage';
+import { buildPerformanceDefaults } from '@/features/performance/utils/buildPerformanceDefaults';
+import { useUserTimezone } from '@/hooks/useUserTimezone';
 import { api } from '@/lib/api';
 import { isTimezoneRejected } from '@/lib/invalidTimezone';
 import { queryClient } from '@/lib/queryClient';
+
+// ---- Deep-link-safe search parsing -----------------------------------------
+// A bare `/performance` used to CRASH to the root error boundary: the strict
+// PerformanceQuerySchema requires granularity/start/end, and TanStack Router
+// turns a validateSearch throw into a SearchParamError. The route now accepts
+// a PARTIAL search — every field optional, and `.catch(undefined)` so even a
+// mangled value degrades to "absent" instead of a crash — and derives the
+// monthly-preset defaults at the boundary (anchored at the STORED reporting
+// timezone) when the window is incomplete. Garbage that still parses as a
+// string (a bad date) flows to the API, whose 400 lands in the page's own
+// banner stack rather than a generic error screen.
+const PerformanceSearchSchema = z.object({
+  granularity: GranularitySchema.optional().catch(undefined),
+  start: z.string().optional().catch(undefined),
+  end: z.string().optional().catch(undefined),
+  tz: z.string().optional().catch(undefined),
+  currency: z.string().optional().catch(undefined),
+});
+
+type PerformanceSearch = z.infer<typeof PerformanceSearchSchema>;
+
+/** The window is usable once all three required params are present. */
+function isComplete(search: PerformanceSearch): search is PerformanceSearch & {
+  granularity: NonNullable<PerformanceSearch['granularity']>;
+  start: string;
+  end: string;
+} {
+  return search.granularity !== undefined && search.start !== undefined && search.end !== undefined;
+}
+
+/** A complete search resolved to the shape the API + page consume. */
+function toParams(search: PerformanceSearch): PerformanceQueryInput {
+  return {
+    granularity: search.granularity!,
+    start: search.start!,
+    end: search.end!,
+    tz: search.tz ?? 'UTC',
+    ...(search.currency !== undefined ? { currency: search.currency } : {}),
+  };
+}
 
 // ---- Shared query options --------------------------------------------------
 // The component-side hook (`usePerformance`, Task 26) layers session-scoped
@@ -31,13 +76,17 @@ function buildPath(params: PerformanceQueryInput): string {
 }
 
 export const Route = createFileRoute('/_auth/performance')({
-  validateSearch: PerformanceQuerySchema,
+  validateSearch: PerformanceSearchSchema,
   // Re-trigger the loader whenever any search param changes so the prefetch
   // tracks the URL one-to-one. Without `loaderDeps`, TanStack Router would
   // skip subsequent loader calls for the same path.
-  loaderDeps: ({ search }) => ({ params: search }),
+  loaderDeps: ({ search }) => ({ search }),
   loader: async ({ deps }) => {
-    const params = deps.params as PerformanceQueryInput;
+    // An incomplete window has nothing to prefetch — the component is about
+    // to derive defaults and replace the URL, which re-runs this loader with
+    // the complete search.
+    if (!isComplete(deps.search)) return null;
+    const params = toParams(deps.search);
     // Best-effort prefetch. Errors are intentionally swallowed here so the
     // component's `usePerformance` hook owns error rendering (banner stack,
     // empty states). Throwing from the loader would bubble to the root error
@@ -56,13 +105,37 @@ export const Route = createFileRoute('/_auth/performance')({
 });
 
 function PerformanceRouteComponent() {
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  // The stored reporting timezone anchors the derived default window;
+  // `undefined` only while the preference query is in flight (on terminal
+  // failure the hook degrades to a browser-detected zone and says so).
+  const timezone = useUserTimezone();
+  const complete = isComplete(search);
+
+  useEffect(() => {
+    if (complete || timezone === undefined) return;
+    // Derive the monthly preset and REPLACE the bare URL so back does not
+    // return to the redirecting state. Anything usable in the partial search
+    // (a currency, an explicit tz) survives the merge.
+    void navigate({
+      search: {
+        ...buildPerformanceDefaults(timezone),
+        ...(search.tz !== undefined ? { tz: search.tz } : {}),
+        ...(search.currency !== undefined ? { currency: search.currency } : {}),
+      },
+      replace: true,
+    });
+  }, [complete, timezone, navigate, search.tz, search.currency]);
+
   // Snapshot the validated search params for the cleanup closure. We capture
   // here (not inside the cleanup) so that an in-flight effect-cleanup cancels
   // the *exact* params it was issued under, not whatever the URL has become
   // by the time the user navigates away.
-  const params = Route.useSearch() as PerformanceQueryInput;
+  const params = complete ? toParams(search) : null;
 
   useEffect(() => {
+    if (params === null) return;
     return () => {
       // `exact: true` is load-bearing — without it, this would cancel every
       // performance query (including ones the user hasn't navigated away
@@ -74,5 +147,18 @@ function PerformanceRouteComponent() {
     };
   }, [params]);
 
-  return <PerformancePage params={params} />;
+  return (
+    <>
+      <PageHeader page="Performance" />
+      {params !== null ? (
+        <PerformancePage params={params} />
+      ) : (
+        // The one-render window while defaults derive (or the zone loads).
+        <div data-testid="performance-page" className="space-y-4">
+          <Skeleton className="h-9 w-72" />
+          <Skeleton className="h-64 w-full" />
+        </div>
+      )}
+    </>
+  );
 }

--- a/apps/web/src/routes/_auth.settings.tsx
+++ b/apps/web/src/routes/_auth.settings.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link, Outlet, redirect, useLocation } from '@tanstack/react-router';
 import { Bot, CircleQuestionMark, Settings as SettingsIcon, User, Wallet } from 'lucide-react';
 
+import { PageHeader } from '@/components/layout/PageHeader';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 // Single composition point for the Settings shell. New tabs are added by
@@ -24,7 +25,7 @@ function SettingsLayout() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-semibold">Settings</h1>
+      <PageHeader page="Settings" className="mb-0" />
       <Tabs value={active} orientation="vertical" className="flex-row">
         <TabsList variant="line" className="shrink-0">
           {SETTINGS_TABS.map((tab) => {


### PR DESCRIPTION
Stacked on #66 (the rail). Second slice of the app's visual redesign.

- **PageHeader + ScopeChip**: the mono `▴ page-name` strip replaces every page's h1 row (Positions, Accounts, Brokerages, Calculator, Changelog, Options, Import, Expenses, Fee Rollup, Tax Summary, Exchange Rates, Settings, Admin, Advisor, Performance). Chips are a slot bound to existing filters/settings only — concrete pickers arrive with each surface's own re-skin. Heading NAMES stay verbatim: ten e2e suites pin them and the redesign changes the grammar, not the words.
- **/performance deep-link fix**: partial `validateSearch` with `.catch(undefined)` per field (garbage degrades to absent, never a SearchParamError), loader skips prefetch on an incomplete window, and the route derives the monthly preset anchored at the stored reporting timezone, replacing the URL. Performance gains its missing h1.
- **Sidebar simplification**: the Performance nav item is a plain link — the seeded search window and the inert-while-loading state are gone with the route now self-deriving.

**Verified locally**: check-types, lint, all four design gates; 600+ unit tests incl. new PageHeader/ScopeChip and route deep-link suites; e2e green across performance, performance-a11y, expenses-tax, csv-import, symbol-search-quotes, ledger-balances, option-position-entry, advisor-tools, changelog, visual-design-parity, admin-platform, dashboard, user-onboarding, drawer.