### PR TITLE
docs: drop the advisor from the maintainer docs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,7 +45,7 @@ We ask that you give us reasonable time to remediate before any public disclosur
 
 - **The Tradr software** (this repository) — anything affecting self-hosted or hosted deployments:
   authentication/session handling, authorization/row-scoping, injection, secret handling (BYOK key
-  encryption), the Stripe webhook path, the IBKR OAuth flow, the AI advisor's data access, etc.
+  encryption), the Stripe webhook path, the IBKR OAuth flow, trade-data access paths, etc.
 - **The hosted platform (`tradr.cloud`)** — report platform-specific issues the same way.
 
 Out of scope: findings that require a fully compromised host or physical access (a self-hosted single-server

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -48,7 +48,7 @@ Tradr with their trading history, and it should be the most precise prose we wri
 **Out of scope — trader-facing narrative:**
 
 - Marketing copy
-- "Why journaling improves your trading", "How the advisor reasons"
+- "Why journaling improves your trading", "Hosted vs self-hosted: what's different"
 - The **introduction** of a tutorial, where a human voice earns attention
 
 Do not retrofit. The best existing pages were written before this guide and are
@@ -71,8 +71,8 @@ should be run" or "You will want to run".
 **4. Use the active voice.** Name the actor. "The api runs migrations on startup",
 not "migrations are run on startup".
 
-**5. Use the present tense for what the system does.** "The advisor reads your trade
-history", not "will read".
+**5. Use the present tense for what the system does.** "The importer maps your
+columns", not "will map".
 
 **6. One term per meaning.** Use [`TERMS.md`](TERMS.md). Never vary a term for
 elegance — a synonym reads as a different thing.

--- a/docs/TERMS.md
+++ b/docs/TERMS.md
@@ -9,43 +9,42 @@ approved term below and use only that one.
 
 ## Product and deployment
 
-| Use | Not | Why |
-| --- | --- | --- |
-| **instance** | deployment, stack, install, box | One running copy of Tradr. "Stack" means the three containers specifically; an instance is the thing an operator owns. |
-| **the stack** | the containers, the compose stack | The three services (`web`, `api`, `postgres`) started by one compose file. |
-| **self-hosted** | on-prem, on-premise, local install | Tradr run by the reader on their own infrastructure. |
-| **hosted** | cloud, SaaS, managed platform | `app.tradr.cloud`, run by us. |
-| **operator** | admin, sysadmin, self-hoster | The person who runs an instance. May or may not be the person trading on it. |
-| **contributor** | developer, dev | Someone changing the code. |
+| Use             | Not                                | Why                                                                                                                    |
+| --------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **instance**    | deployment, stack, install, box    | One running copy of Tradr. "Stack" means the three containers specifically; an instance is the thing an operator owns. |
+| **the stack**   | the containers, the compose stack  | The three services (`web`, `api`, `postgres`) started by one compose file.                                             |
+| **self-hosted** | on-prem, on-premise, local install | Tradr run by the reader on their own infrastructure.                                                                   |
+| **hosted**      | cloud, SaaS, managed platform      | `app.tradr.cloud`, run by us.                                                                                          |
+| **operator**    | admin, sysadmin, self-hoster       | The person who runs an instance. May or may not be the person trading on it.                                           |
+| **contributor** | developer, dev                     | Someone changing the code.                                                                                             |
 
 ## Trading domain
 
-| Use | Not | Why |
-| --- | --- | --- |
-| **position** | trade | A position is the record Tradr stores: one symbol, one direction, its whole lifecycle. Do not use "trade" for it. |
-| **trade** | — | Only in the general sense of the activity ("your trading", "before you take the trade"). Never as a synonym for a stored position. |
-| **fill** | execution, transaction | One buy or sell that moves a position. A position has one or more fills. |
-| **account** | brokerage account, broker account | A brokerage account inside Tradr, with a currency and a balance. Always qualify on first use per page: "a brokerage account (an **account** in Tradr)". |
-| **advisor** | AI, the AI, assistant, chatbot | The conversational feature. "AI advisor" is allowed once, for introduction; thereafter "the advisor". |
-| **BYOK** | bring-your-own-key, own key | Spell it out on first use per page, then abbreviate. |
-| **equity curve** | balance chart, P&L chart | The account-value-over-time chart. |
-| **realized P&L** | profit, gains, returns | Money from closed positions. Always write "P&L", never "PnL" or "P/L". |
+| Use              | Not                               | Why                                                                                                                                                     |
+| ---------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **position**     | trade                             | A position is the record Tradr stores: one symbol, one direction, its whole lifecycle. Do not use "trade" for it.                                       |
+| **trade**        | —                                 | Only in the general sense of the activity ("your trading", "before you take the trade"). Never as a synonym for a stored position.                      |
+| **fill**         | execution, transaction            | One buy or sell that moves a position. A position has one or more fills.                                                                                |
+| **account**      | brokerage account, broker account | A brokerage account inside Tradr, with a currency and a balance. Always qualify on first use per page: "a brokerage account (an **account** in Tradr)". |
+| **BYOK**         | bring-your-own-key, own key       | Spell it out on first use per page, then abbreviate.                                                                                                    |
+| **equity curve** | balance chart, P&L chart          | The account-value-over-time chart.                                                                                                                      |
+| **realized P&L** | profit, gains, returns            | Money from closed positions. Always write "P&L", never "PnL" or "P/L".                                                                                  |
 
 ## Configuration
 
-| Use | Not | Why |
-| --- | --- | --- |
-| **environment variable** | env var, setting, config value | Spell it out in prose. `env var` is acceptable in a table header where space is tight. |
-| **required** | mandatory, must-have | Reserved for the three values with no working default. |
-| **optional** | not required | Everything else. An optional integration is **absent when unconfigured, not broken** — say it that way. |
-| **feature gating** | paywall, plan limits, tiers | The `FEATURE_GATING` mechanism. Off by default; self-hosted instances have no tiers at all. |
+| Use                      | Not                            | Why                                                                                                     |
+| ------------------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| **environment variable** | env var, setting, config value | Spell it out in prose. `env var` is acceptable in a table header where space is tight.                  |
+| **required**             | mandatory, must-have           | Reserved for the three values with no working default.                                                  |
+| **optional**             | not required                   | Everything else. An optional integration is **absent when unconfigured, not broken** — say it that way. |
+| **feature gating**       | paywall, plan limits, tiers    | The `FEATURE_GATING` mechanism. Off by default; self-hosted instances have no tiers at all.             |
 
 ## Words to avoid entirely
 
-| Avoid | Instead |
-| --- | --- |
+| Avoid                           | Instead                                                                        |
+| ------------------------------- | ------------------------------------------------------------------------------ |
 | simply, just, easily, obviously | Delete. If a step is easy, the reader will notice; if it isn't, you have lied. |
-| should work, ought to | State what happens, or test it and then state it. |
-| leverage, utilise | use |
-| in order to | to |
-| please (in instructions) | Delete. "Please run" → "Run". |
+| should work, ought to           | State what happens, or test it and then state it.                              |
+| leverage, utilise               | use                                                                            |
+| in order to                     | to                                                                             |
+| please (in instructions)        | Delete. "Please run" → "Run".                                                  |

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -53,20 +53,19 @@ fire-and-forget after the operation commits. Properties are identifiers, enums,
 or counts only — never prices, quantities, P&L, balances, or any financial
 value.
 
-| Event                          | When                                     | Properties                         |
-| ------------------------------ | ---------------------------------------- | ---------------------------------- |
-| `user_signed_up`               | New account registered                   | —                                  |
-| `user_logged_in`               | Successful email+password login          | —                                  |
-| `email_verified`               | Verification link consumed               | —                                  |
-| `password_reset_completed`     | Password reset finished                  | —                                  |
-| `account_created`              | Trading account created                  | —                                  |
-| `account_deleted`              | Trading account deleted                  | —                                  |
-| `position_created`             | Position opened                          | `assetType`                        |
-| `position_closed`              | Position closed                          | `assetType`                        |
-| `csv_import_completed`         | CSV trade import committed               | `positionsCreated`, `fillsCreated` |
-| `checkout_session_created`     | Stripe checkout started (wallet credits) | `packId`                           |
-| `credits_purchased`            | Credits granted after payment (webhook)  | `packId`                           |
-| `advisor_conversation_started` | First turn of a new advisor conversation | —                                  |
+| Event                      | When                                     | Properties                         |
+| -------------------------- | ---------------------------------------- | ---------------------------------- |
+| `user_signed_up`           | New account registered                   | —                                  |
+| `user_logged_in`           | Successful email+password login          | —                                  |
+| `email_verified`           | Verification link consumed               | —                                  |
+| `password_reset_completed` | Password reset finished                  | —                                  |
+| `account_created`          | Trading account created                  | —                                  |
+| `account_deleted`          | Trading account deleted                  | —                                  |
+| `position_created`         | Position opened                          | `assetType`                        |
+| `position_closed`          | Position closed                          | `assetType`                        |
+| `csv_import_completed`     | CSV trade import committed               | `positionsCreated`, `fillsCreated` |
+| `checkout_session_created` | Stripe checkout started (wallet credits) | `packId`                           |
+| `credits_purchased`        | Credits granted after payment (webhook)  | `packId`                           |
 
 ### Person profile (`identify`)
 

--- a/docs/external-services.md
+++ b/docs/external-services.md
@@ -13,30 +13,29 @@ degraded) and the process makes **no outbound calls** for it.
 
 ## Optional services (implemented today)
 
