### PR TITLE
ci: exclude the SPA shell from the outbound link check

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -44,6 +44,11 @@ exclude_path = [
   "apps/docs/src",
   "apps/docs/dist",
   "apps/web/dist",
+  # The SPA shell. Its only links are root-relative asset paths (`/favicon.svg`,
+  # `/config.js`) that Vite serves from apps/web/public at runtime; on disk they
+  # resolve to nothing and lychee reports them as broken. There is no outbound
+  # link in this file to lose.
+  "apps/web/index.html",
   "pnpm-lock.yaml",
   "CHANGELOG.md",
 ]


### PR DESCRIPTION
Since #78 added `/favicon.svg` and `/favicon.ico` to `apps/web/index.html`, the `lychee` job fails on every PR: it resolves root-relative links as files on disk and finds nothing there. Those paths are runtime assets Vite serves from `apps/web/public`, and the file has no outbound link to check, so it joins `apps/web/dist` in `exclude_path` with a comment saying why.

Advisory job only (not one of the required checks), but a permanently red check is noise nobody reads.