### PR TITLE
fix(web): render advisor transcript oldest-first

### DIFF
--- a/apps/web/src/features/advisor/components/Transcript.tsx
+++ b/apps/web/src/features/advisor/components/Transcript.tsx
@@ -32,7 +32,7 @@
 // renders its cards on reload (not an empty bubble), and streaming + reload use
 // the same components. User text is plain text — no Markdown.
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useShallow } from 'zustand/shallow';
 
 import type {
@@ -344,9 +344,21 @@ function PendingUserBubble({ message }: { message: PendingUserMessage }) {
   );
 }
 
+// The API pages messages newest-first (its cursor walks older); a transcript
+// reads oldest-first like any chat, with the in-flight turn at the bottom.
+// Mirrors the server's (createdAt, id) order key, reversed.
+function compareChronological(a: Message, b: Message): number {
+  const byTime = Date.parse(a.createdAt) - Date.parse(b.createdAt);
+  if (byTime !== 0) return byTime;
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
 export function Transcript({ conversationId, onRetry }: TranscriptProps) {
   const { data } = useConversation(conversationId);
-  const messages = data?.messages ?? [];
+  const messages = useMemo(
+    () => [...(data?.messages ?? [])].sort(compareChronological),
+    [data?.messages],
+  );
 
   // Narrow slice subscription. useShallow re-renders only when this object's
   // fields change, not on cross-conversation store mutations (design v3-9).

--- a/apps/web/src/features/advisor/components/__tests__/Transcript.test.tsx
+++ b/apps/web/src/features/advisor/components/__tests__/Transcript.test.tsx
@@ -571,3 +571,41 @@ describe('Transcript — in-flight turn', () => {
     expect(document.querySelectorAll('[data-role="assistant"]')).toHaveLength(1);
   });
 });
+
+describe('Transcript — ordering', () => {
+  it('renders oldest-first with the in-flight turn last, though the API pages newest-first', () => {
+    conversationMessages = [
+      {
+        ...textMessage({ id: 'a2', role: 'assistant', text: 'second reply' }),
+        createdAt: '2026-08-24T10:00:03.000Z',
+      },
+      {
+        ...textMessage({ id: 'u2', role: 'user', text: 'second question' }),
+        createdAt: '2026-08-24T10:00:02.000Z',
+      },
+      {
+        ...textMessage({ id: 'a1', role: 'assistant', text: 'first reply' }),
+        createdAt: '2026-08-24T10:00:01.000Z',
+      },
+      {
+        ...textMessage({ id: 'u1', role: 'user', text: 'first question' }),
+        createdAt: '2026-08-24T10:00:00.000Z',
+      },
+    ];
+    streamSlice = { kind: 'pending' };
+    userMessageSlice = { clientMessageId: 'cm-3', text: 'third question', attachments: [] };
+    mount(<Transcript conversationId={CID} onRetry={vi.fn()} />);
+
+    const texts = Array.from(document.querySelectorAll('[data-role]')).map((el) =>
+      el.textContent?.replace('Thinking…', '').trim(),
+    );
+    expect(texts).toEqual([
+      'first question',
+      'first reply',
+      'second question',
+      'second reply',
+      'third question',
+      '',
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem

Once a conversation had more than one turn, new messages appeared at the **top** of the transcript and the oldest sat at the bottom. `GET /advisor/conversations/:id` pages messages newest-first (`createdAt DESC, id DESC`, cursor walks older) and `Transcript` rendered the page as returned.

## Fix

Client-side only — the newest-first paging contract is fine for the API. `Transcript` now orders the page by `(createdAt, id)` ascending (the server's order key, reversed). The in-flight turn already renders after the persisted messages, so it stays at the bottom.

## Verification

- New test feeds newest-first fixtures plus a pending turn and asserts DOM order: first question → first reply → second question → second reply → in-flight pair.
- Transcript suite 29/29, `tsc` and eslint clean.