-### AI advisor — LLM providers
+### LLM providers
 
 | Service       | Endpoint host       | Enabled by                                              |
 | ------------- | ------------------- | ------------------------------------------------------- |
 | Anthropic API | `api.anthropic.com` | `ANTHROPIC_API_KEY` (platform key) or per-user BYOK key |
 | OpenAI API    | `api.openai.com`    | `OPENAI_API_KEY` (platform key) or per-user BYOK key    |
 
-The advisor calls providers directly via `@anthropic-ai/sdk` and `openai`.
-Keys resolve in two ways: platform env keys (billed against wallet credits,
-see Stripe below) or user-provided BYOK keys stored AES-256-GCM-encrypted in
-the database (`ENCRYPTION_KEY`). The full advisor experience (market-data
-tools) requires a tool-use-capable provider; without tool use the advisor is
-conversation-only.
+Called directly via `@anthropic-ai/sdk` and `openai`, and only on an instance
+that has opted in with `DISABLE_ADVISOR=false` — the default makes no LLM call
+at all, keys or no keys. Keys resolve in two ways: platform env keys (billed
+against wallet credits, see Stripe below) or user-provided BYOK keys stored
+AES-256-GCM-encrypted in the database (`ENCRYPTION_KEY`).
 
-### AI advisor — market data
+### Market data — Unusual Whales
 
 | Service            | Endpoint host           | Enabled by                                             |
 | ------------------ | ----------------------- | ------------------------------------------------------ |
 | Unusual Whales API | `api.unusualwhales.com` | Per-user API key, stored encrypted (settings, not env) |
 
