### PR TITLE
fix(web): show advisor turn feedback from send to reply

### DIFF
--- a/apps/web/src/features/advisor/components/Composer.tsx
+++ b/apps/web/src/features/advisor/components/Composer.tsx
@@ -19,7 +19,7 @@
 // button that opens a new conversation with the same draft pre-filled.
 
 import { Link } from '@tanstack/react-router';
-import { Paperclip, Send, X } from 'lucide-react';
+import { Loader2, Paperclip, Send, X } from 'lucide-react';
 import { useRef, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -79,6 +79,8 @@ export interface ComposerProps {
   visionEnabled: boolean;
   /** Disabled while a stream is in flight (REQ-1.6e) or no key is configured. */
   disabled?: boolean;
+  /** True while the submitted turn is in flight — the send button shows a spinner. */
+  pending?: boolean;
   /**
    * Error code from the most recent submission, surfaced by the parent.
    * `CONVERSATION_TOO_LONG` changes the composer's own rendering (REQ-1.15); the
@@ -167,6 +169,7 @@ export function Composer({
   defaultPersonaId,
   visionEnabled,
   disabled = false,
+  pending = false,
   errorCode,
   tierState,
   remedies,
@@ -535,11 +538,20 @@ export function Composer({
         <Button
           type="button"
           aria-label="Send message"
+          aria-busy={pending || undefined}
           disabled={!canSend}
           className="ml-auto cursor-pointer"
           onClick={submit}
         >
-          <Send className="size-4" />
+          {pending ? (
+            <Loader2
+              data-testid="send-spinner"
+              className="size-4 animate-spin"
+              aria-hidden="true"
+            />
+          ) : (
+            <Send className="size-4" />
+          )}
           Send
         </Button>
       </div>

--- a/apps/web/src/features/advisor/components/Transcript.tsx
+++ b/apps/web/src/features/advisor/components/Transcript.tsx
@@ -6,11 +6,23 @@
 // token append re-renders only this component, never the whole page, and never
 // on a sibling conversation's token.
 //
-// Handoff (design v4-9): while the store slice is `streaming`/`error`, or `done`
-// but the persisted message with the recorded `messageId` is not yet in the
-// query cache, the live store text is shown. Once the persisted assistant
-// message arrives, the persisted copy is rendered instead — no flash of empty
-// content during the persist-then-invalidate window.
+// Handoff (design v4-9): while the store slice is `pending`/`streaming`/`error`,
+// or `done` but the persisted message with the recorded `messageId` is not yet
+// in the query cache, the live store entry is shown. Once the persisted
+// assistant message arrives, the persisted copy is rendered instead — no flash
+// of empty content during the persist-then-invalidate window.
+//
+// The in-flight turn is shown as a PAIR: the user's own message (recorded in the
+// store at submit, so it appears the instant it is sent) followed by the
+// assistant bubble, which carries a thinking/responding indicator for as long
+// as the turn is in flight — before the first token, and through the silent
+// windows while tools run. Both hand off to the persisted copies together: the
+// server writes them in one transaction, so the assistant `messageId` landing
+// in the cache means the user message is there too.
+//
+// The transcript follows the stream: it scrolls its scroll container (the
+// parent element AdvisorPage wraps it in) to the end as content arrives, unless
+// the user has scrolled up to read something earlier.
 //
 // Per-part rendering (REQ-14.1, 14.5): assistant messages carry `text` /
 // `tool_call` / `tool_result` parts. We walk them IN ORDER — `text` →
@@ -20,6 +32,7 @@
 // renders its cards on reload (not an empty bubble), and streaming + reload use
 // the same components. User text is plain text — no Markdown.
 
+import { useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/shallow';
 
 import type {
@@ -33,7 +46,12 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { isApiCrossOrigin, resolveApiUrl } from '@/lib/api';
 
 import { useConversation } from '../hooks/useConversations';
-import { useStreamStore, type StreamState, type ToolActivity } from '../stores/stream.store';
+import {
+  useStreamStore,
+  type PendingUserMessage,
+  type StreamState,
+  type ToolActivity,
+} from '../stores/stream.store';
 
 import { MarkdownRenderer } from './MarkdownRenderer';
 import { GenericToolCard, safeStringify } from './tool-cards/GenericToolCard';
@@ -276,6 +294,56 @@ function StreamingToolAffordance({ tool }: { tool: ToolActivity }) {
   );
 }
 
+// Three-dot activity indicator for the in-flight assistant bubble. Announced
+// once via role=status; the dots themselves are decoration.
+function StreamActivity({ label }: { label: string }) {
+  return (
+    <div
+      data-testid="stream-activity"
+      role="status"
+      className="mt-1 flex items-center gap-2 text-sm text-muted-foreground"
+    >
+      <span aria-hidden="true" className="flex items-center gap-1">
+        <span className="size-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.3s]" />
+        <span className="size-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.15s]" />
+        <span className="size-1.5 animate-bounce rounded-full bg-current" />
+      </span>
+      {label}
+    </div>
+  );
+}
+
+// The user's message for the in-flight turn, rendered from the store until the
+// persisted copy takes over. Attachments are the submitted bytes, shown inline.
+function PendingUserBubble({ message }: { message: PendingUserMessage }) {
+  return (
+    <div className={ROW_USER}>
+      <div className={STACK}>
+        <span className={`${LABEL} text-left`}>Me</span>
+        <div
+          data-role="user"
+          data-testid="pending-user-message"
+          className={`${BUBBLE} ${BUBBLE_USER} whitespace-pre-wrap`}
+        >
+          {message.text}
+          {message.attachments.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-2">
+              {message.attachments.map((a, i) => (
+                <img
+                  key={i}
+                  src={`data:image/${a.format};base64,${a.dataBase64}`}
+                  alt="Attached image"
+                  className="max-h-48 max-w-full rounded-md"
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function Transcript({ conversationId, onRetry }: TranscriptProps) {
   const { data } = useConversation(conversationId);
   const messages = data?.messages ?? [];
@@ -289,17 +357,50 @@ export function Transcript({ conversationId, onRetry }: TranscriptProps) {
   const billingMode = useStreamStore(
     useShallow((s) => s.billingModeByConversation?.[conversationId]),
   );
+  const userMessage = useStreamStore(
+    useShallow((s) => s.userMessageByConversation?.[conversationId]),
+  );
 
   // Handoff: suppress the live store entry once the persisted assistant message
   // it represents is in the cache (matched by the done-recorded messageId).
   const persistedIds = new Set(messages.map((m) => m.id));
+  const inFlight = stream.kind === 'pending' || stream.kind === 'streaming';
   const showStreamEntry =
-    stream.kind === 'streaming' ||
+    inFlight ||
     stream.kind === 'error' ||
     (stream.kind === 'done' && !persistedIds.has(stream.messageId));
+  const streamText = stream.kind === 'idle' || stream.kind === 'pending' ? '' : stream.text;
+  const activityLabel =
+    streamText.length > 0
+      ? 'Responding…'
+      : tools.some((t) => t.status === 'pending')
+        ? 'Working…'
+        : 'Thinking…';
+
+  // Follow the stream. The scroll container is the parent AdvisorPage wraps the
+  // transcript in; `follow` turns off when the user scrolls up from the end and
+  // back on when they return to it. Runs on every change in what is rendered.
+  const rootRef = useRef<HTMLDivElement>(null);
+  const endRef = useRef<HTMLDivElement>(null);
+  const followRef = useRef(true);
+  useEffect(() => {
+    const scroller = rootRef.current?.parentElement;
+    if (!scroller) return;
+    const onScroll = () => {
+      followRef.current = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight < 80;
+    };
+    scroller.addEventListener('scroll', onScroll, { passive: true });
+    return () => scroller.removeEventListener('scroll', onScroll);
+  }, []);
+  const contentSignature = `${messages.length}:${stream.kind}:${streamText.length}:${tools.length}`;
+  useEffect(() => {
+    if (!followRef.current) return;
+    // jsdom has no scrollIntoView; the optional call keeps tests honest.
+    endRef.current?.scrollIntoView?.({ block: 'end' });
+  }, [contentSignature]);
 
   return (
-    <div data-testid="transcript" className="flex flex-col gap-4 p-4">
+    <div ref={rootRef} data-testid="transcript" className="flex flex-col gap-4 p-4">
       {messages.map((message) =>
         message.role === 'user' ? (
           <div key={message.id} className={ROW_USER}>
@@ -324,6 +425,8 @@ export function Transcript({ conversationId, onRetry }: TranscriptProps) {
         ),
       )}
 
+      {showStreamEntry && userMessage && <PendingUserBubble message={userMessage} />}
+
       {showStreamEntry && (
         <div className={ROW_ASSISTANT}>
           <div className={STACK}>
@@ -347,11 +450,17 @@ export function Transcript({ conversationId, onRetry }: TranscriptProps) {
                 <StreamingToolAffordance key={t.id} tool={t} />
               ))}
 
-              {stream.text.length > 0 && <MarkdownRenderer content={stream.text} />}
+              {streamText.length > 0 && <MarkdownRenderer content={streamText} />}
+
+              {inFlight && <StreamActivity label={activityLabel} />}
 
               {stream.kind === 'error' && (
                 <div data-testid="stream-error" className="mt-2 flex items-center gap-3">
-                  <span className="text-sm text-destructive">Response interrupted — retry?</span>
+                  <span className="text-sm text-destructive">
+                    {streamText.length > 0 || tools.length > 0
+                      ? 'Response interrupted — retry?'
+                      : 'No response — retry?'}
+                  </span>
                   <Button
                     type="button"
                     size="sm"
@@ -367,6 +476,8 @@ export function Transcript({ conversationId, onRetry }: TranscriptProps) {
           </div>
         </div>
       )}
+
+      <div ref={endRef} aria-hidden="true" />
     </div>
   );
 }

--- a/apps/web/src/features/advisor/components/__tests__/AdvisorPage.test.tsx
+++ b/apps/web/src/features/advisor/components/__tests__/AdvisorPage.test.tsx
@@ -92,6 +92,7 @@ vi.mock('../../hooks/useAdvisorStream', () => ({
 }));
 
 import { AdvisorPage } from '../../pages/AdvisorPage';
+import { NEW_CONVERSATION_ID, useStreamStore } from '../../stores/stream.store';
 
 // ---- Helpers --------------------------------------------------------------
 
@@ -376,5 +377,87 @@ describe('AdvisorPage', () => {
       );
       expect(tierInvalidations.length).toBe(1);
     });
+  });
+});
+
+describe('AdvisorPage — first-turn feedback', () => {
+  const sent = { clientMessageId: 'cm-1', text: 'first question', attachments: [] };
+
+  afterEach(() => {
+    useStreamStore.setState({
+      byConversation: {},
+      toolsByConversation: {},
+      billingModeByConversation: {},
+      userMessageByConversation: {},
+    });
+  });
+
+  it('mounts the transcript on the new pane the moment a first turn is in flight', async () => {
+    renderPage({ conversationId: null, isNew: true });
+    expect(screen.getByTestId('empty-state')).toBeTruthy();
+
+    act(() => useStreamStore.getState().start(NEW_CONVERSATION_ID, sent));
+
+    expect(await screen.findByTestId('transcript')).toBeTruthy();
+    expect(screen.getByTestId('pending-user-message').textContent).toBe('first question');
+    expect(screen.getByTestId('stream-activity').textContent).toContain('Thinking…');
+    expect(screen.queryByTestId('empty-state')).toBeNull();
+  });
+
+  it('adopts the finished first turn under the server id before navigating to it', async () => {
+    conversationsValue = {
+      data: { items: [] },
+      refetch: vi.fn().mockResolvedValue({ data: { items: [{ id: 'conv-new' }] } }),
+    };
+    mutateAsyncMock.mockImplementation(async () => {
+      const store = useStreamStore.getState();
+      store.start(NEW_CONVERSATION_ID, sent);
+      store.appendToken(NEW_CONVERSATION_ID, 'answer');
+      store.setDone(NEW_CONVERSATION_ID, 'a1');
+    });
+    renderPage({ conversationId: null, isNew: true });
+
+    fireEvent.change(screen.getByLabelText('Message'), { target: { value: 'first question' } });
+    fireEvent.click(screen.getByLabelText('Send message'));
+
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith({
+        to: '/advisor/$id',
+        params: { id: 'conv-new' },
+        replace: true,
+      }),
+    );
+    const state = useStreamStore.getState();
+    expect(state.byConversation['conv-new']).toEqual({
+      kind: 'done',
+      text: 'answer',
+      messageId: 'a1',
+    });
+    expect(state.userMessageByConversation['conv-new']?.text).toBe('first question');
+  });
+
+  it('clears a finished placeholder entry once a real conversation is on screen', () => {
+    const store = useStreamStore.getState();
+    store.start(NEW_CONVERSATION_ID, sent);
+    store.appendToken(NEW_CONVERSATION_ID, 'answer');
+    store.setDone(NEW_CONVERSATION_ID, 'a1');
+    renderPage({ conversationId: 'conv-1' });
+    expect(useStreamStore.getState().byConversation[NEW_CONVERSATION_ID]).toBeUndefined();
+  });
+
+  it('leaves an in-flight placeholder turn alone when another conversation is opened', () => {
+    useStreamStore.getState().start(NEW_CONVERSATION_ID, sent);
+    renderPage({ conversationId: 'conv-1' });
+    expect(useStreamStore.getState().byConversation[NEW_CONVERSATION_ID]).toEqual({
+      kind: 'pending',
+    });
+    expect(useStreamStore.getState().userMessageByConversation[NEW_CONVERSATION_ID]).toEqual(sent);
+  });
+
+  it('spins the send button while the turn is in flight', () => {
+    streamValue = { mutateAsync: mutateAsyncMock, isPending: true, error: undefined };
+    renderPage({ conversationId: 'conv-1' });
+    expect(screen.getByTestId('send-spinner')).toBeTruthy();
+    expect(screen.getByLabelText('Send message').getAttribute('aria-busy')).toBe('true');
   });
 });

--- a/apps/web/src/features/advisor/components/__tests__/Transcript.test.tsx
+++ b/apps/web/src/features/advisor/components/__tests__/Transcript.test.tsx
@@ -6,7 +6,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Message } from '@tradr/shared/schemas/advisor';
 
 // eslint-disable-next-line import-x/order -- import-x/order miscounts groups in this file because the component import is intentionally placed after vi.mock() (hoisting).
-import type { BillingMode, StreamState, ToolActivity } from '../../stores/stream.store';
+import type {
+  BillingMode,
+  PendingUserMessage,
+  StreamState,
+  ToolActivity,
+} from '../../stores/stream.store';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -21,21 +26,25 @@ vi.mock('../../hooks/useConversations', () => ({
 let streamSlice: StreamState = { kind: 'idle' };
 let toolSlice: ToolActivity[] = [];
 let billingModeSlice: BillingMode | undefined;
+let userMessageSlice: PendingUserMessage | undefined;
 // The component calls useStreamStore(useShallow(selector)); apply the selector
 // to a state object exposing the single conversation's slice + tool activity +
-// billing-mode disclosure (matching the real store's initial shape).
+// billing-mode disclosure + pending user message (matching the real store's
+// initial shape).
 vi.mock('../../stores/stream.store', () => ({
   useStreamStore: (
     selector: (s: {
       byConversation: Record<string, StreamState>;
       toolsByConversation: Record<string, ToolActivity[]>;
       billingModeByConversation: Record<string, BillingMode>;
+      userMessageByConversation: Record<string, PendingUserMessage>;
     }) => unknown,
   ) =>
     selector({
       byConversation: { [CID]: streamSlice },
       toolsByConversation: { [CID]: toolSlice },
       billingModeByConversation: billingModeSlice ? { [CID]: billingModeSlice } : {},
+      userMessageByConversation: userMessageSlice ? { [CID]: userMessageSlice } : {},
     }),
 }));
 vi.mock('zustand/shallow', () => ({
@@ -103,6 +112,7 @@ beforeEach(() => {
   streamSlice = { kind: 'idle' };
   toolSlice = [];
   billingModeSlice = undefined;
+  userMessageSlice = undefined;
 });
 
 afterEach(() => {
@@ -471,5 +481,93 @@ describe('Transcript', () => {
     mount(<Transcript conversationId={CID} onRetry={vi.fn()} />);
     expect(document.querySelector('[data-testid="stream-entry"]')).toBeNull();
     expect(document.body.textContent).toContain('persisted reply');
+  });
+});
+
+describe('Transcript — in-flight turn', () => {
+  const sent: PendingUserMessage = {
+    clientMessageId: 'cm-1',
+    text: 'what is my win rate?',
+    attachments: [],
+  };
+  const activity = () => document.querySelector('[data-testid="stream-activity"]');
+
+  it('shows the sent message and a thinking indicator before any frame arrives', () => {
+    streamSlice = { kind: 'pending' };
+    userMessageSlice = sent;
+    mount(<Transcript conversationId={CID} onRetry={vi.fn()} />);
+
+    const pending = document.querySelector('[data-testid="pending-user-message"]')!;
+    expect(pending.textContent).toBe('what is my win rate?');
+    // Same side and label as a persisted user message.
+    expect(pending.parentElement!.parentElement!.className).toContain('justify-start');
+    expect(pending.previousElementSibling!.textContent).toBe('Me');
+    expect(document.querySelector('[data-testid="stream-entry"]')).not.toBeNull();
+    expect(activity()!.textContent).toContain('Thinking…');
+  });
+
+  it('labels the indicator by what the advisor is doing: tools → Working, tokens → Responding', () => {
+    streamSlice = { kind: 'pending' };
+    userMessageSlice = sent;
+    toolSlice = [
+      { id: 'tc-1', name: 'trade_data_stats', argumentsPreview: '{}', status: 'pending' },
+    ];
+    mount(<Transcript conversationId={CID} onRetry={vi.fn()} />);
+    expect(activity()!.textContent).toContain('Working…');
+
+    act(() => mounted!.root.unmount());
+    mounted = null;
+    streamSlice = { kind: 'streaming', text: 'Your win rate' };
+    mount(<Transcript conversationId={CID} onRetry={vi.fn()} />);
+    expect(document.body.textContent).toContain('Your win rate');
+    expect(activity()!.textContent).toContain('Responding…');
+  });
+
+  it('renders submitted image attachments inline on the pending message', () => {
+    streamSlice = { kind: 'pending' };
+    userMessageSlice = {
+      ...sent,
+      attachments: [{ format: 'png', dataBase64: 'iVBORw0KGgo=' }],
+    };
+    mount(<Transcript conversationId={CID} onRetry={vi.fn()} />);
+
+    const img = document.querySelector('[data-testid="pending-user-message"] img')!;
+    expect(img.getAttribute('src')).toBe('data:image/png;base64,iVBORw0KGgo=');
+  });
+
+  it('offers a retry with no-response copy when the turn failed before any output', () => {
+    streamSlice = { kind: 'error', text: '', errorCode: 'INSUFFICIENT_CREDITS' };
+    userMessageSlice = sent;
+    mount(<Transcript conversationId={CID} onRetry={vi.fn()} />);
+
+    expect(document.querySelector('[data-testid="pending-user-message"]')).not.toBeNull();
+    expect(document.body.textContent).toContain('No response — retry?');
+    expect(activity()).toBeNull();
+  });
+
+  it('hides the indicator once the turn is done, before the persisted copy lands', () => {
+    streamSlice = { kind: 'done', text: 'final', messageId: 'a9' };
+    userMessageSlice = sent;
+    mount(<Transcript conversationId={CID} onRetry={vi.fn()} />);
+
+    expect(document.querySelector('[data-testid="stream-entry"]')).not.toBeNull();
+    expect(document.querySelector('[data-testid="pending-user-message"]')).not.toBeNull();
+    expect(activity()).toBeNull();
+  });
+
+  it('drops the pending pair together once the persisted turn is in the cache', () => {
+    streamSlice = { kind: 'done', text: 'final', messageId: 'a9' };
+    userMessageSlice = sent;
+    conversationMessages = [
+      textMessage({ id: 'u9', role: 'user', text: 'what is my win rate?' }),
+      textMessage({ id: 'a9', role: 'assistant', text: 'final' }),
+    ];
+    mount(<Transcript conversationId={CID} onRetry={vi.fn()} />);
+
+    expect(document.querySelector('[data-testid="pending-user-message"]')).toBeNull();
+    expect(document.querySelector('[data-testid="stream-entry"]')).toBeNull();
+    // Exactly one copy of each side of the turn.
+    expect(document.querySelectorAll('[data-role="user"]')).toHaveLength(1);
+    expect(document.querySelectorAll('[data-role="assistant"]')).toHaveLength(1);
   });
 });

--- a/apps/web/src/features/advisor/hooks/useAdvisorStream.test.tsx
+++ b/apps/web/src/features/advisor/hooks/useAdvisorStream.test.tsx
@@ -4,14 +4,17 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { readSseStream } from '../lib/sse';
+import { readSseStream, SsePreStreamError } from '../lib/sse';
 import { useStreamStore } from '../stores/stream.store';
 
 import { useAdvisorStream, type StreamSubmitInput } from './useAdvisorStream';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-vi.mock('../lib/sse', () => ({ readSseStream: vi.fn() }));
+vi.mock('../lib/sse', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/sse')>()),
+  readSseStream: vi.fn(),
+}));
 
 const CONV_ID = '11111111-1111-1111-1111-111111111111';
 
@@ -30,7 +33,12 @@ function makeWrapper(qc: QueryClient) {
 }
 
 afterEach(() => {
-  useStreamStore.setState({ byConversation: {}, toolsByConversation: {} });
+  useStreamStore.setState({
+    byConversation: {},
+    toolsByConversation: {},
+    billingModeByConversation: {},
+    userMessageByConversation: {},
+  });
   vi.restoreAllMocks();
   vi.mocked(readSseStream).mockReset();
 });
@@ -125,5 +133,57 @@ describe('useAdvisorStream', () => {
 
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(readSseStream).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the turn pending and records the user message before the first frame', async () => {
+    let seenMidStream: unknown;
+    vi.mocked(readSseStream).mockImplementation(async (_url, opts) => {
+      seenMidStream = useStreamStore.getState().byConversation[CONV_ID];
+      opts.onDone('msg-1');
+      return { messageId: 'msg-1', deduped: false };
+    });
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+
+    const { result } = renderHook(() => useAdvisorStream(), { wrapper: makeWrapper(qc) });
+    await result.current.mutateAsync(makeInput());
+
+    expect(seenMidStream).toEqual({ kind: 'pending' });
+    expect(useStreamStore.getState().userMessageByConversation[CONV_ID]).toEqual({
+      clientMessageId: '22222222-2222-2222-2222-222222222222',
+      text: 'hello',
+      attachments: [],
+    });
+  });
+
+  it('moves a pre-stream refusal into the error state (no indicator left running)', async () => {
+    vi.mocked(readSseStream).mockRejectedValue(
+      new SsePreStreamError(402, 'INSUFFICIENT_CREDITS', 'out of credits'),
+    );
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+
+    const { result } = renderHook(() => useAdvisorStream(), { wrapper: makeWrapper(qc) });
+    await expect(result.current.mutateAsync(makeInput())).rejects.toThrow('out of credits');
+
+    expect(useStreamStore.getState().byConversation[CONV_ID]).toEqual({
+      kind: 'error',
+      text: '',
+      errorCode: 'INSUFFICIENT_CREDITS',
+    });
+    // The sent message stays on screen next to the retry control.
+    expect(useStreamStore.getState().userMessageByConversation[CONV_ID]?.text).toBe('hello');
+  });
+
+  it('a failure with no error frame and no code lands as STREAM_DISCONNECTED', async () => {
+    vi.mocked(readSseStream).mockRejectedValue(new Error('boom'));
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+
+    const { result } = renderHook(() => useAdvisorStream(), { wrapper: makeWrapper(qc) });
+    await expect(result.current.mutateAsync(makeInput())).rejects.toThrow('boom');
+
+    expect(useStreamStore.getState().byConversation[CONV_ID]).toEqual({
+      kind: 'error',
+      text: '',
+      errorCode: 'STREAM_DISCONNECTED',
+    });
   });
 });

--- a/apps/web/src/features/advisor/hooks/useAdvisorStream.ts
+++ b/apps/web/src/features/advisor/hooks/useAdvisorStream.ts
@@ -14,7 +14,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { StreamRequestInput } from '@tradr/shared/schemas/advisor';
 
 import { resolveApiUrl } from '../../../lib/api';
-import { readSseStream } from '../lib/sse';
+import { readSseStream, SsePreStreamError } from '../lib/sse';
 import { useStreamStore } from '../stores/stream.store';
 
 export interface StreamSubmitInput extends StreamRequestInput {
@@ -24,7 +24,7 @@ export interface StreamSubmitInput extends StreamRequestInput {
 export function useAdvisorStream() {
   // Per-action selectors. Zustand returns a stable reference for actions assigned
   // at store init, so these never re-render the caller on per-token store changes.
-  const reset = useStreamStore((s) => s.reset);
+  const start = useStreamStore((s) => s.start);
   const appendToken = useStreamStore((s) => s.appendToken);
   const addToolCall = useStreamStore((s) => s.addToolCall);
   const addToolResult = useStreamStore((s) => s.addToolResult);
@@ -39,7 +39,13 @@ export function useAdvisorStream() {
     networkMode: 'always',
     mutationFn: async (input: StreamSubmitInput) => {
       const { conversationId, ...body } = input;
-      reset(conversationId);
+      // Clears the previous turn and records the user's message so the
+      // transcript shows it (and a thinking indicator) before any frame lands.
+      start(conversationId, {
+        clientMessageId: body.clientMessageId,
+        text: body.text,
+        attachments: body.attachments ?? [],
+      });
       return readSseStream(
         resolveApiUrl(`/advisor/conversations/${conversationId}/messages/stream`),
         {
@@ -65,6 +71,18 @@ export function useAdvisorStream() {
           onDone: (messageId) => setDone(conversationId, messageId),
         },
       );
+    },
+    onError: (error, vars) => {
+      // A failure that never reached an SSE `error` frame — a pre-stream JSON
+      // refusal (402/403/5xx), a malformed frame, or a missing body — would
+      // otherwise leave the slice stuck in `pending`/`streaming` with the
+      // thinking indicator running forever. Move it to `error` so the
+      // transcript offers a retry; a frame-delivered error is already there.
+      const slice = useStreamStore.getState().byConversation[vars.conversationId];
+      if (slice?.kind === 'error') return;
+      const code =
+        error instanceof SsePreStreamError && error.code ? error.code : 'STREAM_DISCONNECTED';
+      setError(vars.conversationId, code);
     },
     onSuccess: (_data, vars) => {
       // Invalidate ONLY the conversation query — never persona/key queries, and

--- a/apps/web/src/features/advisor/hooks/useConversations.ts
+++ b/apps/web/src/features/advisor/hooks/useConversations.ts
@@ -13,6 +13,8 @@ import type { Conversation, ConversationListItem, Message } from '@tradr/shared/
 
 import { api } from '@/lib/api';
 
+import { NEW_CONVERSATION_ID } from '../stores/stream.store';
+
 // Query-key factory. Detail key matches useAdvisorStream's invalidation target
 // (['advisor', 'conversation', id]) so a streamed reply and a manual refetch
 // share one cache entry.
@@ -40,12 +42,16 @@ export function useConversations() {
   });
 }
 
-/** REQ-2.3 — a conversation plus its latest messages. */
+/**
+ * REQ-2.3 — a conversation plus its latest messages. Never fetches for the
+ * new-conversation placeholder id: that transcript has no persisted messages
+ * yet and renders from the stream store alone.
+ */
 export function useConversation(id: string) {
   return useQuery<ConversationDetail>({
     queryKey: conversationKeys.detail(id),
     queryFn: () => api.get<ConversationDetail>(`/advisor/conversations/${id}`),
-    enabled: id.length > 0,
+    enabled: id.length > 0 && id !== NEW_CONVERSATION_ID,
   });
 }
 

--- a/apps/web/src/features/advisor/pages/AdvisorPage.tsx
+++ b/apps/web/src/features/advisor/pages/AdvisorPage.tsx
@@ -6,9 +6,13 @@
 //
 // New-conversation flow (REQ-1.8): the page never navigates to `/advisor/{id}`
 // before the server has confirmed the conversation exists. The first send on a
-// new conversation streams against the `new` endpoint; once the stream and the
-// conversation-list refetch confirm the server-assigned id, the URL is replaced
-// (replace: true) so the back button never lands on `/advisor/new`.
+// new conversation streams against the `new` endpoint, and the transcript is
+// mounted against that placeholder id so the user's message and the streaming
+// reply show up immediately. Once the stream and the conversation-list refetch
+// confirm the server-assigned id, the store entry is adopted under that id and
+// the URL is replaced (replace: true) so the back button never lands on
+// `/advisor/new` and the finished turn stays on screen while the persisted
+// messages load.
 //
 // This module is lazy-loaded at the route boundary (the route files import it
 // via React.lazy) so the advisor bundle — and the syntax highlighter it pulls in
@@ -38,6 +42,7 @@ import { useAdvisorStream } from '../hooks/useAdvisorStream';
 import { useConversations } from '../hooks/useConversations';
 import { useListPersonas } from '../hooks/usePersonas';
 import { useProviderKeys } from '../hooks/useProviderKeys';
+import { NEW_CONVERSATION_ID, useStreamStore } from '../stores/stream.store';
 
 // System fallback persona id (REQ-7 default-resolution order). Used only when the
 // user has not marked a default and no persona is otherwise selectable.
@@ -59,6 +64,13 @@ export function AdvisorPage({ conversationId, isNew = false }: AdvisorPageProps)
   const tierQuery = useTierState();
   const stream = useAdvisorStream();
   const queryClient = useQueryClient();
+  // Whether a first turn is in flight (or finished / failed) under the
+  // new-conversation placeholder — mounts the transcript on the new pane.
+  const newTurnActive = useStreamStore(
+    (s) => (s.byConversation[NEW_CONVERSATION_ID]?.kind ?? 'idle') !== 'idle',
+  );
+  const adoptStream = useStreamStore((s) => s.adopt);
+  const resetStream = useStreamStore((s) => s.reset);
 
   const [drawerOpen, setDrawerOpen] = useState(false);
   // The clientMessageId of the in-flight submission, retained so the retry button
@@ -115,6 +127,18 @@ export function AdvisorPage({ conversationId, isNew = false }: AdvisorPageProps)
 
   const activeId = isNew ? null : conversationId;
 
+  // Once a real conversation is on screen a finished placeholder entry has
+  // served its purpose (it was adopted under the real id before navigation);
+  // clear it so the next visit to the new pane starts empty. A turn still in
+  // flight is left alone — the user may have clicked another conversation while
+  // it streams, and it is adopted and navigated to when it completes.
+  useEffect(() => {
+    if (activeId === null) return;
+    const kind = useStreamStore.getState().byConversation[NEW_CONVERSATION_ID]?.kind;
+    if (kind === 'pending' || kind === 'streaming') return;
+    resetStream(NEW_CONVERSATION_ID);
+  }, [activeId, resetStream]);
+
   // REQ-8.9b preselect: a no-BYOK user with allowance headroom gets the
   // allowance model preselected instead of an empty picker (an empty start
   // auto-refuses a zero-credit first turn with INSUFFICIENT_CREDITS on the most
@@ -130,7 +154,7 @@ export function AdvisorPage({ conversationId, isNew = false }: AdvisorPageProps)
   const runSubmit = async (submission: ComposerSubmit) => {
     setLastSubmit(submission);
     const personaId = submission.personaId ?? defaultPersonaId;
-    const targetId = activeId ?? 'new';
+    const targetId = activeId ?? NEW_CONVERSATION_ID;
 
     // Capture the known conversation ids BEFORE streaming so we can identify the
     // newly-created conversation by set-difference after the refetch (avoids the
@@ -179,6 +203,9 @@ export function AdvisorPage({ conversationId, isNew = false }: AdvisorPageProps)
       const refetched = await conversations.refetch();
       const newIds = (refetched.data?.items ?? []).filter((c) => !knownIds.has(c.id));
       if (newIds.length === 1) {
+        // Carry the finished turn over to the real id so the transcript there
+        // renders it straight away instead of waiting on the detail query.
+        adoptStream(NEW_CONVERSATION_ID, newIds[0].id);
         await navigate({
           to: '/advisor/$id',
           params: { id: newIds[0].id },
@@ -277,6 +304,8 @@ export function AdvisorPage({ conversationId, isNew = false }: AdvisorPageProps)
           <div className="min-h-0 flex-1 overflow-y-auto">
             {activeId ? (
               <Transcript conversationId={activeId} onRetry={onRetry} />
+            ) : canStartConversation && newTurnActive ? (
+              <Transcript conversationId={NEW_CONVERSATION_ID} onRetry={onRetry} />
             ) : !canStartConversation ? (
               <div className="p-6" data-testid="no-key-banner">
                 <EmptyState
@@ -323,6 +352,7 @@ export function AdvisorPage({ conversationId, isNew = false }: AdvisorPageProps)
                 defaultPersonaId={defaultPersonaId}
                 visionEnabled={false}
                 disabled={composerDisabled}
+                pending={stream.isPending}
                 errorCode={errorCode}
                 tierState={tierState}
                 remedies={{

--- a/apps/web/src/features/advisor/stores/stream.store.test.ts
+++ b/apps/web/src/features/advisor/stores/stream.store.test.ts
@@ -5,7 +5,12 @@ import { useStreamStore } from './stream.store';
 
 describe('stream.store', () => {
   afterEach(() => {
-    useStreamStore.setState({ byConversation: {}, toolsByConversation: {} });
+    useStreamStore.setState({
+      byConversation: {},
+      toolsByConversation: {},
+      billingModeByConversation: {},
+      userMessageByConversation: {},
+    });
   });
 
   it('appendToken starts a streaming entry and accumulates deltas', () => {
@@ -113,5 +118,56 @@ describe('stream.store', () => {
     expect(toolsByConversation.c2).toEqual([
       { id: 'tc-2', name: 'y', argumentsPreview: '', status: 'pending' },
     ]);
+  });
+
+  it('start clears the previous turn, records the user message, and marks the turn pending', () => {
+    const { appendToken, addToolCall, setDone, start } = useStreamStore.getState();
+    appendToken('c1', 'old answer');
+    setDone('c1', 'msg-old');
+    addToolCall('c1', { id: 'tc-old', name: 'x', argumentsPreview: '' });
+
+    const userMessage = { clientMessageId: 'cm-1', text: 'next question', attachments: [] };
+    start('c1', userMessage);
+
+    const state = useStreamStore.getState();
+    expect(state.byConversation.c1).toEqual({ kind: 'pending' });
+    expect(state.toolsByConversation.c1).toBeUndefined();
+    expect(state.userMessageByConversation.c1).toEqual(userMessage);
+  });
+
+  it('adopt copies every slice under the new id and leaves the source in place', () => {
+    const { start, appendToken, addToolCall, setBillingMode, setDone, adopt } =
+      useStreamStore.getState();
+    start('new', { clientMessageId: 'cm-1', text: 'hi', attachments: [] });
+    addToolCall('new', { id: 'tc-1', name: 'x', argumentsPreview: '' });
+    setBillingMode('new', { mode: 'byok' });
+    appendToken('new', 'answer');
+    setDone('new', 'msg-1');
+
+    adopt('new', 'c9');
+
+    const state = useStreamStore.getState();
+    for (const id of ['new', 'c9']) {
+      expect(state.byConversation[id]).toEqual({
+        kind: 'done',
+        text: 'answer',
+        messageId: 'msg-1',
+      });
+      expect(state.toolsByConversation[id]).toHaveLength(1);
+      expect(state.billingModeByConversation[id]).toEqual({ mode: 'byok' });
+      expect(state.userMessageByConversation[id]?.text).toBe('hi');
+    }
+  });
+
+  it('adopt is a no-op when the source has no entry', () => {
+    useStreamStore.getState().adopt('missing', 'c9');
+    expect(useStreamStore.getState().byConversation.c9).toBeUndefined();
+  });
+
+  it('reset also drops the recorded user message', () => {
+    const { start, reset } = useStreamStore.getState();
+    start('c1', { clientMessageId: 'cm-1', text: 'hi', attachments: [] });
+    reset('c1');
+    expect(useStreamStore.getState().userMessageByConversation.c1).toBeUndefined();
   });
 });

--- a/apps/web/src/features/advisor/stores/stream.store.ts
+++ b/apps/web/src/features/advisor/stores/stream.store.ts
@@ -1,10 +1,21 @@
 import { create } from 'zustand';
 
+/**
+ * Placeholder conversation id for the first turn of a new conversation. The
+ * server creates the row while persisting that turn, so the stream runs — and
+ * the store entry lives — under this key until the real id is known, then
+ * `adopt` carries it over.
+ */
+export const NEW_CONVERSATION_ID = 'new';
+
 // v4-4: per-conversation in-flight assistant text lives in a flat Record (NOT a Map),
 // and appendToken mutates via a single-key spread. v4-9 pins the concrete semantics for
 // setError, setDone, and reset.
 export type StreamState =
   | { kind: 'idle' }
+  // submitted, no frame from the server yet — the transcript shows a thinking
+  // indicator so the user sees the turn was accepted before the first token
+  | { kind: 'pending' }
   | { kind: 'streaming'; text: string }
   // text retained until the query cache has the persisted message with this messageId
   | { kind: 'done'; text: string; messageId: string }
@@ -30,10 +41,23 @@ export interface BillingMode {
   fellThrough?: boolean;
 }
 
+// The user's own message for the in-flight turn, rendered optimistically the
+// instant it is submitted. Persisted messages only reach the query cache after
+// the turn commits, so without this the sent text vanishes from the composer
+// and reappears (with the reply) seconds later. Cleared on reset alongside text.
+export interface PendingUserMessage {
+  clientMessageId: string;
+  text: string;
+  attachments: { format: 'png' | 'jpeg' | 'webp'; dataBase64: string }[];
+}
+
 export interface StreamStore {
   byConversation: Record<string, StreamState>;
   toolsByConversation: Record<string, ToolActivity[]>;
   billingModeByConversation: Record<string, BillingMode>;
+  userMessageByConversation: Record<string, PendingUserMessage>;
+  start: (conversationId: string, userMessage: PendingUserMessage) => void;
+  adopt: (fromId: string, toId: string) => void;
   appendToken: (conversationId: string, delta: string) => void;
   addToolCall: (
     conversationId: string,
@@ -53,6 +77,47 @@ export const useStreamStore = create<StreamStore>((set) => ({
   byConversation: {},
   toolsByConversation: {},
   billingModeByConversation: {},
+  userMessageByConversation: {},
+
+  // Marks a submission as in flight: clears the previous turn's entry for this
+  // conversation (as reset does), records the user's message for optimistic
+  // rendering, and puts the slice in `pending` until the first frame arrives.
+  start: (id, userMessage) =>
+    set((s) => {
+      const cleared = omitConversation(s, id);
+      return {
+        ...cleared,
+        byConversation: { ...cleared.byConversation, [id]: { kind: 'pending' } },
+        userMessageByConversation: { ...cleared.userMessageByConversation, [id]: userMessage },
+      };
+    }),
+
+  // Copies one conversation's slices under another key. The new-conversation
+  // flow streams under the `new` placeholder id and only learns the server id
+  // at the end; adopting the entry under that id lets the transcript at
+  // /advisor/{id} keep showing the finished turn until the persisted messages
+  // load. The source entry is left in place — the page clears it once it is
+  // rendering a real conversation.
+  adopt: (fromId, toId) =>
+    set((s) => {
+      const state = s.byConversation[fromId];
+      if (!state) return {};
+      const tools = s.toolsByConversation[fromId];
+      const mode = s.billingModeByConversation[fromId];
+      const userMessage = s.userMessageByConversation[fromId];
+      return {
+        byConversation: { ...s.byConversation, [toId]: state },
+        toolsByConversation: tools
+          ? { ...s.toolsByConversation, [toId]: tools }
+          : s.toolsByConversation,
+        billingModeByConversation: mode
+          ? { ...s.billingModeByConversation, [toId]: mode }
+          : s.billingModeByConversation,
+        userMessageByConversation: userMessage
+          ? { ...s.userMessageByConversation, [toId]: userMessage }
+          : s.userMessageByConversation,
+      };
+    }),
 
   // v4-4: single-key spread. O(N) per token in the number of open conversations; for the
   // expected workload (N <= 20) sub-millisecond per token at 50 Hz token frequency.
@@ -117,20 +182,33 @@ export const useStreamStore = create<StreamStore>((set) => ({
     }),
 
   // v4-9: clears any prior error/done placeholder for THIS conversation. Called by
-  // useAdvisorStream at the start of each submission (before the SSE open). Does NOT
-  // touch persisted messages (those live in TanStack Query).
-  reset: (id) =>
-    set((s) => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructure-omit: drop this id's entry, keep the rest
-      const { [id]: _removed, ...rest } = s.byConversation;
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructure-omit: drop this id's tool activity too
-      const { [id]: _removedTools, ...restTools } = s.toolsByConversation;
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructure-omit: drop this id's billing mode too
-      const { [id]: _removedMode, ...restModes } = s.billingModeByConversation;
-      return {
-        byConversation: rest,
-        toolsByConversation: restTools,
-        billingModeByConversation: restModes,
-      };
-    }),
+  // useAdvisorStream (via start) at the start of each submission (before the SSE
+  // open). Does NOT touch persisted messages (those live in TanStack Query).
+  reset: (id) => set((s) => omitConversation(s, id)),
 }));
+
+// Drops every per-conversation slice for `id`, leaving the other conversations
+// untouched.
+function omitConversation(
+  s: StreamStore,
+  id: string,
+): Pick<
+  StreamStore,
+  | 'byConversation'
+  | 'toolsByConversation'
+  | 'billingModeByConversation'
+  | 'userMessageByConversation'
+> {
+  /* eslint-disable @typescript-eslint/no-unused-vars -- destructure-omit: drop this id's entry, keep the rest */
+  const { [id]: _state, ...byConversation } = s.byConversation;
+  const { [id]: _tools, ...toolsByConversation } = s.toolsByConversation;
+  const { [id]: _mode, ...billingModeByConversation } = s.billingModeByConversation;
+  const { [id]: _user, ...userMessageByConversation } = s.userMessageByConversation;
+  /* eslint-enable @typescript-eslint/no-unused-vars */
+  return {
+    byConversation,
+    toolsByConversation,
+    billingModeByConversation,
+    userMessageByConversation,
+  };
+}


### PR DESCRIPTION
## Problem

Sending a message in the advisor gave no visible feedback until the whole reply arrived, then everything appeared at once.

Three causes:

1. **New conversation** — `AdvisorPage` only mounts `<Transcript>` when a conversation id is active. On `/advisor/new` the stream ran under the `new` placeholder id with nothing subscribed to it, and the server only creates the conversation row while persisting the turn, so the page waited for `done` → list refetch → navigate before anything rendered.
2. **Existing conversation** — no optimistic user bubble. The sent text was cleared from the composer on submit and only reappeared after the detail query refetched on `done`.
3. **No pre-token state** — the assistant bubble only appeared on the first `token` frame, so provider latency and tool-first turns showed nothing. There was also no auto-scroll, so on long threads the stream grew below the fold.

## Fix (client only, no API change)

- **stream store**: `pending` state, the submitted user message, `start()` (replaces `reset()` at submit) and `adopt()` to carry the finished first turn from the placeholder id to the server id.
- **Transcript**: renders the sent message immediately; the assistant bubble carries a Thinking / Working / Responding indicator for as long as the turn is in flight (before the first token and through silent tool windows); "No response — retry?" when a turn fails before any output; follows the stream unless the user scrolled up. The optimistic pair hands off 1:1 to the persisted messages (same handoff rule as before, keyed on the `done` messageId).
- **AdvisorPage**: mounts the transcript on the new pane as soon as a first turn starts; adopts the entry under the real id before navigating so the finished turn stays on screen while the persisted messages load; clears the placeholder once a real conversation is on screen (leaves an in-flight one alone).
- **useAdvisorStream**: a pre-stream refusal (402/403/5xx) or a transport failure with no `error` frame now moves the turn to `error` instead of leaving the indicator running forever. Previously non-billing pre-stream failures rendered nothing at all.
- **Composer**: spinner + `aria-busy` on the send button while the turn is in flight.

## Verification

- 17 new unit tests (store, hook, Transcript, AdvisorPage); advisor suite 141/141, routes test green, `tsc` and eslint clean.
- Ran the stack locally against an OpenAI-shaped SSE stub with a 3 s first-token delay and sampled the DOM at 100 ms: sent bubble + "Thinking…" + spinner at 100 ms, "Responding…" at 3.2 s, clean 1:1 handoff to persisted messages at 11.8 s with the view pinned to the bottom throughout. Same on the new-conversation path (URL replaced to `/advisor/{id}` with the turn still on screen).
