### PR TITLE
fix(billing): mirror cancel_at as a scheduled cancellation

### DIFF
--- a/apps/api/src/features/billing/subscription.service.test.ts
+++ b/apps/api/src/features/billing/subscription.service.test.ts
@@ -249,6 +249,7 @@ interface FakeSubOverrides {
   customer?: unknown;
   status?: string;
   cancelAtPeriodEnd?: boolean;
+  cancelAtSec?: number | null;
   createdSec?: number;
   items?: unknown[];
 }
@@ -260,6 +261,7 @@ function fakeSub(over: FakeSubOverrides = {}): Stripe.Subscription {
     customer: over.customer ?? 'cus_1',
     status: over.status ?? 'active',
     cancel_at_period_end: over.cancelAtPeriodEnd ?? false,
+    cancel_at: over.cancelAtSec ?? null,
     created: over.createdSec ?? BASE_SEC,
     items: {
       data: over.items ?? [
@@ -676,6 +678,18 @@ describe('extractSubscriptionMirror — clover extraction (D6)', () => {
     expect(mirror.priceId).toBeNull();
     expect(mirror.priceUnitAmount).toBeNull();
     expect(mirror.priceCurrency).toBeNull();
+  });
+
+  it('treats a flexible-mode cancel_at (boolean false) as a scheduled cancellation', () => {
+    const sub = fakeSub({ cancelAtPeriodEnd: false, cancelAtSec: 1_700_100_000 });
+
+    expect(extractSubscriptionMirror(sub).cancelAtPeriodEnd).toBe(true);
+  });
+
+  it('mirrors cancelAtPeriodEnd false when neither cancel signal is set', () => {
+    const sub = fakeSub({ cancelAtPeriodEnd: false, cancelAtSec: null });
+
+    expect(extractSubscriptionMirror(sub).cancelAtPeriodEnd).toBe(false);
   });
 
   it('mirrors a null unit_amount as null (the card omits the price line)', () => {

--- a/apps/api/src/features/billing/subscription.service.ts
+++ b/apps/api/src/features/billing/subscription.service.ts
@@ -199,7 +199,10 @@ export function extractSubscriptionMirror(sub: Stripe.Subscription): ExtractedSu
     stripeCustomerId: resolveId(sub.customer),
     stripeSubscriptionId: sub.id,
     status: sub.status,
-    cancelAtPeriodEnd: sub.cancel_at_period_end,
+    // Flexible billing mode (Stripe's default for new subscriptions) records a
+    // Portal "cancel at period end" as `cancel_at` = period end with the boolean
+    // left false, so either signal counts as a scheduled cancellation.
+    cancelAtPeriodEnd: sub.cancel_at_period_end || sub.cancel_at != null,
     currentPeriodEnd: new Date(periodEndSeconds * 1000),
     priceId: price?.id ?? null,
     priceUnitAmount: price?.unit_amount ?? null,


### PR DESCRIPTION
Stripe subscriptions in flexible billing mode (the default for new subscriptions; the app never sets `billing_mode`) represent a Customer Portal "cancel at period end" as `cancel_at` = period-end timestamp with `cancel_at_period_end: false` (see https://docs.stripe.com/billing/subscriptions/billing-mode/compare, "Cancellations in the Customer Portal").

`extractSubscriptionMirror` only read the boolean, so a real Portal cancellation mirrored `cancelAtPeriodEnd: false`: the billing tab never showed the scheduled-cancel state and the `subscription_cancel_scheduled` analytics event never fired. Entitlement was unaffected.

Fix: `cancelAtPeriodEnd: sub.cancel_at_period_end || sub.cancel_at != null`, with a short comment explaining why.

Tests: `fakeSub` gains a `cancelAtSec` override; two new `extractSubscriptionMirror` cases cover `cancel_at` set with the boolean false (mirrors `true`) and neither signal set (mirrors `false`).