-Options flow, stock quotes, and options chains, fetched server-side and passed
-to the LLM as tool results. The key is per-user BYOK in the
-`external_api_keys` table; `UNUSUAL_WHALES_BASE_URL` only overrides the host
-for test stubs.
+Options flow, stock quotes, and options chains, fetched server-side. Same
+opt-in as the LLM providers: nothing is called on the default posture. The key
+is per-user BYOK in the `external_api_keys` table; `UNUSUAL_WHALES_BASE_URL`
+only overrides the host for test stubs.
 
 ### Wallet billing — Stripe
 
@@ -46,7 +45,7 @@ for test stubs.
 | Inbound   | Payment-confirmation webhooks from Stripe | `STRIPE_WEBHOOK_SECRET` + reachable webhook |
 
 Both vars are required to enable billing; without them the purchase UI is
-absent and the advisor is BYOK-only. Note the **inbound** dependency: Stripe
+absent. Note the **inbound** dependency: Stripe
 must be able to reach the deployment's webhook endpoint.
 
 ### Changelog — GitHub API
@@ -74,7 +73,7 @@ privacy design.
 
 | Service                    | Purpose                                    | Enabled by                              |
 | -------------------------- | ------------------------------------------ | --------------------------------------- |
-| S3-compatible object store | Advisor image uploads (R2 / S3 / MinIO)    | All four `OBJECT_STORAGE_*` credentials |
+| S3-compatible object store | Uploaded images (R2 / S3 / MinIO)          | All four `OBJECT_STORAGE_*` credentials |
 | Redis                      | Shared rate limiting across API containers | `REDIS_URL`                             |
 
 Fallbacks when unset: images are stored inline as base64 in PostgreSQL;
