### PR TITLE
fix(billing): hide credit purchase UI when advisor is disabled

### DIFF
--- a/apps/web/src/hooks/useRegistrationEnabled.ts
+++ b/apps/web/src/hooks/useRegistrationEnabled.ts
@@ -55,7 +55,9 @@ export function useRegistrationEnabled(): { registrationEnabled: boolean; isPend
 
 /**
  * Whether this instance offers the AI advisor. Gates the sidebar entry, the
- * settings tab, the plan card's advisor rows and the options-chain viewer.
+ * settings tab, the plan card's advisor rows, the options-chain viewer, and
+ * the billing tab's credit purchase/usage surface (credits only fund platform
+ * advisor usage, so they have nothing to buy or spend on without it).
  *
  * Courtesy, not control, like {@link useRegistrationEnabled}: the control is
  * the 403 ADVISOR_DISABLED every /api/advisor route answers. Unlike

--- a/apps/web/src/routes/_auth.settings.billing.test.tsx
+++ b/apps/web/src/routes/_auth.settings.billing.test.tsx
@@ -104,8 +104,16 @@ function renderRoute(initialEntry: string) {
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
+// Advisor withdrawn by default (useAdvisorEnabled fails closed); tests that
+// exercise the opted-in state flip this before calling renderRoute.
+let advisorEnabled = false;
+
 beforeEach(() => {
+  advisorEnabled = false;
   vi.mocked(api.get).mockImplementation((path: string) => {
+    if (path === '/config') {
+      return Promise.resolve({ registrationEnabled: true, advisorEnabled });
+    }
     if (path === '/billing/config') {
       return Promise.resolve({ enabled: false, packs: [], models: [] });
     }
@@ -122,29 +130,42 @@ afterEach(() => {
 });
 
 describe('billing route — gating off, no subscription (REQ-11.7 state 4)', () => {
-  it("renders byte-identical today's billing-disabled output, with no plan card", async () => {
+  it('renders no credit mentions with the advisor withdrawn (default), no plan card', async () => {
     const { qc } = renderRoute('/settings/billing');
 
-    await screen.findByTestId('billing-disabled');
+    await screen.findByText('Manage your subscription.');
     // Wait until the tier read settled too, so the assertion covers the FINAL
     // output, not a still-loading intermediate.
     await waitFor(() => expect(qc.getQueryState(billingKeys.tier())?.status).toBe('success'));
 
     expect(screen.queryByTestId('plan-card')).toBeNull();
     expect(screen.queryByTestId('subscription-confirming')).toBeNull();
+    expect(screen.queryByTestId('billing-disabled')).toBeNull();
+    expect(screen.queryByTestId('billing-panel')).toBeNull();
+    expect(screen.queryByText(/credit/i)).toBeNull();
 
-    // Byte-identical pin: exactly the pre-plan-tiers markup of
-    // _auth.settings.billing.tsx's disabled state.
     const tab = document.querySelector('[data-slot="settings-billing"]');
     expect(tab).not.toBeNull();
     expect(tab!.outerHTML).toBe(
       '<div class="space-y-8" data-slot="settings-billing">' +
         '<div><h2 class="text-lg font-medium">Billing</h2>' +
-        '<p class="text-sm text-muted-foreground">View your credit balance, buy credits, and review usage.</p>' +
+        '<p class="text-sm text-muted-foreground">Manage your subscription.</p>' +
         '</div>' +
-        '<p class="text-sm text-muted-foreground" data-testid="billing-disabled">Billing is not enabled on this instance.</p>' +
         '</div>',
     );
+  });
+});
+
+describe('billing route — advisor enabled (opted in)', () => {
+  it('shows the credit purchase copy and graceful-absence notice when Stripe is unconfigured', async () => {
+    advisorEnabled = true;
+    renderRoute('/settings/billing');
+
+    await screen.findByTestId('billing-disabled');
+    expect(
+      screen.getByText('View your credit balance, buy credits, and review usage.'),
+    ).toBeTruthy();
+    expect(screen.queryByTestId('billing-panel')).toBeNull();
   });
 });
 
@@ -163,7 +184,7 @@ describe('billing route — ?subscription=confirming (REQ-2.6)', () => {
     // as a boolean. Validation must be total: no error boundary, no banner.
     renderRoute('/settings/billing?subscription=true');
 
-    expect(await screen.findByTestId('billing-disabled')).toBeTruthy();
+    expect(await screen.findByText('Manage your subscription.')).toBeTruthy();
     expect(screen.queryByTestId('subscription-confirming')).toBeNull();
   });
 });

--- a/apps/web/src/routes/_auth.settings.billing.tsx
+++ b/apps/web/src/routes/_auth.settings.billing.tsx
@@ -5,6 +5,7 @@ import { BillingPanel } from '@/features/billing/BillingPanel';
 import { PlanCard } from '@/features/billing/PlanCard';
 import { UsageHistory } from '@/features/billing/UsageHistory';
 import { useBillingConfig } from '@/features/billing/useWalletBalance';
+import { useAdvisorEnabled } from '@/hooks/useRegistrationEnabled';
 
 // Stripe Checkout returns to `?subscription=confirming` (REQ-2.6); the cancel
 // return is the bare tab. Total validation: the router JSON-parses search
@@ -17,13 +18,20 @@ const BillingSearchSchema = z.object({
 function SettingsBilling() {
   const { subscription } = Route.useSearch();
   const { data: config, isLoading } = useBillingConfig();
+  // Credits fund platform (non-BYOK) advisor usage — with the advisor
+  // withdrawn by default (useRegistrationEnabled.useAdvisorEnabled), there is
+  // nothing to buy or spend them on, so the whole purchase surface stays
+  // hidden alongside the advisor itself.
+  const advisorEnabled = useAdvisorEnabled();
 
   return (
     <div className="space-y-8" data-slot="settings-billing">
       <div>
         <h2 className="text-lg font-medium">Billing</h2>
         <p className="text-sm text-muted-foreground">
-          View your credit balance, buy credits, and review usage.
+          {advisorEnabled
+            ? 'View your credit balance, buy credits, and review usage.'
+            : 'Manage your subscription.'}
         </p>
       </div>
 
@@ -34,20 +42,21 @@ function SettingsBilling() {
           surfaces below only. */}
       <PlanCard confirming={subscription === 'confirming'} />
 
