### PR TITLE
feat(dashboard): move the setup checklist into the widget grid

### DIFF
--- a/apps/web/src/features/dashboard/components/DashboardGrid.test.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardGrid.test.tsx
@@ -488,6 +488,153 @@ describe('DashboardGrid — gesture completion is the only write path', () => {
 });
 
 // ---------------------------------------------------------------------------
+// The aside: a transient item the grid shows top-right and never persists
+// (the activation checklist).
+// ---------------------------------------------------------------------------
+
+describe('DashboardGrid — the aside', () => {
+  const stored: WidgetPlacement[] = [
+    W({ id: 'a', type: 'stats-summary', x: 0, y: 0, w: 12, h: STATS_MIN_H }),
+    W({ id: 'b', type: 'performance-chart', x: 0, y: STATS_MIN_H, w: 8, h: PERF_MIN_H }),
+  ];
+  const aside = { id: 'note', w: 4, h: STATS_MIN_H, node: <p data-testid="aside-node">aside</p> };
+
+  function mountWith(asideProp: typeof aside | undefined, scheduleLayoutWrite = vi.fn()) {
+    installMatchMediaSpy({});
+    const { container, root } = mountIntoBody();
+    const render = (next: typeof aside | undefined): void => {
+      act(() => {
+        root.render(
+          <DashboardGrid
+            widgets={stored}
+            aside={next}
+            onRemove={() => undefined}
+            scheduleLayoutWrite={scheduleLayoutWrite}
+          />,
+        );
+      });
+    };
+    render(asideProp);
+    const unmount = (): void => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    };
+    return { container, render, unmount, scheduleLayoutWrite };
+  }
+
+  it('renders the node in a locked top-right item and narrows what it displaces, without writing', () => {
+    const { container, unmount, scheduleLayoutWrite } = mountWith(aside);
+    const grid = gridOf(container);
+
+    const item = container.querySelector('[data-grid-aside="note"]') as GridItemHTMLElement | null;
+    expect(item).not.toBeNull();
+    expect(item!.contains(container.querySelector('[data-testid="aside-node"]'))).toBe(true);
+    expect(item!.gridstackNode).toMatchObject({
+      x: GRID_COLUMNS - 4,
+      y: 0,
+      w: 4,
+      h: STATS_MIN_H,
+      locked: true,
+      noMove: true,
+      noResize: true,
+    });
+    // It is not a widget: no card chrome, no `data-widget-id`.
+    expect(item!.hasAttribute('data-widget-id')).toBe(false);
+    expect(item!.querySelector('section[data-widget-id]')).toBeNull();
+
+    // Stats Summary is shown at eight columns beside it; nothing else moved.
+    expect(itemOf(grid, 'a').gridstackNode).toMatchObject({ x: 0, y: 0, w: 8, h: STATS_MIN_H });
+    expect(itemOf(grid, 'b').gridstackNode).toMatchObject({ x: 0, y: STATS_MIN_H, w: 8 });
+    // Making room is a view, not an edit.
+    expect(scheduleLayoutWrite).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('gives the room back when the aside goes, still without writing', () => {
+    const { container, render, unmount, scheduleLayoutWrite } = mountWith(aside);
+    const grid = gridOf(container);
+    expect(itemOf(grid, 'a').gridstackNode?.w).toBe(8);
+
+    render(undefined);
+    expect(container.querySelector('[data-grid-aside]')).toBeNull();
+    expect(itemOf(grid, 'a').gridstackNode).toMatchObject({ x: 0, y: 0, w: 12, h: STATS_MIN_H });
+    expect(container.querySelectorAll('.grid-stack-item')).toHaveLength(2);
+    expect(scheduleLayoutWrite).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('a gesture persists neither the aside nor the narrowing of a widget it left alone', () => {
+    const { container, unmount, scheduleLayoutWrite } = mountWith(aside);
+    const grid = gridOf(container);
+
+    // Drag the chart into empty canvas below everything; Stats Summary is untouched.
+    const emptyRow = STATS_MIN_H + PERF_MIN_H;
+    const itemB = itemOf(grid, 'b');
+    grid.update(itemB, { x: 0, y: emptyRow, w: 8, h: PERF_MIN_H });
+    fireGesture(grid, 'dragstop', itemB);
+
+    expect(scheduleLayoutWrite).toHaveBeenCalledTimes(1);
+    const written = scheduleLayoutWrite.mock.calls[0][0] as WidgetPlacement[];
+    expect(written.map((widget) => widget.id).sort()).toEqual(['a', 'b']);
+    // The stored full width, not the eight columns on screen.
+    expect(written.find((widget) => widget.id === 'a')).toMatchObject({
+      x: 0,
+      y: 0,
+      w: 12,
+      h: STATS_MIN_H,
+    });
+    expect(written.find((widget) => widget.id === 'b')).toMatchObject({
+      x: 0,
+      y: emptyRow,
+      w: 8,
+      h: PERF_MIN_H,
+    });
+    unmount();
+  });
+
+  it('a gesture on the narrowed widget itself persists where the user put it', () => {
+    const { container, unmount, scheduleLayoutWrite } = mountWith(aside);
+    const grid = gridOf(container);
+
+    const emptyRow = STATS_MIN_H + PERF_MIN_H;
+    const itemA = itemOf(grid, 'a');
+    grid.update(itemA, { x: 0, y: emptyRow, w: 8, h: STATS_MIN_H });
+    fireGesture(grid, 'dragstop', itemA);
+
+    const written = scheduleLayoutWrite.mock.calls[0][0] as WidgetPlacement[];
+    expect(written.find((widget) => widget.id === 'a')).toMatchObject({ x: 0, y: emptyRow, w: 8 });
+    unmount();
+  });
+
+  it('leads the mobile stack', () => {
+    installMatchMediaSpy({ '(max-width: 767px)': true });
+    const { container, root } = mountIntoBody();
+    act(() => {
+      root.render(
+        <DashboardGrid
+          widgets={stored}
+          aside={aside}
+          onRemove={() => undefined}
+          scheduleLayoutWrite={vi.fn()}
+        />,
+      );
+    });
+    const stack = container.querySelector('[data-grid-mode="mobile"]')!;
+    expect(stack.firstElementChild?.tagName).toBe('SPAN'); // the sr-only instructions
+    expect(stack.children[1]?.getAttribute('data-grid-aside')).toBe('note');
+    expect(stack.children[1]?.contains(container.querySelector('[data-testid="aside-node"]'))).toBe(
+      true,
+    );
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Mobile fallback (Req 4.9)
 // ---------------------------------------------------------------------------
 

--- a/apps/web/src/features/dashboard/components/DashboardGrid.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardGrid.tsx
@@ -6,13 +6,13 @@ import {
   type GridStackOptions,
   type GridStackWidget,
 } from 'gridstack';
-import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactElement, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
 import { PerWidgetMinSize, type WidgetPlacement } from '@tradr/shared/schemas/dashboard';
 
 import { GRID_COLUMNS, GRID_GAP_PX, GRID_MAX_ROWS, GRID_ROW_HEIGHT_PX } from '../grid.constants';
-import { sortByYThenX } from '../layout';
+import { keepStoredGeometry, reserveTopRightSlot, sortByYThenX } from '../layout';
 
 import { WidgetCard, WIDGET_DRAG_CANCEL_CLASS, WIDGET_DRAG_HANDLE_CLASS } from './WidgetCard';
 
@@ -132,8 +132,22 @@ export function createGridOptions(): GridStackOptions {
   };
 }
 
+/**
+ * A transient item the grid shows in its top-right corner without ever
+ * persisting it — the activation checklist. It is locked in place (no drag, no
+ * resize) and the widgets around it give way for as long as it is mounted; see
+ * `reserveTopRightSlot`. Its id must never be a widget id.
+ */
+export interface GridAside {
+  id: string;
+  w: number;
+  h: number;
+  node: ReactNode;
+}
+
 export interface DashboardGridProps {
   widgets: WidgetPlacement[];
+  aside?: GridAside;
   onRemove: (id: string) => void;
   /**
    * Called with the next `widgets[]` after a drag-end or resize-end. The route
@@ -229,11 +243,23 @@ const NO_HOSTS: ReadonlyMap<string, HTMLElement> = new Map();
  */
 function DashboardGridCanvas({
   widgets,
+  aside,
   onRemove,
   scheduleLayoutWrite,
   onUpdateConfig,
 }: DashboardGridProps): ReactElement {
   const rootRef = useRef<HTMLDivElement | null>(null);
+  // What gridstack is handed: the stored layout, or that layout with room made
+  // for the aside. `widgets` itself stays the stored truth for the write path.
+  const asideW = aside?.w;
+  const asideH = aside?.h;
+  const shown = useMemo(
+    () =>
+      asideW !== undefined && asideH !== undefined
+        ? reserveTopRightSlot(widgets, { w: asideW, h: asideH })
+        : widgets,
+    [widgets, asideW, asideH],
+  );
   const [grid, setGrid] = useState<GridStack | null>(null);
   /**
    * Portal targets, by widget id. State rather than a ref because the elements
@@ -247,6 +273,10 @@ function DashboardGridCanvas({
   // registered once, at init, and would otherwise close over a stale render.
   const widgetsRef = useRef(widgets);
   widgetsRef.current = widgets;
+  const shownRef = useRef(shown);
+  shownRef.current = shown;
+  const asideRef = useRef(aside);
+  asideRef.current = aside;
   const scheduleLayoutWriteRef = useRef(scheduleLayoutWrite);
   scheduleLayoutWriteRef.current = scheduleLayoutWrite;
 
@@ -273,7 +303,13 @@ function DashboardGridCanvas({
         saved.w = node.w;
         saved.h = node.h;
       }) as GridStackWidget[];
-      scheduleLayoutWriteRef.current(fromGridWidgets(nodes, widgetsRef.current));
+      // The aside has no matching widget, so `fromGridWidgets` drops it here:
+      // it is never persisted. What IS persisted, while the aside is up, is
+      // the stored geometry for every widget the gesture left alone.
+      const moved = fromGridWidgets(nodes, shownRef.current);
+      scheduleLayoutWriteRef.current(
+        asideRef.current ? keepStoredGeometry(moved, shownRef.current, widgetsRef.current) : moved,
+      );
     };
     instance.on('dragstop', commit);
     instance.on('resizestop', commit);
@@ -295,9 +331,24 @@ function DashboardGridCanvas({
   // differs. After a gesture the route echoes our own placements back as
   // `widgets`, so the common case is a no-op; a failed PUT rolls the query
   // cache back and this is what returns the widget to where it was.
+  const asideId = aside?.id;
   useEffect(() => {
     if (!grid) return;
-    const desired = toGridWidgets(widgets);
+    const desired: IdentifiedGridWidget[] = toGridWidgets(shown);
+    if (asideId !== undefined && asideW !== undefined && asideH !== undefined) {
+      // Locked: nothing the user drags can push it, and gridstack routes a
+      // widget dropped onto it underneath instead. No handle, no resize.
+      desired.unshift({
+        id: asideId,
+        x: GRID_COLUMNS - asideW,
+        y: 0,
+        w: asideW,
+        h: asideH,
+        locked: true,
+        noMove: true,
+        noResize: true,
+      });
+    }
     const desiredIds = new Set(desired.map((widget) => widget.id));
 
     const existing = new Map<string, GridItemHTMLElement>();
@@ -322,7 +373,10 @@ function DashboardGridCanvas({
           // React's anyway. It only has to create the empty item + content divs.
           const created = grid.addWidget(widget);
           if (created) {
-            created.setAttribute('data-widget-id', widget.id);
+            created.setAttribute(
+              widget.id === asideId ? 'data-grid-aside' : 'data-widget-id',
+              widget.id,
+            );
             existing.set(widget.id, created);
             membershipChanged = true;
           }
@@ -348,13 +402,16 @@ function DashboardGridCanvas({
       if (content) hosts.set(id, content);
     }
     setContentHosts(hosts);
-  }, [grid, widgets]);
+  }, [grid, shown, asideId, asideW, asideH]);
 
   return (
     <div data-grid-mode="grid" className="w-full">
       <div ref={rootRef} className="grid-stack" />
+      {grid && aside && contentHosts.has(aside.id)
+        ? createPortal(aside.node, contentHosts.get(aside.id)!, aside.id)
+        : null}
       {grid
-        ? widgets.map((widget) => {
+        ? shown.map((widget) => {
             const host = contentHosts.get(widget.id);
             if (!host) return null;
             return (
@@ -375,6 +432,7 @@ function DashboardGridCanvas({
 
 export function DashboardGrid({
   widgets,
+  aside,
   onRemove,
   scheduleLayoutWrite,
   onUpdateConfig,
@@ -419,6 +477,11 @@ export function DashboardGrid({
         <span id="dashboard-grid-mobile-instructions" className="sr-only">
           Reorder requires a pointer-fine device
         </span>
+        {aside ? (
+          <div data-grid-aside={aside.id} className="w-full">
+            {aside.node}
+          </div>
+        ) : null}
         {sortedForMobile.map((widget) => (
           <div
             key={widget.id}
@@ -443,6 +506,7 @@ export function DashboardGrid({
   return (
     <DashboardGridCanvas
       widgets={widgets}
+      aside={aside}
       onRemove={onRemove}
       scheduleLayoutWrite={scheduleLayoutWrite}
       onUpdateConfig={onUpdateConfig}

--- a/apps/web/src/features/dashboard/layout.test.ts
+++ b/apps/web/src/features/dashboard/layout.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { type WidgetPlacement } from '@tradr/shared';
+import { DEFAULT_WIDGETS, PerWidgetMinSize, type WidgetPlacement } from '@tradr/shared';
 
-import { findFirstSlot, sortByYThenX } from './layout';
+import { findFirstSlot, keepStoredGeometry, reserveTopRightSlot, sortByYThenX } from './layout';
 
 const W = (over: Partial<WidgetPlacement>): WidgetPlacement =>
   ({
@@ -35,5 +35,93 @@ describe('sortByYThenX', () => {
     ];
     expect(sortByYThenX(input).map((w) => w.id)).toEqual(['a', 'b', 'c', 'd']);
     expect(input.map((w) => w.id)).toEqual(['d', 'b', 'c', 'a']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The transient top-right slot (the activation checklist's grid item).
+// ---------------------------------------------------------------------------
+
+const STATS_MIN_W = PerWidgetMinSize['stats-summary'].w;
+
+describe('reserveTopRightSlot', () => {
+  const slot = { w: 4, h: 6 };
+
+  it('narrows a widget that straddles the slot when the part left of it is a legal width', () => {
+    // The default Stats Summary: full width on the top row.
+    const shown = reserveTopRightSlot([W({ id: 'a', x: 0, y: 0, w: 12, h: 6 })], slot);
+    expect(shown).toEqual([W({ id: 'a', x: 0, y: 0, w: 8, h: 6 })]);
+  });
+
+  it('moves a widget below the slot when narrowing would take it under its minimum', () => {
+    // Anchored at x=6, only two columns would survive — fewer than the type's minimum.
+    expect(STATS_MIN_W).toBeGreaterThan(2);
+    const shown = reserveTopRightSlot([W({ id: 'a', x: 6, y: 0, w: 6, h: 6 })], slot);
+    expect(shown).toEqual([W({ id: 'a', x: 6, y: 6, w: 6, h: 6 })]);
+  });
+
+  it('moves a widget wholly inside the slot below it', () => {
+    const shown = reserveTopRightSlot(
+      [W({ id: 'a', type: 'account-balances', x: 8, y: 2, w: 4, h: 4 })],
+      slot,
+    );
+    expect(shown[0]).toMatchObject({ x: 8, y: 6, w: 4, h: 4 });
+  });
+
+  it('pushes whatever a moved widget lands on further down, so nothing overlaps', () => {
+    const shown = reserveTopRightSlot(
+      [
+        W({ id: 'a', type: 'account-balances', x: 8, y: 0, w: 4, h: 4 }),
+        W({ id: 'b', type: 'position-sizing', x: 8, y: 6, w: 4, h: 6 }),
+      ],
+      slot,
+    );
+    expect(shown.find((w) => w.id === 'a')).toMatchObject({ x: 8, y: 6 });
+    expect(shown.find((w) => w.id === 'b')).toMatchObject({ x: 8, y: 10 });
+  });
+
+  it('leaves widgets clear of the slot exactly as stored, by reference', () => {
+    const left = W({ id: 'a', x: 0, y: 0, w: 8, h: 6 });
+    const below = W({ id: 'b', type: 'account-balances', x: 8, y: 6, w: 4, h: 12 });
+    const shown = reserveTopRightSlot([left, below], slot);
+    expect(shown[0]).toBe(left);
+    expect(shown[1]).toBe(below);
+  });
+
+  it('reflows the default layout to Stats Summary at eight columns and nothing else moved', () => {
+    const stored = DEFAULT_WIDGETS.map((d, i) => W({ ...d, id: `w${i}` }));
+    const shown = reserveTopRightSlot(stored, slot);
+    expect(shown[0]).toMatchObject({ type: 'stats-summary', x: 0, y: 0, w: 8, h: 6 });
+    expect(shown.slice(1)).toEqual(stored.slice(1));
+  });
+});
+
+describe('keepStoredGeometry', () => {
+  const stored = [
+    W({ id: 'a', x: 0, y: 0, w: 12, h: 6 }),
+    W({ id: 'b', type: 'performance-chart', x: 0, y: 6, w: 8, h: 12 }),
+  ];
+  const shown = reserveTopRightSlot(stored, { w: 4, h: 6 });
+
+  it('restores the stored geometry of a widget the gesture left where it was shown', () => {
+    // The user dragged `b` down; `a` still sits narrowed where the slot put it.
+    const next = [{ ...shown[0] }, { ...shown[1], y: 20 }];
+    const kept = keepStoredGeometry(next, shown, stored);
+    expect(kept.find((w) => w.id === 'a')).toMatchObject({ x: 0, y: 0, w: 12, h: 6 });
+    expect(kept.find((w) => w.id === 'b')).toMatchObject({ x: 0, y: 20, w: 8, h: 12 });
+  });
+
+  it('keeps the new geometry of a widget the gesture moved, narrowed or not', () => {
+    const next = [{ ...shown[0], y: 1 }, { ...shown[1] }];
+    const kept = keepStoredGeometry(next, shown, stored);
+    // Moved one row: it stays eight columns wide, where the user put it…
+    expect(kept.find((w) => w.id === 'a')).toMatchObject({ x: 0, y: 1, w: 8, h: 6 });
+    // …and `b`, restored to its stored row, is pushed clear of it rather than
+    // left overlapping.
+    expect(kept.find((w) => w.id === 'b')).toMatchObject({ x: 0, y: 7, w: 8, h: 12 });
+  });
+
+  it('is the identity when nothing was shown differently', () => {
+    expect(keepStoredGeometry(stored, stored, stored)).toEqual(stored);
   });
 });

--- a/apps/web/src/features/dashboard/layout.ts
+++ b/apps/web/src/features/dashboard/layout.ts
@@ -1,6 +1,21 @@
-import type { WidgetPlacement } from '@tradr/shared';
+import { PerWidgetMinSize, reconcileStoredLayout, type WidgetPlacement } from '@tradr/shared';
 
 import { GRID_COLUMNS, GRID_MAX_ROWS } from './grid.constants';
+
+interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+function overlaps(a: Rect, b: Rect): boolean {
+  return a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h;
+}
+
+function sameGeometry(a: Rect, b: Rect): boolean {
+  return a.x === b.x && a.y === b.y && a.w === b.w && a.h === b.h;
+}
 
 /**
  * Pure helper: left-to-right top-to-bottom packing.
@@ -13,18 +28,10 @@ export function findFirstSlot(
   existing: WidgetPlacement[],
   size: { w: number; h: number },
 ): { x: number; y: number } {
-  function overlaps(x: number, y: number): boolean {
-    for (const p of existing) {
-      const a = { x, y, w: size.w, h: size.h };
-      const overlapsX = a.x < p.x + p.w && p.x < a.x + a.w;
-      const overlapsY = a.y < p.y + p.h && p.y < a.y + a.h;
-      if (overlapsX && overlapsY) return true;
-    }
-    return false;
-  }
   for (let y = 0; y <= GRID_MAX_ROWS * 4; y++) {
     for (let x = 0; x + size.w <= GRID_COLUMNS; x++) {
-      if (!overlaps(x, y)) return { x, y };
+      const candidate = { x, y, w: size.w, h: size.h };
+      if (!existing.some((p) => overlaps(candidate, p))) return { x, y };
     }
   }
   return { x: 0, y: 0 };
@@ -33,4 +40,55 @@ export function findFirstSlot(
 /** Reading order for the grid: top-to-bottom, then left-to-right. */
 export function sortByYThenX(widgets: WidgetPlacement[]): WidgetPlacement[] {
   return [...widgets].sort((a, b) => a.y - b.y || a.x - b.x);
+}
+
+/**
+ * The layout to SHOW while a transient item occupies the top-right `size`
+ * block of the grid — the activation checklist's slot.
+ *
+ * The stored layout is left alone; this is a view of it. A widget that
+ * overlaps the block gives way in one of two ways: if the part of it left of
+ * the block is still a legal width for its type, it is narrowed to that part
+ * (the default Stats Summary at `(0,0,12,6)` becomes `(0,0,8,6)`); otherwise
+ * it moves down to the row under the block. Anything that then collides is
+ * pushed down in reading order by the same reflow a stored layout gets on read,
+ * so the result never overlaps. Widgets clear of the block keep their geometry.
+ */
+export function reserveTopRightSlot(
+  widgets: WidgetPlacement[],
+  size: { w: number; h: number },
+): WidgetPlacement[] {
+  const slot: Rect = { x: GRID_COLUMNS - size.w, y: 0, w: size.w, h: size.h };
+  const moved = widgets.map((widget) => {
+    if (!overlaps(widget, slot)) return widget;
+    const keep = slot.x - widget.x;
+    if (keep >= PerWidgetMinSize[widget.type].w) return { ...widget, w: keep };
+    return { ...widget, y: slot.y + slot.h };
+  });
+  return reconcileStoredLayout(moved);
+}
+
+/**
+ * The inverse, for the write path: a gesture on the grid reports EVERY item's
+ * geometry, in the terms of the shown layout. A widget the gesture did not
+ * move — one still exactly where `reserveTopRightSlot` put it — goes back to
+ * its stored geometry, so the Stats Summary that was narrowed to make room is
+ * not persisted narrow because the user dragged something else. A widget the
+ * gesture did move (or push) keeps the geometry it was given. The reflow runs
+ * once more because restored and moved geometry can, in principle, meet.
+ */
+export function keepStoredGeometry(
+  next: WidgetPlacement[],
+  shown: WidgetPlacement[],
+  stored: WidgetPlacement[],
+): WidgetPlacement[] {
+  const shownById = new Map(shown.map((widget) => [widget.id, widget]));
+  const storedById = new Map(stored.map((widget) => [widget.id, widget]));
+  const merged = next.map((widget) => {
+    const wasShown = shownById.get(widget.id);
+    const wasStored = storedById.get(widget.id);
+    if (!wasShown || !wasStored || !sameGeometry(widget, wasShown)) return widget;
+    return { ...widget, x: wasStored.x, y: wasStored.y, w: wasStored.w, h: wasStored.h };
+  });
+  return reconcileStoredLayout(merged);
 }

--- a/apps/web/src/features/onboarding/components/ActivationChecklist.test.tsx
+++ b/apps/web/src/features/onboarding/components/ActivationChecklist.test.tsx
@@ -18,7 +18,7 @@ import { deriveChecklist, type ChecklistItemId } from '../lib/derive-checklist';
 
 vi.mock('../hooks/useOnboarding', () => ({ useOnboarding: vi.fn() }));
 
-import { ActivationChecklist } from './ActivationChecklist';
+import { ActivationChecklist, resolveChecklistView } from './ActivationChecklist';
 
 const mockUseOnboarding = vi.mocked(useOnboarding);
 
@@ -416,6 +416,87 @@ describe('ActivationChecklist — keyboard and design-system gates', () => {
 
     for (const el of document.querySelectorAll('[data-slot="skeleton"]')) {
       expect(el.className).toContain('motion-reduce:animate-none');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// `resolveChecklistView` — the one statement of which of the four things the
+// checklist shows. The route reads it too (to tell the grid whether to make
+// room), so it is pinned here against the same cases the component is.
+// ---------------------------------------------------------------------------
+
+describe('resolveChecklistView', () => {
+  it('answers `card` for an outstanding checklist and `none` for a finished one', () => {
+    expect(
+      resolveChecklistView({
+        checklist: checklistOf(),
+        preference: preference('pending'),
+        isError: false,
+      }),
+    ).toBe('card');
+    expect(
+      resolveChecklistView({
+        checklist: checklistOf(ALL_DONE),
+        preference: preference('active'),
+        isError: false,
+      }),
+    ).toBe('none');
+  });
+
+  it('answers `loading` only once the status is known and the reads are still out', () => {
+    expect(
+      resolveChecklistView({
+        checklist: undefined,
+        preference: preference('pending'),
+        isError: false,
+      }),
+    ).toBe('loading');
+    expect(
+      resolveChecklistView({ checklist: undefined, preference: undefined, isError: false }),
+    ).toBe('none');
+    expect(
+      resolveChecklistView({
+        checklist: undefined,
+        preference: preference('pending'),
+        isError: true,
+      }),
+    ).toBe('none');
+  });
+
+  it('answers `reopen` for a dismissal and `none` for a retirement', () => {
+    expect(
+      resolveChecklistView({ checklist: null, preference: preference('skipped'), isError: false }),
+    ).toBe('reopen');
+    expect(
+      resolveChecklistView({ checklist: null, preference: preference('done'), isError: false }),
+    ).toBe('none');
+  });
+
+  it('agrees with the component on every case', () => {
+    const cases = [
+      { checklist: checklistOf(), preference: preference('pending') },
+      { checklist: checklistOf(ALL_DONE), preference: preference('active') },
+      { checklist: undefined, preference: preference('pending') },
+      { checklist: undefined, preference: undefined },
+      { checklist: null, preference: preference('skipped') },
+      { checklist: null, preference: preference('done') },
+    ] as const;
+    const testIdFor = {
+      card: 'activation-checklist',
+      loading: 'activation-checklist-loading',
+      reopen: 'activation-checklist-reopen',
+    } as const;
+    for (const c of cases) {
+      useHook({ ...c });
+      const { unmount } = render(<ActivationChecklist />);
+      const view = resolveChecklistView({ ...c, isError: false });
+      for (const [name, testId] of Object.entries(testIdFor)) {
+        expect(screen.queryByTestId(testId) !== null, `${name} for ${JSON.stringify(c)}`).toBe(
+          view === name,
+        );
+      }
+      unmount();
     }
   });
 });

--- a/apps/web/src/features/onboarding/components/ActivationChecklist.tsx
+++ b/apps/web/src/features/onboarding/components/ActivationChecklist.tsx
@@ -1,5 +1,19 @@
 // ActivationChecklist — the four-item "what set up means" list.
 //
+// IT WEARS THE WIDGET CHROME, NOT A CARD'S. On the populated dashboard it is a
+// grid item — locked in the top-right slot, never persisted — and a card with
+// its own border weight and radius sat in that grid like a visitor. So the
+// shell here is `WidgetCard`'s (hairline border, `rounded-md`, the mono
+// uppercase title strip, with the progress line in it), and the same shell
+// serves every other mount: the zero-state, the empty layout, the mobile stack.
+// Nothing here knows which one it is in — the caller sizes the box, this fills
+// it.
+//
+// `resolveChecklistView` IS THE ONE STATEMENT OF WHICH OF THE FOUR THINGS TO
+// SHOW. The route needs the same answer BEFORE rendering, to tell the grid
+// whether to make room, and a second copy of the rules there is a second thing
+// to get wrong. So the rules live in the function and the component reads it.
+//
 // It renders derived state and writes nothing except the onboarding STATUS.
 // Every completion decision comes from `useOnboarding().checklist`, which is
 // `deriveChecklist`'s output: this file must never restate a rule like
@@ -79,22 +93,31 @@
 // never rests on colour alone.
 
 import { Circle, CircleCheck, Play, RotateCcw, X } from 'lucide-react';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, type ComponentProps, type ReactNode } from 'react';
 
 import { Button } from '@/components/ui/button';
-import {
-  Card,
-  CardAction,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 
-import { useOnboarding } from '../hooks/useOnboarding';
+import { useOnboarding, type UseOnboardingResult } from '../hooks/useOnboarding';
 import type { ChecklistItemId } from '../lib/derive-checklist';
+
+/** What the checklist renders as, for the three checklist values (above). */
+export type ChecklistView = 'none' | 'loading' | 'reopen' | 'card';
+
+export function resolveChecklistView({
+  checklist,
+  preference,
+  isError,
+}: Pick<UseOnboardingResult, 'checklist' | 'preference' | 'isError'>): ChecklistView {
+  // "There is no checklist for this user." Only a dismissal leaves a trace.
+  if (checklist === null) return preference?.status === 'skipped' ? 'reopen' : 'none';
+  // "Not known yet." A terminal failure is not a loading state, and neither is
+  // an unknown status — see the note on `undefined` above.
+  if (checklist === undefined) return isError || preference === undefined ? 'none' : 'loading';
+  // Retired. The component persists it; this stops showing it now.
+  return checklist.allComplete ? 'none' : 'card';
+}
 
 interface ActivationChecklistProps {
   /**
@@ -126,6 +149,38 @@ interface ActivationChecklistProps {
   canStartStep?: (id: ChecklistItemId) => boolean;
 }
 
+/**
+ * The widget shell — the same classes as `WidgetCard`'s section and header, so
+ * the checklist reads as one of the grid's own. `h-full` fills a grid item; in
+ * a flow container it is inert.
+ *
+ * THE BOX IS 224px TALL IN THE GRID — six rows of 40px less the 16px gutter —
+ * and the four rows, the header and the body padding come to 209px. Nothing
+ * else fits: a footer here put the card 14px over and gave it a scrollbar. So
+ * the progress line lives in the header, beside the dismiss control, and the
+ * loading state mirrors that row for row.
+ */
+function Shell({
+  trailing,
+  children,
+  ...rest
+}: { trailing?: ReactNode; children: ReactNode } & ComponentProps<'section'>) {
+  return (
+    <section
+      {...rest}
+      className="flex h-full flex-col overflow-hidden rounded-md border border-hairline bg-card text-card-foreground"
+    >
+      <header className="flex min-h-10 items-center justify-between gap-2 border-b border-hairline px-3 py-1.5">
+        <h3 className="font-mono text-xs font-medium uppercase tracking-[0.1em] text-muted-foreground">
+          Get set up
+        </h3>
+        <div className="flex items-center gap-2">{trailing}</div>
+      </header>
+      <div className="flex-1 overflow-auto p-3">{children}</div>
+    </section>
+  );
+}
+
 export function ActivationChecklist({ onStartStep, canStartStep }: ActivationChecklistProps) {
   const { checklist, preference, isError, isSaving, setStatus, dismiss } = useOnboarding();
 
@@ -143,9 +198,11 @@ export function ActivationChecklist({ onStartStep, canStartStep }: ActivationChe
     setStatus('done');
   }, [allComplete, status, setStatus]);
 
-  // "There is no checklist for this user." Only a dismissal leaves a trace.
-  if (checklist === null) {
-    if (status !== 'skipped') return null;
+  const view = resolveChecklistView({ checklist, preference, isError });
+
+  if (view === 'none') return null;
+
+  if (view === 'reopen') {
     return (
       <div data-testid="activation-checklist-reopen">
         <Button
@@ -162,113 +219,108 @@ export function ActivationChecklist({ onStartStep, canStartStep }: ActivationChe
     );
   }
 
-  // "Not known yet." A terminal failure is not a loading state — an unticked
-  // box we cannot substantiate is worse than no box, so render nothing at all.
-  if (checklist === undefined) {
-    if (isError) return null;
-    // Status unknown: the cheap preference read has not landed, so we cannot
-    // tell a user who is about to see a checklist from one who never will.
-    // Occupy no space rather than reserve room for a card most users lose.
-    if (preference === undefined) return null;
+  if (view === 'loading') {
+    // Row for row the geometry of the settled card, so the swap moves nothing
+    // around it — whichever box the caller put this in.
     return (
-      <Card
+      <Shell
         data-testid="activation-checklist-loading"
         role="status"
         aria-label="Loading your setup checklist"
-        className="gap-4 py-4"
+        trailing={<Skeleton className="h-4 w-24 motion-reduce:animate-none" />}
       >
-        <CardHeader className="px-4">
-          <Skeleton className="h-5 w-32 motion-reduce:animate-none" />
-        </CardHeader>
-        <CardContent className="flex flex-col gap-3 px-4">
+        <ol className="flex flex-col">
           {[0, 1, 2, 3].map((row) => (
-            <Skeleton key={row} className="h-6 w-full motion-reduce:animate-none" />
+            <li key={row} className="flex min-h-9 items-center py-1">
+              <Skeleton className="h-4 w-full motion-reduce:animate-none" />
+            </li>
           ))}
-        </CardContent>
-      </Card>
+        </ol>
+      </Shell>
     );
   }
 
-  // Retired. The effect above persists it; this stops showing it now.
-  if (allComplete) return null;
+  // `card` implies a checklist; the type system cannot follow the resolver.
+  if (!checklist) return null;
 
   const doneCount = checklist.items.filter((item) => item.done).length;
 
   return (
-    <Card data-testid="activation-checklist" className="gap-4 py-4">
-      <CardHeader className="px-4">
-        <CardTitle className="text-base">Get set up</CardTitle>
-        {/* The non-colour carrier for overall progress, and the answer to "how
-            far along am I?" that a setup checklist has to give. */}
-        <CardDescription data-testid="activation-checklist-progress">
-          {doneCount} of {checklist.items.length} complete
-        </CardDescription>
-        <CardAction>
+    <Shell
+      data-testid="activation-checklist"
+      trailing={
+        <>
+          {/* The non-colour carrier for overall progress, and the answer to
+              "how far along am I?" that a setup checklist has to give. */}
+          <span
+            data-testid="activation-checklist-progress"
+            className="font-mono text-xs text-muted-foreground"
+          >
+            {doneCount} of {checklist.items.length} complete
+          </span>
           <Button
             variant="ghost"
-            size="icon-sm"
-            className="cursor-pointer"
+            size="icon-xs"
+            className="cursor-pointer text-muted-foreground"
             aria-label="Dismiss checklist"
             disabled={isSaving}
             onClick={dismiss}
           >
             <X aria-hidden="true" />
           </Button>
-        </CardAction>
-      </CardHeader>
-      <CardContent className="px-4">
-        {/* Ordered because the four items have a fixed presentation order, not
-            because they gate on each other — any one can be completed first. */}
-        <ol className="flex flex-col">
-          {checklist.items.map((item) => (
-            <li
-              key={item.id}
-              // The join to the walkthrough: this attribute is the anchor the
-              // tour targets and the handle the per-item action is found by.
-              data-checklist-item={item.id}
-              className="flex min-h-9 items-center gap-3 py-1"
+        </>
+      }
+    >
+      {/* Ordered because the four items have a fixed presentation order, not
+          because they gate on each other — any one can be completed first. */}
+      <ol className="flex flex-col">
+        {checklist.items.map((item) => (
+          <li
+            key={item.id}
+            // The join to the walkthrough: this attribute is the anchor the
+            // tour targets and the handle the per-item action is found by.
+            data-checklist-item={item.id}
+            className="flex min-h-9 items-center gap-3 py-1"
+          >
+            {item.done ? (
+              <CircleCheck className="size-4 shrink-0 text-success" aria-hidden="true" />
+            ) : (
+              <Circle className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+            )}
+            <span
+              className={cn(
+                'min-w-0 flex-1 text-sm',
+                item.done && 'text-muted-foreground line-through',
+              )}
             >
-              {item.done ? (
-                <CircleCheck className="size-4 shrink-0 text-success" aria-hidden="true" />
-              ) : (
-                <Circle className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-              )}
-              <span
-                className={cn(
-                  'min-w-0 flex-1 text-sm',
-                  item.done && 'text-muted-foreground line-through',
-                )}
-              >
-                {item.label}
-                <span className="sr-only">{item.done ? ' — completed' : ' — not completed'}</span>
-              </span>
-              {/* No primary (amber) action anywhere on this card. The checklist
-                  is embedded in the zero-state, which carries the one primary
-                  action that view is allowed.
+              {item.label}
+              <span className="sr-only">{item.done ? ' — completed' : ' — not completed'}</span>
+            </span>
+            {/* No primary (amber) action anywhere on this card. The checklist
+                is embedded in the zero-state, which carries the one primary
+                action that view is allowed.
 
-                  A PLAY TRIANGLE, AND A NAME THE ICON DOES NOT CARRY. The row is
-                  a line of text and a tick; a word here read as a second label
-                  competing with the item's own. The icon says "this starts
-                  something" at a glance and `aria-label` says which — an icon
-                  alone would leave a screen reader with an unnamed button four
-                  times over, one per row. Same size and variant as the dismiss
-                  control in the header, so the card has one icon-button size. */}
-              {onStartStep && (canStartStep?.(item.id) ?? true) && (
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  className="shrink-0 cursor-pointer"
-                  data-checklist-action={item.id}
-                  aria-label={`Start: ${item.label}`}
-                  onClick={() => onStartStep(item.id)}
-                >
-                  <Play aria-hidden="true" />
-                </Button>
-              )}
-            </li>
-          ))}
-        </ol>
-      </CardContent>
-    </Card>
+                A PLAY TRIANGLE, AND A NAME THE ICON DOES NOT CARRY. The row is
+                a line of text and a tick; a word here read as a second label
+                competing with the item's own. The icon says "this starts
+                something" at a glance and `aria-label` says which — an icon
+                alone would leave a screen reader with an unnamed button four
+                times over, one per row. */}
+            {onStartStep && (canStartStep?.(item.id) ?? true) && (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="shrink-0 cursor-pointer"
+                data-checklist-action={item.id}
+                aria-label={`Start: ${item.label}`}
+                onClick={() => onStartStep(item.id)}
+              >
+                <Play aria-hidden="true" />
+              </Button>
+            )}
+          </li>
+        ))}
+      </ol>
+    </Shell>
   );
 }

--- a/apps/web/src/routes/_auth.dashboard.test.tsx
+++ b/apps/web/src/routes/_auth.dashboard.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 import type { DashboardLayoutResponse, WidgetPlacement } from '@tradr/shared';
+import type { GridItemHTMLElement } from 'gridstack';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -220,6 +221,19 @@ afterEach(() => {
   fetchSpy = null;
   vi.restoreAllMocks();
 });
+
+/** The gridstack item wrapping the card of one widget type, once the grid is up. */
+function gridItemOf(container: HTMLElement, type: string): GridItemHTMLElement {
+  const card = container.querySelector(`section[data-widget-type="${type}"]`);
+  const item = card?.closest('.grid-stack-item') as GridItemHTMLElement | null;
+  expect(item, `grid item for ${type}`).not.toBeNull();
+  return item!;
+}
+
+/** The grid's aside item — the checklist's slot — or null when there is none. */
+function asideItem(container: HTMLElement): GridItemHTMLElement | null {
+  return container.querySelector('[data-grid-aside]') as GridItemHTMLElement | null;
+}
 
 // ---- Tests ----------------------------------------------------------------
 
@@ -550,7 +564,7 @@ describe('_auth.dashboard route — the activation checklist beyond the zero-sta
     calculatorFirstUsedAt: '2026-05-01T00:00:00.000Z',
   });
 
-  it('a user with an account and pending onboarding sees the checklist ABOVE the grid', async () => {
+  it('a user with an account and pending onboarding sees the checklist IN the grid, locked top-right', async () => {
     layoutMockValue = baseLayout({ data: populated });
     setOnboarding('pending');
     accountsMock = { data: oneAccount, isLoading: false, isError: false };
@@ -564,11 +578,40 @@ describe('_auth.dashboard route — the activation checklist beyond the zero-sta
     expect(screen.getByText('Close it and see the stats')).toBeTruthy();
 
     await waitFor(() => {
-      expect(container.querySelector('[data-grid-mode]')).not.toBeNull();
+      expect(asideItem(container)).not.toBeNull();
     });
-    const grid = container.querySelector('[data-grid-mode]')!;
-    // Above the grid, not merely present somewhere on the page.
-    expect(checklist.compareDocumentPosition(grid) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // One item among the widgets — not a card bolted on above them — locked in
+    // the top-right slot at the right-rail width and the Stats Summary's height.
+    const aside = asideItem(container)!;
+    expect(aside.contains(checklist)).toBe(true);
+    expect(aside.gridstackNode).toMatchObject({
+      x: 8,
+      y: 0,
+      w: 4,
+      h: 6,
+      locked: true,
+      noMove: true,
+      noResize: true,
+    });
+    // Stats Summary narrows to sit beside it; the rest of the default layout
+    // is where it was.
+    expect(gridItemOf(container, 'stats-summary').gridstackNode).toMatchObject({
+      x: 0,
+      y: 0,
+      w: 8,
+      h: 6,
+    });
+    expect(gridItemOf(container, 'account-balances').gridstackNode).toMatchObject({
+      x: 8,
+      y: 6,
+      w: 4,
+      h: 12,
+    });
+    // Making room is a view of the stored layout, never a write to it.
+    expect(layoutMockValue.scheduleLayoutWrite).not.toHaveBeenCalled();
+    // Exactly one mount: nothing above the grid.
+    expect(screen.getAllByTestId('activation-checklist')).toHaveLength(1);
+    expect(container.querySelector('[data-grid-mode]')!.contains(checklist)).toBe(true);
   });
 
   it('the empty-layout branch mounts it too, and keeps its own empty state', () => {
@@ -582,7 +625,7 @@ describe('_auth.dashboard route — the activation checklist beyond the zero-sta
     expect(screen.getByRole('button', { name: /Use the default layout/i })).toBeTruthy();
   });
 
-  it('a retired (done) user with accounts sees no checklist and no reserved space', () => {
+  it('a retired (done) user with accounts sees no checklist and the grid keeps its full width', async () => {
     layoutMockValue = baseLayout({ data: populated });
     setOnboarding('done');
     accountsMock = { data: oneAccount, isLoading: false, isError: false };
@@ -590,15 +633,17 @@ describe('_auth.dashboard route — the activation checklist beyond the zero-sta
     expect(screen.queryByTestId('activation-checklist')).toBeNull();
     expect(screen.queryByTestId('activation-checklist-loading')).toBeNull();
     expect(screen.queryByTestId('activation-checklist-reopen')).toBeNull();
-    // The slot is present but EMPTY, and `empty:hidden` is what keeps it out of
-    // the flow. Without it the wrapper would still count as a child of the
-    // surrounding `space-y-*` and open a permanent gap between the header and
-    // the grid — for the majority of users, who are exactly the ones this
-    // branch is for.
-    const slot = container.querySelector('[data-slot="activation-checklist-slot"]')!;
-    expect(slot).not.toBeNull();
-    expect(slot.childNodes.length).toBe(0);
-    expect(slot.className).toContain('empty:hidden');
+    await waitFor(() => {
+      expect(container.querySelector('[data-grid-mode]')).not.toBeNull();
+    });
+    // No slot is held for the majority, who are exactly who this branch is for.
+    expect(asideItem(container)).toBeNull();
+    expect(gridItemOf(container, 'stats-summary').gridstackNode).toMatchObject({
+      x: 0,
+      y: 0,
+      w: 12,
+      h: 6,
+    });
   });
 
   it('a SKIPPED user with accounts still reaches the reopen row — dismissal stays recoverable', () => {
@@ -621,12 +666,14 @@ describe('_auth.dashboard route — the activation checklist beyond the zero-sta
     layoutMockValue = baseLayout({ data: populated });
     setOnboarding('active', { checklist: allDone, setStatus });
     accountsMock = { data: oneAccount, isLoading: false, isError: false };
-    renderRoute();
+    const renderResult = renderRoute();
     await waitFor(() => {
       expect(setStatus).toHaveBeenCalledWith('done');
     });
     expect(setStatus).toHaveBeenCalledTimes(1);
     expect(screen.queryByTestId('activation-checklist')).toBeNull();
+    // And the grid never held a slot for a checklist that was already finished.
+    expect(asideItem(renderResult.container)).toBeNull();
   });
 
   it('no flash: nothing is rendered when the route falls through with the status still unknown', () => {
@@ -668,22 +715,18 @@ describe('_auth.dashboard route — the activation checklist beyond the zero-sta
   });
 });
 
-// ---- The checklist slot's reserved geometry --------------------------------
+// ---- The checklist's loading state holds the card's grid item ---------------
 //
-// `ActivationChecklist` paints a four-row card skeleton while its derived reads
-// are in flight, and that skeleton is 28px SHORTER than the card that replaces
-// it (210px vs 238px — the arithmetic is on `ChecklistSlot`). Mounted bare above
-// the widget grid, the swap dropped the whole grid by that much, once per load,
-// for every user still mid-onboarding — exactly the loading-state layout jump
-// the design system forbids. The checklist is correct and untouched; the slot
-// it mounts into reserves the settled height.
-//
-// jsdom computes no layout, so these cases pin the two things it CAN see: the
-// reservation is declared against the skeleton's own test id, and the skeleton
-// and the settled card occupy ONE element — a reservation on a box that is
-// replaced rather than refilled would reserve nothing.
+// `ActivationChecklist` paints a skeleton while its derived reads are in
+// flight. Mounted bare above the widget grid it was once 28px shorter than the
+// card that replaced it, and the whole grid dropped by that much, once per
+// load, for every user still mid-onboarding — the loading-state layout jump the
+// design system forbids. In the grid the geometry is the item's, not the
+// content's, and the skeleton matches the card row for row besides. jsdom
+// computes no layout, so these cases pin what it CAN see: the skeleton mounts
+// in the aside item, and the card then refills that SAME item.
 
-describe('_auth.dashboard route — the checklist slot reserves its height', () => {
+describe('_auth.dashboard route — the checklist skeleton holds the same grid item as the card', () => {
   const populated = {
     widgets: sixDefaultWidgets,
     theme: 'light',
@@ -697,12 +740,7 @@ describe('_auth.dashboard route — the checklist slot reserves its height', () 
     closedPositionCount: 0,
   });
 
-  // The settled card's outer height. If the card's rows, padding or header
-  // change, this and `ChecklistSlot`'s class change together — that is what this
-  // constant is for.
-  const RESERVED = 'has-data-[testid=activation-checklist-loading]:min-h-[238px]';
-
-  it('reserves the settled card height while the skeleton is up, on the same element that then holds the card', () => {
+  it('mounts the skeleton in the aside slot, and the card refills that same item', async () => {
     layoutMockValue = baseLayout({ data: populated });
     // Preference landed, gated reads still in flight: the one window in which
     // the skeleton is on screen.
@@ -710,41 +748,39 @@ describe('_auth.dashboard route — the checklist slot reserves its height', () 
     accountsMock = { data: oneAccount, isLoading: false, isError: false };
     const { container, rerenderRoute } = renderRoute();
 
-    const slot = container.querySelector('[data-slot="activation-checklist-slot"]')!;
-    expect(slot).not.toBeNull();
+    await waitFor(() => {
+      expect(asideItem(container)).not.toBeNull();
+    });
+    const slot = asideItem(container)!;
     expect(slot.contains(screen.getByTestId('activation-checklist-loading'))).toBe(true);
-    expect(slot.className).toContain(RESERVED);
+    expect(slot.gridstackNode).toMatchObject({ x: 8, y: 0, w: 4, h: 6 });
 
     // The positions read lands and the card replaces the skeleton.
     setOnboarding('pending', { checklist: someChecklist });
     rerenderRoute();
 
     expect(screen.queryByTestId('activation-checklist-loading')).toBeNull();
-    // SAME node — the card refills the reserved box rather than replacing it,
-    // which is the only arrangement in which reserving anything helps.
-    const after = container.querySelector('[data-slot="activation-checklist-slot"]')!;
+    // SAME item — the grid was told nothing changed, so nothing around it moved.
+    const after = asideItem(container)!;
     expect(after).toBe(slot);
     expect(after.contains(screen.getByTestId('activation-checklist'))).toBe(true);
   });
 
-  it('reserves on the empty-layout branch too — the same skeleton mounts there', () => {
+  it('mounts the skeleton on the empty-layout branch too, above the empty state', () => {
     layoutMockValue = baseLayout({ data: emptyLayout });
     setOnboarding('pending', { checklist: undefined });
     accountsMock = { data: oneAccount, isLoading: false, isError: false };
-    const { container } = renderRoute();
+    renderRoute();
 
-    const slot = container.querySelector('[data-slot="activation-checklist-slot"]')!;
-    expect(slot).not.toBeNull();
-    expect(slot.contains(screen.getByTestId('activation-checklist-loading'))).toBe(true);
-    expect(slot.className).toContain(RESERVED);
+    expect(screen.getByTestId('activation-checklist-loading')).toBeTruthy();
     // And the branch's own content is unchanged.
     expect(screen.getByText('Your dashboard is empty')).toBeTruthy();
   });
 
   it('does not reintroduce the flash of four unticked boxes', () => {
-    // The reservation must not tempt anyone into rendering the card early to
-    // fill it. While the reads are in flight the user sees a skeleton and the
-    // four item labels are nowhere on screen.
+    // The slot must not tempt anyone into rendering the card early to fill it.
+    // While the reads are in flight the user sees a skeleton and the four item
+    // labels are nowhere on screen.
     layoutMockValue = baseLayout({ data: populated });
     setOnboarding('pending', { checklist: undefined });
     accountsMock = { data: oneAccount, isLoading: false, isError: false };

--- a/apps/web/src/routes/_auth.dashboard.tsx
+++ b/apps/web/src/routes/_auth.dashboard.tsx
@@ -18,7 +18,10 @@ import { DashboardHeader } from '@/features/dashboard/components/DashboardHeader
 import { GRID_COLUMNS } from '@/features/dashboard/grid.constants';
 import { useDashboardLayout } from '@/features/dashboard/hooks/useDashboardLayout';
 import { findFirstSlot } from '@/features/dashboard/layout';
-import { ActivationChecklist } from '@/features/onboarding/components/ActivationChecklist';
+import {
+  ActivationChecklist,
+  resolveChecklistView,
+} from '@/features/onboarding/components/ActivationChecklist';
 import { CoachMark } from '@/features/onboarding/components/CoachMark';
 import { ZeroState } from '@/features/onboarding/components/ZeroState';
 import { useOnboarding, useOnboardingQuery } from '@/features/onboarding/hooks/useOnboarding';
@@ -84,37 +87,18 @@ function ReadOnlyDefaultLayout(): ReactElement {
 }
 
 /**
- * The checklist's mount slot on the populated and empty-layout branches.
- *
- * WHY A SLOT AND NOT A BARE MOUNT. `ActivationChecklist` paints a four-row card
- * skeleton while its derived reads are in flight, and the skeleton is SHORTER
- * than the card that replaces it — so on the primary screen the widget grid
- * dropped by the difference, once per load, for every user still mid-onboarding.
- * The design system forbids exactly that — no layout jump between loading,
- * empty and loaded. The checklist itself is correct and is left alone; the
- * geometry is the mount site's problem, and this is the mount site.
- *
- * THE RESERVATION IS DRIVEN BY WHAT ACTUALLY RENDERED, via `:has()` on the
- * skeleton's own test id, rather than by re-deciding here which users get a
- * checklist. That matters twice over: nothing in this file restates the
- * component's rules (a second copy of them is a second thing to get wrong), and
- * the space is reserved ONLY while the skeleton is on screen — not for a retired
- * user who renders nothing, and not for the beat between the last item being
- * ticked and `status: 'done'` landing, where a status-driven reservation would
- * leave an empty box behind.
- *
- * 238px is the settled card's outer height, and it is arithmetic, not a guess:
- * 1px border + 16px (`py-4`) + 44px header (16px `text-base leading-none` title
- * + 8px `gap-2` + 20px `text-sm` description) + 16px (`gap-4`) + 144px content
- * (4 items × `min-h-9`) + 16px + 1px. The skeleton comes to 210px by the same
- * sum, hence the 28px it was short by. If the card's rows, padding or header
- * change, this number changes with them — `_auth.dashboard.test.tsx` pins it so
- * the pair cannot drift silently.
- *
- * `empty:hidden` is not cosmetic. The checklist renders nothing at all for a
- * `done` user — the majority — and a wrapper that stayed in the flow would count
- * as a child of the surrounding `space-y-*`, adding a permanent gap of dead
- * space between the header and the grid that was not there before.
+ * The checklist's grid footprint: the width of the right-rail widgets under it
+ * in the default layout and the Stats Summary's height, so the top row of the
+ * default dashboard becomes Stats Summary at eight columns beside it. The id is
+ * the grid's handle for the item and must never be a widget id.
+ */
+const CHECKLIST_ASIDE = { id: 'activation-checklist', w: 4, h: 6 } as const;
+
+/**
+ * The checklist, wired to the walkthrough, for the populated and empty-layout
+ * branches. It decides nothing about WHETHER to render — `ActivationChecklist`
+ * answers for every state itself, and the route reads the same answer through
+ * `resolveChecklistView` to know whether the grid has to make room.
  */
 function ChecklistSlot(): ReactElement {
   // THE WALKTHROUGH'S OTHER DOOR, and without it items 2-4 had none. `ZeroState`
@@ -141,24 +125,19 @@ function ChecklistSlot(): ReactElement {
     [setStatus, start],
   );
 
+  // Withdrawn when the tour runtime will not load, exactly as the zero-state
+  // withdraws it: a "Start" with nothing behind it is a dead control, and the
+  // checklist is useful without one.
+  //
+  // `canStart` withholds the same thing one set at a time. On THIS screen the
+  // user has an account, so the account set's first step — the zero-state's
+  // "Create my first account" — is a control this branch by definition does
+  // not render.
   return (
-    <div
-      data-slot="activation-checklist-slot"
-      className="empty:hidden has-data-[testid=activation-checklist-loading]:min-h-[238px]"
-    >
-      {/* Withdrawn when the tour runtime will not load, exactly as the
-          zero-state withdraws it: a "Start" with nothing behind it is a dead
-          control, and the checklist is useful without one.
-
-          `canStart` withholds the same thing one set at a time. On THIS screen
-          the user has an account, so the account set's first step — the
-          zero-state's "Create my first account" — is a control this branch by
-          definition does not render. */}
-      <ActivationChecklist
-        onStartStep={isUnavailable ? undefined : beginGuided}
-        canStartStep={canStart}
-      />
-    </div>
+    <ActivationChecklist
+      onStartStep={isUnavailable ? undefined : beginGuided}
+      canStartStep={canStart}
+    />
   );
 }
 
@@ -174,10 +153,11 @@ function DashboardPage(): ReactElement {
   // A user with no accounts gets a screen that tells them what to do instead of
   // six widgets that are each individually empty for a different reason.
   //
-  // TWO READS, NOT THREE. `useOnboardingQuery` is the CHEAP preference read; the
-  // full `useOnboarding` hook additionally pulls the whole unfiltered positions
-  // list down to count it, and this route has no use for a checklist — only for
-  // the stored status. The accounts list is the one the dashboard already needs:
+  // THE CHEAP READ FOR THE GATE. `useOnboardingQuery` is the preference read on
+  // its own; the gate below needs only the stored status, and needs it before
+  // anything else. (The full `useOnboarding` hook is read further down for the
+  // checklist's own view — see there.) The accounts list is the one the
+  // dashboard already needs:
   // `account-balances` is one of the six default widgets and calls `useAccounts`
   // itself, so hoisting the same `['accounts', 'list']` query up here shares one
   // request with it rather than adding a second (Performance NFR).
@@ -200,6 +180,15 @@ function DashboardPage(): ReactElement {
   const onboardingRetired = preference?.status === 'done';
   const accountsQuery = useAccounts({ enabled: !onboardingRetired });
   const accounts = accountsQuery.data;
+
+  // WHETHER THE CHECKLIST IS ON SCREEN, decided once here rather than left to
+  // the component, because on the populated branch it is a grid item and the
+  // grid has to be told to make room before anything renders. The rules stay in
+  // `resolveChecklistView`; this only reads the answer. The full hook is the
+  // one the checklist itself reads — its two gated reads are shared with that
+  // mount and switched off for a retired user, so this adds no request.
+  const checklistView = resolveChecklistView(useOnboarding());
+  const checklistInGrid = checklistView === 'card' || checklistView === 'loading';
 
   // beforeunload: flush any pending debounced PUT (Req 1.9).
   useEffect(() => {
@@ -399,27 +388,26 @@ function DashboardPage(): ReactElement {
   // reads off for good — would never get a chance to fire. So both remaining
   // branches mount it.
   //
-  // UNCONDITIONALLY, and that is safe because the component answers for every
-  // state itself: nothing for a retired (`done`) user, nothing while the stored
-  // status is still unknown, the quiet reopen row for a `skipped` user, and the
-  // card otherwise. Nothing here may restate those rules — a second copy of them
-  // is a second thing to get wrong.
+  // ON THE POPULATED BRANCH IT IS A GRID ITEM. A card above the grid stretched
+  // four short rows across the whole content width, with each row's play button
+  // a screen away from its label. In the grid it is one widget among the
+  // others: locked in the top-right slot, sized like the right-rail widgets
+  // below it, with the Stats Summary narrowing to sit beside it. The grid makes
+  // the room and takes it back — the stored layout is never written with the
+  // checklist in it, and a drag while it is up persists only what the drag
+  // moved (`reserveTopRightSlot` / `keepStoredGeometry`). The skeleton and the
+  // card occupy the same item, row for row, so the loading swap moves nothing.
   //
-  // NO LAYOUT JUMP, and it takes all three of these. `ActivationChecklist`
-  // occupies no space while `preference` is `undefined`, so it cannot appear and
-  // then vanish on an established user; this route never even reaches these
-  // branches with an unknown status unless a read failed, because the gate above
-  // holds the skeleton until the preference lands; and `ChecklistSlot` reserves
-  // the settled card's height for the one transition the first two do not cover,
-  // the skeleton → card swap a mid-onboarding user still sees. Mount through the
-  // slot, never `ActivationChecklist` directly.
+  // The reopen row for a `skipped` user is not a grid item — one ghost button
+  // is not a widget — and sits above the grid as before. The empty branch has
+  // no grid, so the checklist renders as a plain block there, whichever state
+  // it is in. On both, the component answers for every state itself and is
+  // mounted unconditionally; the route reads `resolveChecklistView` only to
+  // choose WHERE, never whether.
   //
   // NO SECOND PRIMARY ACTION. The checklist carries no amber of its own by
   // design, so the one primary each of these views is allowed stays where it is
   // — "Use the default layout" below, and nothing on the populated dashboard.
-  // The per-item "Start" buttons `ChecklistSlot` now wires are ghost-variant and
-  // change none of that; they were left unwired only while the walkthrough
-  // itself was still to be built.
   // ===========================================================================
 
   // Empty
@@ -477,7 +465,9 @@ function DashboardPage(): ReactElement {
           It is handed to the header rather than placed beside it so that it
           anchors to the HEADING, as every other surface's mark does — see the
           prop's own note. Anchored at the right-hand end of this row it opened
-          on top of the checklist's play buttons. */}
+          on top of the checklist's play buttons — which is also why the
+          checklist's grid slot is the top-RIGHT one: anchored here, the mark
+          opens over the Stats Summary's tiles, and those are not controls. */}
       <DashboardHeader
         placedTypes={placedTypes}
         onAdd={handleAdd}
@@ -487,11 +477,16 @@ function DashboardPage(): ReactElement {
         resetBusy={defaultBusy}
         coachMark={<CoachMark surface="dashboard-widgets" />}
       />
-      {/* Above the grid, below the page heading and its actions — see the note
-          on the empty branch. */}
-      <ChecklistSlot />
+      {/* Mounted exactly once on this branch, wherever it goes: in the grid
+          when there is a card (or its skeleton) to show, above it otherwise —
+          where it renders the reopen row, or nothing. "Nothing" still has to
+          mount: the retirement write on the fourth completed item is the
+          component's own effect, and a route that skipped the mount for a
+          finished checklist would never let it fire. */}
+      {checklistInGrid ? null : <ChecklistSlot />}
       <DashboardGrid
         widgets={widgets}
+        aside={checklistInGrid ? { ...CHECKLIST_ASIDE, node: <ChecklistSlot /> } : undefined}
         onRemove={handleRemove}
         scheduleLayoutWrite={handleGridChange}
         onUpdateConfig={handleUpdateConfig}

--- a/e2e/tests/dashboard.spec.ts
+++ b/e2e/tests/dashboard.spec.ts
@@ -72,6 +72,17 @@ async function registerUser(req: APIRequestContext, label: string): Promise<Seed
     data: { name: `${label} account`, currency: 'USD' },
   });
   expect(accountRes.status(), `POST /accounts for ${email}`).toBe(201);
+  // And past the checklist too. With an account and onboarding still pending
+  // the dashboard mounts the "Get set up" checklist IN the grid — a seventh,
+  // locked item in the top-right slot, with Stats Summary narrowed to eight
+  // columns beside it. Every case here characterises the six-widget default
+  // layout (item counts, the full-width band's drag behaviour), so the seeded
+  // user is retired from onboarding the way a finished checklist retires
+  // itself. The checklist's own e2e coverage is in user-onboarding.spec.ts.
+  const onboardingRes = await req.patch('/api/users/me/onboarding', {
+    data: { status: 'done' },
+  });
+  expect(onboardingRes.status(), `PATCH onboarding for ${email}`).toBe(200);
   return { email, userId: body.user.id };
 }
 


### PR DESCRIPTION
## Summary

On any desktop-sized screen the "Get set up" checklist spanned the whole dashboard above the widget grid: four short rows stretched across ~1000px, labels on the left and each row's play button a screen away on the right.

The checklist is now **a widget in the grid** — locked in the top-right w=4 × h=6 slot with Stats Summary narrowing to eight columns beside it — so it reads as one of the dashboard's own cards instead of something bolted on above them.

## How

- `DashboardGrid` gains an optional `aside`: a transient item gridstack lays out (locked, `noMove`, `noResize`) that is **never persisted**.
  - `reserveTopRightSlot` derives the *shown* layout from the stored one: a widget straddling the slot is narrowed if the part left of it is still a legal width for its type, otherwise it moves below the slot; collisions reflow through the same `reconcileStoredLayout` a stored layout gets on read.
  - `keepStoredGeometry` runs on every gesture while the aside is up: a widget the gesture left where the slot put it goes back to its **stored** geometry, one the user moved keeps its new one. So dragging another widget while onboarding does not persist the narrowed Stats Summary, and there is no hole when the checklist retires.
  - `fromGridWidgets` already drops any node without a matching widget, so the aside never reaches a write.
- `ActivationChecklist` wears the widget chrome (hairline border, `rounded-md`, mono uppercase title strip, progress line in the header beside the dismiss control). The loading skeleton matches the card row for row inside the same grid item, so the old 238px `:has()` reservation in `ChecklistSlot` goes away.
- `resolveChecklistView` is the one statement of which of the four states (`none` / `loading` / `reopen` / `card`) the checklist shows. The route reads it to decide whether the grid makes room, and mounts the component exactly once on every branch — the retirement effect (`status: 'done'` on the fourth completed item) still fires.
- Mobile fallback: the checklist leads the single-column stack. Empty-layout branch: rendered as a plain block above the empty state, as before.

Top-**right** rather than top-left because the dashboard coach mark opens bottom-left under the page heading and `e2e/tests/user-onboarding.spec.ts` asserts no mark ever covers a control; over the Stats Summary tiles it covers nothing pressable.

## Tests

- `layout.test.ts`: `reserveTopRightSlot` (narrow / move-down / cascade / untouched-by-reference / default layout) and `keepStoredGeometry` (restore untouched, keep moved, identity).
- `DashboardGrid.test.tsx`: the aside is a locked top-right item, narrows what it displaces without writing, gives the room back when removed, a gesture persists neither the aside nor the narrowing of an untouched widget, and it leads the mobile stack.
- `ActivationChecklist.test.tsx`: `resolveChecklistView` cases, plus a sweep asserting it agrees with what the component renders.
- `_auth.dashboard.test.tsx`: checklist mounts *in* the grid at (8,0,4,6) with Stats Summary at w=8 and no layout write; a retired user gets no aside and full-width Stats Summary; the skeleton and card share one grid item.

Verified in a real browser at 1280px: the item is 224px tall (6 rows × 40 − the 16px gutter), no overflow, no resize handles, locked at (8,0,4,6); coach mark opens over the stats tiles.