### PR TITLE
docs(readme): the hosted option is open, not planned

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,11 @@ order.
 **Self-hosted, with the quickstart below** — free and completely unlimited, forever. No
 feature is fenced off; plan gating is a single deployment setting that ships **off**.
 
-A managed option at `app.tradr.cloud` is planned and **not open yet**, so self-hosting is
-the way to run Tradr today. Nothing about the self-hosted build depends on it.
+**Hosted at [app.tradr.cloud](https://app.tradr.cloud)**, if you'd rather not run a
+server. It is the same software from the same releases, with backups and upgrades handled
+for you. The free plan is capped ([what the caps
+are](https://docs.tradr.cloud/user-guide/reference/plan-limits/)); Pro lifts them for $10
+a month. Nothing in the self-hosted build depends on it, and your data exports either way.
 
 ## Quickstart
 


### PR DESCRIPTION
**Do not merge until registration is actually open on `app.tradr.cloud`.** This is the only paragraph in the repo that told a reader the managed option was unreleased, and merging it early points people at a closed door.

## What changed

One paragraph in `README.md`. Before:

> A managed option at `app.tradr.cloud` is planned and **not open yet**, so self-hosting is the way to run Tradr today. Nothing about the self-hosted build depends on it.

After: a link to the app, what it actually is (same software, same releases, managed backups and upgrades), the free plan's caps behind the generated plan-limits reference, and Pro at $10 a month. The "nothing in the self-hosted build depends on it" clause survives, because that has not changed.

Self-hosting keeps the first slot in the section. Nothing else about the repo's posture moves.

## Verified

Both links resolve: `docs.tradr.cloud/user-guide/reference/plan-limits/` → 200, `app.tradr.cloud` → 200.

I swept the repo for other pre-launch copy while I was here (`not open yet`, `coming soon`, `waitlist`, `when it opens`, `early access`, across `.md`/`.mdx`/`.ts`/`.tsx`/`.astro`). This paragraph was the only hit. The docs already describe the managed app as something that exists.

## One thing I found and did not fix

`apps/docs/.../user-guide/explanation/hosted-vs-self-hosted.mdx` describes hosted billing as "Stripe wallet" and LLM access as "wallet credits". That is not what launch ships: billing is a Pro subscription, and the credit-purchase UI is hidden while the advisor is off (#85). The page is explicitly marked a stub, and correcting it is a separate change from "stop saying coming soon", so I left it. Worth a follow-up before anyone reads it in anger.