-      {isLoading ? (
-        <p className="text-sm text-muted-foreground">Loading…</p>
-      ) : config?.enabled ? (
-        <>
-          <BillingPanel packs={config.packs} />
-          <UsageHistory />
-        </>
-      ) : (
-        // Graceful absence (REQ-7.4): Stripe is not configured on this instance,
-        // so there is nothing to purchase. The rest of settings is unaffected.
-        <p className="text-sm text-muted-foreground" data-testid="billing-disabled">
-          Billing is not enabled on this instance.
-        </p>
-      )}
+      {advisorEnabled &&
+        (isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        ) : config?.enabled ? (
+          <>
+            <BillingPanel packs={config.packs} />
+            <UsageHistory />
+          </>
+        ) : (
+          // Graceful absence (REQ-7.4): Stripe is not configured on this instance,
+          // so there is nothing to purchase. The rest of settings is unaffected.
+          <p className="text-sm text-muted-foreground" data-testid="billing-disabled">
+            Billing is not enabled on this instance.
+          </p>
+        ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Credits only fund platform (non-BYOK) advisor usage, so with the advisor withdrawn by default (#82), the settings/billing page still showed credit balance / buy-credits / usage-history UI for a feature that isn't running on the instance.
- Gate that section on `useAdvisorEnabled()`, the same pattern `PlanCard` already uses for its own advisor-specific rows — this was the spot that got missed.
- Intro copy now reads "Manage your subscription." by default, and only mentions credits when the advisor is actually enabled.

## Test plan
- [x] `vitest run` on the billing route test + `PlanCard` + settings route tests — all pass
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on touched files
- [x] Confirmed the e2e wallet-billing/visual-regression specs are unaffected — their harness explicitly re-enables the advisor (`DISABLE_ADVISOR=false`) to exercise this still-shipped code path