@@ -94,12 +93,12 @@ dependencies.
 For locked-down networks, the complete set of hosts a fully configured
 instance connects out to:
 
-- `api.anthropic.com`, `api.openai.com` — advisor LLM calls
-- `api.unusualwhales.com` — advisor market-data tools
+- `api.anthropic.com`, `api.openai.com` — LLM calls (opt-in, `DISABLE_ADVISOR=false`)
+- `api.unusualwhales.com` — Unusual Whales market data (same opt-in)
 - `api.stripe.com` — wallet purchases
 - `api.github.com` — changelog releases feed
 - `us.i.posthog.com` (or configured host) — PostHog analytics, backend + frontend
-- The configured `OBJECT_STORAGE_ENDPOINT` — advisor images (hosted)
+- The configured `OBJECT_STORAGE_ENDPOINT` — uploaded images (hosted)
 - The configured `REDIS_URL` — rate limiting (hosted, multi-container)
 
 Inbound: Stripe webhooks.
@@ -116,7 +115,6 @@ Inbound: Stripe webhooks.
 
 ## Notably absent
 
-No chart-image APIs (users upload chart screenshots to the advisor), no
-external fonts or CDN scripts (the frontend bundle is self-contained), no
+No chart-image APIs, no external fonts or CDN scripts (the frontend bundle is self-contained), no
 external session store (sessions live in PostgreSQL), and no message queues.
 The only hard runtime dependency is PostgreSQL itself.

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -96,7 +96,8 @@ Two pairs of settings must be kept consistent or requests fail:
 - **nginx timeout ↔ app stream timeout.** `ADVISOR_NGINX_PROXY_TIMEOUT`
   (default `180s`, consumed by the `web`/nginx container) MUST exceed
   `ADVISOR_STREAM_TIMEOUT_MS` (default `120000`, the app). If nginx is shorter
-  it cuts advisor streaming responses early. The app should time out first.
+  it cuts streaming responses early. The app should time out first. Only
+  matters on an instance that opted in with `DISABLE_ADVISOR=false`.
 - **upload size ↔ images per message.** `MAX_UPLOAD_SIZE` (default `20m`,
   nginx `client_max_body_size`) must be large enough to carry
   `ADVISOR_MAX_IMAGES_PER_MESSAGE` (default `4`) images in one request, or large
@@ -122,8 +123,8 @@ terminate TLS — it is out of scope.
 
 ## Encryption key: pinning, mismatch crash-loop, and rotation
 
-The advisor encrypts stored provider keys with `ENCRYPTION_KEY` (AES-256-GCM,
-BYOK). Key material is loaded once at bootstrap.
+Stored API keys are encrypted with `ENCRYPTION_KEY` (AES-256-GCM, BYOK). Key
+material is loaded once at bootstrap.
 
 ### Pin the fingerprint
 


### PR DESCRIPTION
Follow-up to #81/#82: the root `docs/` maintainer files and `SECURITY.md` still narrated the advisor.

- `docs/external-services.md`: the two advisor sections become *LLM providers* and *Market data — Unusual Whales*, described as opt-in via `DISABLE_ADVISOR=false` (the default makes no call); Stripe, object-store and host-list wording adjusted; *Notably absent* trimmed.
- `docs/runbooks/deployment.md`: coupled-settings bullet says *streaming responses* and notes it only matters when opted in; encryption paragraph generalised.
- `docs/analytics.md`: `advisor_conversation_started` row removed (it cannot fire on the default posture).
- `docs/STYLE.md`, `docs/TERMS.md`: examples and the terminology row swapped/removed.
- `SECURITY.md`: scope example reworded.

What remains are env-var identifiers (`DISABLE_ADVISOR`, `ADVISOR_*`), which are the settings' real names. Docs-only; no generated pages touched.