### PR TITLE
fix(web): make widget corner grips read as corner grips

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -220,6 +220,18 @@
   background-color: var(--color-primary);
   border-radius: var(--radius-md, 0.375rem);
 }
+/* gridstack stacks its own furniture with raw z-indexes — 100/101 on the resize
+   handles, 10000 on whatever is being dragged — which are numbers chosen
+   against a bare page, not against this app's `z-50` dialog overlay. Left in
+   the root stacking context they beat that overlay, so with
+   `alwaysShowResizeHandle` on, every handle on the board paints over an open
+   modal at full brightness while the widgets themselves dim underneath.
+   `isolation` scopes those numbers to the grid. The grid's own z-index stays
+   `auto`, so the whole board now passes under any portalled overlay, and the
+   handles still stack correctly against the widgets they belong to. */
+.grid-stack {
+  isolation: isolate;
+}
 /* Corner grips, not direction arrows.
    gridstack ships a double-headed arrow per corner, which reads as an
    instruction about which way the widget may move — six of them at once is
@@ -227,6 +239,10 @@
    strokes say "there is a grip here" and stop talking. The strokes run
    PARALLEL to the corner they sit in, so the texture points into the corner
    rather than across it.
+   `transform: none` is load-bearing: gridstack rotates each corner handle by
+   ±45deg to aim its own arrow, and that rotation would land these already
+   diagonal strokes upright — orthogonal to the corner, reading as anything but
+   a grip.
    The mask is a `data:` URI, which cannot read a CSS variable, so it is used
    as an alpha mask and painted through with the token colour. */
 .grid-stack > .grid-stack-item > .ui-resizable-nw,
@@ -236,18 +252,19 @@
   background-image: none;
   background-color: var(--color-muted-foreground);
   opacity: 0.55;
+  transform: none;
   -webkit-mask-repeat: no-repeat;
   mask-repeat: no-repeat;
   -webkit-mask-position: center;
   mask-position: center;
 }
-/* `╲` corners — top-left and bottom-right. */
+/* `╱` corners — top-left and bottom-right. */
 .grid-stack > .grid-stack-item > .ui-resizable-nw,
 .grid-stack > .grid-stack-item > .ui-resizable-se {
   -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" stroke="black" stroke-linecap="round" stroke-width="1.6" viewBox="0 0 20 20"><path d="M6 14 14 6M11 15l4-4"/></svg>');
   mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" stroke="black" stroke-linecap="round" stroke-width="1.6" viewBox="0 0 20 20"><path d="M6 14 14 6M11 15l4-4"/></svg>');
 }
-/* `╱` corners — top-right and bottom-left. */
+/* `╲` corners — top-right and bottom-left. */
 .grid-stack > .grid-stack-item > .ui-resizable-ne,
 .grid-stack > .grid-stack-item > .ui-resizable-sw {
   -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" stroke="black" stroke-linecap="round" stroke-width="1.6" viewBox="0 0 20 20"><path d="M6 6l8 8M5 11l4 4"/></svg>');


### PR DESCRIPTION
Two defects in the dashboard widget corner resize handles, both traced to gridstack's own stylesheet reaching past the custom styling that was layered on top of it.

## 1. The grips pointed the wrong way

gridstack rotates each corner handle by `±45deg` to aim its double-headed arrow glyph:

```css
.grid-stack-item > .ui-resizable-nw { transform: rotate(-45deg); }
.grid-stack-item > .ui-resizable-ne { transform: rotate(45deg); }
```

The custom grip strokes that replaced that arrow are already drawn diagonal in the mask, so the inherited rotation added a second 45° and landed them **upright** — orthogonal to the corner they mark. They read as a stray tick, not a corner grip.

Opting out with `transform: none` restores the intended angle. Each corner now brackets itself: `//` top-left, `\\` top-right, `\\` bottom-left, `//` bottom-right.

The two `╱` / `╲` comment labels above the mask rules also had the corners backwards; corrected in passing.

## 2. The handles painted over modals and the side drawer

gridstack stacks its furniture with raw z-indexes — `100`/`101` on the handles, `10000` on whatever is being dragged. Those are numbers chosen against a bare page, not against this app's `z-50` dialog overlay or the `z-30`/`z-40` side drawer.

Nothing between the grid and the root established a stacking context, so the handles won outright. With `alwaysShowResizeHandle: true`, that meant **every handle on the board sat over an open modal at full brightness** while the widgets themselves dimmed underneath.

`isolation: isolate` on `.grid-stack` scopes those numbers to the grid. The grid's own z-index stays `auto`, so the whole board passes under any portalled overlay, and handles still stack correctly against the widgets they belong to.

## Verification

Rendered the changed rules in a browser against the real `gridstack.css`, in both states:

- All four corners bracket their corner correctly after the `transform` fix.
- Under a `z-50` overlay the handles now dim with the widgets; toggling `isolation` back off reproduces the bright punch-through, confirming that declaration is what fixes it.
- `apps/web` dashboard unit tests: 82 passed.

Not run: the full app (a dev server from another checkout holds `:5173`, and the e2e config deliberately refuses to reuse it).

## Follow-up

`e2e/tests/visual-design-reference.spec.ts-snapshots/dashboard-{dark,light}.png` still show the old upright ticks. That capture is gated behind `VISUAL_REFERENCE_CAPTURE` and is not a CI gate, so nothing is red — worth a recapture on the next reference run.
