### PR TITLE
fix(onboarding): advance dialog-opening steps on the dialog, not Next

### DIFF
--- a/apps/web/src/features/onboarding/hooks/useWalkthrough.test.ts
+++ b/apps/web/src/features/onboarding/hooks/useWalkthrough.test.ts
@@ -1074,6 +1074,41 @@ describe('useWalkthrough — action signals', () => {
     );
   });
 
+  // THE OTHER HALF OF THE DOWNGRADE, AND THE REASON IT IS NOT JUST "PRESS NEXT".
+  //
+  // Two of those four open a dialog, and the step after each names a field
+  // inside it. "Next" cannot move a tour onto a target that is not on screen —
+  // it strands driver.js in that step's wait with the previous popover still up,
+  // which is the "the next button does nothing" both sets were reported for. So
+  // the dialog arriving is named as the signal instead, and the engine holds the
+  // step until it does.
+  it('names the control that advances each downgraded step, or nothing', async () => {
+    const signals = async (item: ChecklistItemId): Promise<[string, string | undefined][]> => {
+      resetSession();
+      await start(item);
+      return (started?.steps ?? [])
+        .filter((step) => step.advanceOnAppearanceOf !== undefined)
+        .map((step) => [step.target ?? '(centred)', step.advanceOnAppearanceOf]);
+    };
+
+    expect(await signals('account')).toEqual([['[data-tour="account-new"]', '#name']]);
+    expect(await signals('position')).toEqual([['[data-tour="position-new"]', '#symbol']]);
+
+    // The calculator's two are named as well — both point at a control
+    // `/calculator` already renders, so the engine finds it present, leaves the
+    // gate open and "Next" moves them exactly as it always did.
+    expect(await signals('calculator')).toEqual([
+      ['[data-tour="calculator-risk"]', '[data-tour="calculator-account"]'],
+      ['[data-tour="calculator-account"]', '#riskPercent, #dollarRisk'],
+    ]);
+
+    // Nothing in the close set: neither of its action steps is downgraded, and
+    // its one step that changes screen is reached by NAVIGATING, which nothing
+    // does until the tour moves. Waiting for that target would be waiting for
+    // something the wait itself prevents.
+    expect(await signals('close')).toEqual([]);
+  });
+
   it('does not otherwise alter the authored steps', async () => {
     await start('close');
     expect(currentTargets()).toEqual(WALKTHROUGH_STEPS.close.map((s) => s.target));

--- a/apps/web/src/features/onboarding/hooks/useWalkthrough.ts
+++ b/apps/web/src/features/onboarding/hooks/useWalkthrough.ts
@@ -295,21 +295,71 @@ function bindAdvance(engine: TourEngineModule, navigate: NavigateFn): void {
  * Percent risk basis, picking an account in the calculator) which changes no
  * server data and publishes nothing.
  *
- * For those, the flag is turned off and "Next" advances normally. The highlighted
- * control stays interactive either way (`disableActiveInteraction: false`), so
- * the user still performs the gesture; they just also press Next afterwards, and
- * the following step's `waitForMs` covers a dialog that is still opening. That
- * is a narrower reading of advance-on-the-real-action than those four steps
- * were authored for, and it is the honest one until a gesture has an event to
- * advance on — being asked to press Next is a worse tour, but a tour that
- * cannot be advanced at all is a broken one.
+ * For those the flag is turned off, and `appearanceSignal()` below then says
+ * what the step advances on instead. The highlighted control stays interactive
+ * throughout (`disableActiveInteraction: false`), so the gesture is always the
+ * user's to make.
+ *
+ * "NEXT ADVANCES THEM" WAS THE PREVIOUS ANSWER, AND ON TWO OF THE FOUR IT WAS
+ * NOT TRUE. Turning the flag off hands "Next" back, but "Next" can only move a
+ * tour onto a step whose target exists — and the first step of the account set
+ * and of the position set both name a field inside a dialog the user has not
+ * opened. Pressing it moved driver.js onto that step, which then sat in its
+ * `waitForElement` window with the PREVIOUS popover still on screen for the full
+ * 15 seconds before ending the walkthrough. Reported as "the next button does
+ * nothing", against both sets, and correctly: it did nothing a user could see,
+ * for fifteen seconds, and then took the walkthrough away.
+ *
+ * So the gesture's own result is the signal. The dialog opening IS the step's
+ * action, observed in the DOM instead of on the bus, and the engine holds "Next"
+ * until it lands exactly as it does for an action step with an event behind it.
+ * The other two of the four keep advancing on "Next" as they always did, because
+ * the control their next step names is already on the screen they run on.
  */
 function withObservableActionsOnly(steps: WalkthroughStep[]): WalkthroughStep[] {
-  return steps.map((step) => {
+  return steps.map((step, index) => {
     if (!step.advanceOnAction) return step;
     if (step.target !== undefined && step.target in ACTION_SIGNALS) return step;
-    return { ...step, advanceOnAction: false };
+    return {
+      ...step,
+      advanceOnAction: false,
+      advanceOnAppearanceOf: appearanceSignal(step, steps[index + 1]),
+    };
   });
+}
+
+/**
+ * The control whose ARRIVAL is this step's action, when there is one.
+ *
+ * The four steps above ask for a gesture with no event behind it, but two of
+ * them — "Choose New Account" and "Choose New Position" — do leave a mark we can
+ * see: the dialog they open, which is where the NEXT step's target lives. Naming
+ * it here is what turns those two from steps driven by a "Next" that cannot work
+ * into steps driven by the gesture their own copy asks for, and it is why the
+ * flag being off above no longer means "Next is the only way on".
+ *
+ * TWO KINDS OF NEXT STEP ARE REFUSED, AND THE FIRST IS THE ONE THAT MATTERS:
+ *
+ * - A NEXT STEP ON ANOTHER ROUTE is reached by NAVIGATING, and nothing navigates
+ *   until the tour moves. Waiting for its target would be waiting for something
+ *   the wait itself prevents — a step with no way out but Escape, which is the
+ *   trap the downgrade above exists to avoid. No step is in that position today:
+ *   all four run their gesture and their next step on one screen. It is a guard
+ *   for the fifth, because the failure it prevents is silent and the check is one
+ *   comparison.
+ * - A NEXT STEP WITH NO TARGET is centred, so there is nothing to wait for.
+ *
+ * The calculator's two gesture steps are named here and cost nothing: both point
+ * at a control `/calculator` already renders, so the engine finds the selector
+ * present, leaves the gate open and lets "Next" move them exactly as before.
+ */
+function appearanceSignal(
+  step: WalkthroughStep,
+  next: WalkthroughStep | undefined,
+): string | undefined {
+  if (next?.target === undefined) return undefined;
+  if (next.route !== step.route) return undefined;
+  return next.target;
 }
 
 /**

--- a/apps/web/src/features/onboarding/lib/tour-engine.test.ts
+++ b/apps/web/src/features/onboarding/lib/tour-engine.test.ts
@@ -207,6 +207,110 @@ describe('action steps', () => {
 });
 
 /**
+ * A STEP HELD ON A CONTROL THAT IS STILL TO COME.
+ *
+ * The reported defect: the first step of the account set and of the position set
+ * each ask the user to open a dialog, and the step after each anchors to a field
+ * inside it. Neither gesture publishes anything, so both steps reached the
+ * engine with "Next" live — and a "Next" that moves the tour onto a target that
+ * does not exist parks driver.js in that step's `waitForElement` window with the
+ * PREVIOUS popover still on screen. A live button that did nothing for fifteen
+ * seconds, and then the walkthrough ended.
+ *
+ * `advanceOnAppearanceOf` names the control whose arriving IS the action, which
+ * makes the step gated like any other action step while it is still to come and
+ * an ordinary step once it is there.
+ */
+describe('a step waiting for the control its gesture creates', () => {
+  const steps: TourStep[] = [
+    {
+      target: '#one',
+      title: 'Open it',
+      description: 'Choose the button.',
+      advanceOnAppearanceOf: '#late',
+    },
+    { target: '#late', title: 'The field', description: 'Fill this in.' },
+  ];
+
+  /** What the gesture does: the dialog mounts, carrying the next step's field. */
+  function mountLateTarget(): void {
+    document.body.insertAdjacentHTML('beforeend', '<input id="late" />');
+  }
+
+  it('ignores "Next" while the control is still to come', () => {
+    startTour(steps);
+
+    clickPopoverButton('.driver-popover-next-btn');
+
+    expect(popoverTitle()).toBe('Open it');
+  });
+
+  it('ignores the right-arrow key on the same terms', () => {
+    startTour(steps);
+
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowRight', bubbles: true }));
+
+    expect(popoverTitle()).toBe('Open it');
+  });
+
+  it('advances by itself the moment the control appears', async () => {
+    const onBeforeAdvance = vi.fn();
+    startTour(steps, { onBeforeAdvance });
+    expect(popoverTitle()).toBe('Open it');
+
+    mountLateTarget();
+
+    await vi.waitFor(() => expect(popoverTitle()).toBe('The field'));
+    // Through the same path a "Next" press takes, so the caller gets its chance
+    // to prepare the screen either way.
+    expect(onBeforeAdvance).toHaveBeenCalledExactlyOnceWith(0);
+  });
+
+  // The step is not gated on principle, only on the control being absent. A set
+  // whose next step names something the screen already renders — both of the
+  // calculator's gesture steps do — keeps "Next" exactly as it was.
+  it('leaves "Next" alone when the control is already on screen', () => {
+    mountLateTarget();
+    startTour(steps);
+
+    clickPopoverButton('.driver-popover-next-btn');
+
+    expect(popoverTitle()).toBe('The field');
+  });
+
+  // The classification the user is owed on the way out: the control the step
+  // named was there and usable, so leaving is declining something they could
+  // have done — not the tour pointing at nothing.
+  it('reports a step left this way as an action the user declined', () => {
+    const onExit = vi.fn();
+    startTour(steps, { onExit });
+
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape', bubbles: true }));
+
+    expect(onExit).toHaveBeenCalledWith('dismissed', { cause: 'action-required', step: steps[0] });
+  });
+
+  // THE WATCH BELONGS TO ONE STEP. The position set navigates onto a screen
+  // carrying the very control the step before it was waiting on, so a watch that
+  // outlived its step would advance the tour again the moment that screen
+  // rendered — one step skipped, and the one that teaches the draft state.
+  it('stops watching once the tour has moved on', async () => {
+    startTour(steps);
+
+    mountLateTarget();
+    await vi.waitFor(() => expect(popoverTitle()).toBe('The field'));
+
+    // A second mutation of the same kind must move nothing: the tour is on its
+    // last step and a live watch would finish it.
+    document.body.insertAdjacentHTML('beforeend', '<input id="late-again" />');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(isActive()).toBe(true);
+    expect(popoverTitle()).toBe('The field');
+  });
+});
+
+/**
  * The caller's chance to put the next step's screen up before the tour moves
  * onto it. Only for a move the USER made: a caller driving the tour with
  * `advance()` has already prepared, and firing here as well would do it twice.

--- a/apps/web/src/features/onboarding/lib/tour-engine.ts
+++ b/apps/web/src/features/onboarding/lib/tour-engine.ts
@@ -68,13 +68,46 @@ export interface TourStep {
    * "Next", such a step would strand the user, so `useWalkthrough` downgrades it
    * at runtime: any step whose target is absent from `ACTION_SIGNALS` there is
    * handed to the engine with the flag off and advances on "Next" like any
-   * other. Four are, today — `[data-testid="zero-state-create-account"]`,
+   * other. Four are, today — `[data-tour="account-new"]`,
    * `[data-tour="calculator-risk"]`, `[data-tour="calculator-account"]` and
    * `[data-tour="position-new"]` — because each asks for a pure UI gesture that
    * changes no server data. `hooks/useWalkthrough.ts` owns both the mapping and
    * the downgrade, and a test there fails if a fifth step joins them unnoticed.
+   *
+   * A DOWNGRADED STEP IS NOT THEREBY DRIVEN BY "NEXT" — two of the four are
+   * driven by `advanceOnAppearanceOf` below, because "Next" is the one thing
+   * that cannot move them.
    */
   advanceOnAction?: boolean;
+  /**
+   * ADVANCE WHEN THIS SELECTOR APPEARS. The step's action IS something we can
+   * observe after all — not on the event bus, but in the DOM: the control the
+   * NEXT step is about arriving is the gesture having happened.
+   *
+   * IT EXISTS BECAUSE "NEXT" COULD NOT WORK ON THESE STEPS AND LOOKED LIKE IT
+   * DID. A step downgraded to "Next" (see `advanceOnAction`) whose next step's
+   * target lives inside a dialog the user has not opened moves the tour onto a
+   * target that is not there, and driver.js then holds the PREVIOUS popover on
+   * screen for the whole of that step's `waitForElement` window — 15 seconds on
+   * both sets that do this. To the user "Next" is a live button that does
+   * nothing, and then the walkthrough ends with a notice about a step they never
+   * saw. That is the reported defect, against "Log a position" and "Create a
+   * brokerage account": the only two sets whose first step opens a dialog.
+   *
+   * So the wait becomes the signal. While the selector is absent the step is
+   * gated exactly as an action step is — "Next" is suppressed rather than
+   * misleading — and the moment it resolves the tour advances by itself, which
+   * is the gesture the step's own copy asked for ("Choose New Position"). Once
+   * the control IS there the gate lifts, because from then on "Next" lands on a
+   * step that exists.
+   *
+   * SET BY `useWalkthrough`, NOT AUTHORED. Only it knows which steps have no
+   * event to advance on, and only it knows whether the next step is on this
+   * step's own screen — a target that arrives by NAVIGATION must never be waited
+   * for here, because nothing navigates until the tour moves and the wait would
+   * never end.
+   */
+  advanceOnAppearanceOf?: string;
 }
 
 export type TourExitReason =
@@ -183,6 +216,8 @@ let exitReason: TourExitReason = 'dismissed';
 /** Why the tour could not carry on, if it could not — see `TourHandlers.onExit`. */
 let blocked: TourBlock | undefined;
 let pendingStopTimer: number | undefined;
+/** Watches for the step's `advanceOnAppearanceOf` control, while one is awaited. */
+let appearanceObserver: MutationObserver | null = null;
 
 function prefersReducedMotion(): boolean {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
@@ -202,11 +237,57 @@ function toDriveStep(step: TourStep): DriveStep {
   };
 }
 
+/**
+ * Stop waiting for a step's `advanceOnAppearanceOf` control.
+ *
+ * Called from `advance()` and from the teardown, which is EVERY way a step stops
+ * being the current one. A watch that outlived its step would advance the tour
+ * off whichever step came next the moment its selector happened to resolve — and
+ * the position set navigates onto a screen carrying the very control the step
+ * before it was waiting on, so that is a step skipped rather than a theoretical
+ * one.
+ */
+function disarmAppearanceAdvance(): void {
+  appearanceObserver?.disconnect();
+  appearanceObserver = null;
+}
+
+/**
+ * Wait for the control this step's gesture creates, and advance when it lands.
+ *
+ * Armed only when the selector is ABSENT: a step whose next control is already
+ * on screen is not waiting for anything, "Next" can move it, and arming here
+ * would advance it the instant the tour opened. That is what keeps the
+ * calculator set — whose two gesture steps both name a control the page already
+ * renders — behaving exactly as it did.
+ *
+ * `document.body` with `subtree`, because what we are waiting for is a dialog
+ * being portalled in somewhere we do not own. The callback is cheap: one
+ * `querySelector` per mutation batch, for as long as one step is on screen.
+ */
+function armAppearanceAdvance(index: number): void {
+  disarmAppearanceAdvance();
+  const selector = activeSteps[index]?.advanceOnAppearanceOf;
+  if (selector === undefined) return;
+  if (document.querySelector(selector) !== null) return;
+
+  appearanceObserver = new MutationObserver(() => {
+    if (document.querySelector(selector) === null) return;
+    // Through `advanceFromUser`, not `advance`, because this IS the user
+    // advancing — they did the thing the step asked for. It is also what gives
+    // the caller its `onBeforeAdvance`, so the move is prepared the same way a
+    // "Next" press would have been.
+    advanceFromUser();
+  });
+  appearanceObserver.observe(document.body, { childList: true, subtree: true });
+}
+
 function clearState(): void {
   if (pendingStopTimer !== undefined) {
     window.clearTimeout(pendingStopTimer);
     pendingStopTimer = undefined;
   }
+  disarmAppearanceAdvance();
   window.removeEventListener('keyup', handleKeyup);
   instance = null;
   activeSteps = [];
@@ -251,12 +332,27 @@ function clearState(): void {
  *   point of an action step, and a user who leaves anyway declined something
  *   they could have done.
  *
- * A step with no `advanceOnAction` is never blocking: "Next" moves it, so
- * whatever the user did, they had a way on.
+ * TWO THINGS PUT A STEP IN THAT POSITION, AND `holdsNext` IS WHERE THEY MEET —
+ * the authored `advanceOnAction`, and an `advanceOnAppearanceOf` control that
+ * has not arrived yet. They are one question here because they have one answer:
+ * either way the user is being asked to do something, and either way "Next" must
+ * not pretend otherwise. A step held by neither is never blocking: "Next" moves
+ * it, so whatever the user did, they had a way on.
  */
+function holdsNext(step: TourStep): boolean {
+  if (step.advanceOnAction === true) return true;
+  // Held only while the control is still to come. Once it is on screen the step
+  // is an ordinary one again: "Next" would land on a step that exists, so there
+  // is nothing left to hold the user for.
+  return (
+    step.advanceOnAppearanceOf !== undefined &&
+    document.querySelector(step.advanceOnAppearanceOf) === null
+  );
+}
+
 function blockOn(index: number): TourBlock | undefined {
   const step = activeSteps[index];
-  if (step?.advanceOnAction !== true) return undefined;
+  if (step === undefined || !holdsNext(step)) return undefined;
   if (step.target === undefined) return { cause: 'action-required', step };
 
   const element = document.querySelector(step.target);
@@ -342,6 +438,9 @@ function handleKeyup(event: KeyboardEvent): void {
   // Never off the front of the set: driver.js's own left-arrow handler stops at
   // the first step, while `movePrevious()` there tears the tour down.
   if (event.key === 'ArrowLeft' && running.hasPreviousStep()) {
+    // Going back leaves the step too, so its watch goes with it — the highlight
+    // that re-arms is the one for the step being moved to.
+    disarmAppearanceAdvance();
     running.movePrevious();
   }
 }
@@ -421,6 +520,9 @@ const handleHighlightStarted: DriverHook = (element, _driveStep, opts) => {
     return;
   }
 
+  // Before the caller hears about the step, so a handler that reads the tour's
+  // state finds the watch already in place.
+  armAppearanceAdvance(index);
   activeHandlers.onStepChange?.(index, step);
 };
 
@@ -527,6 +629,10 @@ export function startTour(steps: TourStep[], handlers: TourHandlers = {}): void 
  */
 export function advance(): void {
   if (!instance?.isActive()) return;
+  // The step being left stops being waited for HERE rather than on the next
+  // highlight: a step whose target has to be waited for is highlighted long
+  // after the move, and the old watch would be live for all of it.
+  disarmAppearanceAdvance();
   if (instance.isLastStep()) {
     exitReason = 'completed';
     stop();

--- a/e2e/tests/user-onboarding.spec.ts
+++ b/e2e/tests/user-onboarding.spec.ts
@@ -266,11 +266,31 @@ async function tabTo(page: Page, selector: string): Promise<void> {
  * either way, which is why nothing below this line changed with it.
  */
 async function walkAccountSetTo(page: Page, stopAt: number): Promise<void> {
-  await page.locator('[data-tour="account-new"]').click();
-  await expect(page.getByLabel('Name')).toBeVisible();
-  for (let index = 1; index <= stopAt; index += 1) {
+  await openAccountDialogFromStepOne(page);
+  for (let index = 2; index <= stopAt; index += 1) {
     await advanceTo(page, index);
   }
+}
+
+/**
+ * Step 1's action, and the advance it earns.
+ *
+ * Opening the dialog IS what step 1 asks for, so the tour moves on it — there is
+ * no "Next" in this, and pressing one here would ask for a field that does not
+ * exist yet. That press is what users reported as a dead button: it moved
+ * driver.js onto `#name` before the dialog was open, which left the step-1
+ * popover on screen for the whole of that step's wait and then ended the
+ * walkthrough.
+ */
+async function openAccountDialogFromStepOne(page: Page): Promise<void> {
+  await page.locator('[data-tour="account-new"]').click();
+  // `#name`, not `getByLabel('Name')`: the step this advance lands on is titled
+  // "Name", and driver.js gives its popover `role="dialog"` labelled by that
+  // title, so the accessible-name lookup matches the popover as well as the
+  // field. The id is the step's own target and names only the field.
+  await expect(page.locator('#name')).toBeVisible();
+  await expect(popoverTitle(page)).toHaveText(ACCOUNT_STEP_TITLES[1]);
+  await expectStepClear(page, `account step 2, "${ACCOUNT_STEP_TITLES[1]}"`);
 }
 
 /** Fill the account form and submit it — the real action the gated step waits for. */
@@ -438,36 +458,70 @@ test.describe('user onboarding', () => {
     await expect(checklistItemLabel(page, 'account')).toHaveText(/— completed$/);
   });
 
-  // A TARGET THE USER HAS NOT MADE YET IS WAITED FOR, NOT GIVEN UP ON.
+  // "THE NEXT BUTTON DOES NOTHING" — the reported defect, from the press that
+  // caused it, on the set it was reported against and on the one reported after.
   //
-  // The first step asks the user to open the account dialog, and that gesture
-  // publishes nothing the walkthrough can hear, so "Next" is what drives it.
-  // Pressing Next before opening the dialog is therefore the ordinary thing to
-  // do — the step names a button, not a Next — and it asks for `#name`, a field
-  // that does not exist yet. The wait behind that step used to be sized for a
-  // dialog already opening, so it expired while the user was still reading and
-  // ended the walkthrough on a field that was about to appear.
+  // The first step of each asks the user to open a dialog, and the step after it
+  // anchors to a field inside that dialog. The gesture publishes nothing on the
+  // event bus, so the step used to be handed to the engine with "Next" live —
+  // and pressing it moved driver.js onto a target that did not exist, which
+  // parks it in that step's `waitForElement` window with the PREVIOUS popover
+  // still on screen. Fifteen seconds of a live button doing nothing, then the
+  // walkthrough ended on a step the user never saw.
   //
-  // The five-second pause is the assertion: it is longer than any render this
-  // screen does, so a tour still up after it is one that is genuinely waiting.
-  test('a step waits for a target the user has not created yet', async ({ page, request }) => {
-    const email = await registerUser(request, 'waitfor');
-    await loginViaUi(page, email);
-    await startWalkthrough(page);
+  // THE FIVE-SECOND PAUSE IS THE ASSERTION, and it is what a shorter one cannot
+  // do: it is longer than any render either screen does, so a tour still sitting
+  // on step 1 after it is a tour that never entered the doomed wait. The press
+  // has to leave the walkthrough exactly where it stands AND leave it able to go
+  // on, which is what the second half checks.
+  for (const set of [
+    {
+      name: 'the account set',
+      start: async (page: Page, request: APIRequestContext): Promise<void> => {
+        const email = await registerUser(request, 'nextdead-account');
+        await loginViaUi(page, email);
+        await startWalkthrough(page);
+      },
+      first: ACCOUNT_STEP_TITLES[0],
+      second: ACCOUNT_STEP_TITLES[1],
+      opener: '[data-tour="account-new"]',
+    },
+    {
+      name: 'the position set',
+      start: async (page: Page, request: APIRequestContext): Promise<void> => {
+        const email = await registerUser(request, 'nextdead-position');
+        await createAccount(request, 'Next account');
+        await loginViaUi(page, email);
+        await expect(page.getByTestId('activation-checklist')).toBeVisible();
+        await page.locator('[data-checklist-action="position"]').click();
+        await expect(page).toHaveURL(/\/positions$/);
+      },
+      first: POSITION_STEP_TITLES[0],
+      second: POSITION_STEP_TITLES[1],
+      opener: '[data-tour="position-new"]',
+    },
+  ]) {
+    test(`${set.name} survives a Next pressed before the dialog is open`, async ({
+      page,
+      request,
+    }) => {
+      await set.start(page, request);
+      await expect(popoverTitle(page)).toHaveText(set.first);
 
-    await popoverNext(page).click();
-    await expect(popover(page)).toHaveCount(1);
-    await page.waitForTimeout(5_000);
-    await expect(popover(page)).toHaveCount(1);
-    // Still on the step that asked, because the tour has not moved — it is
-    // holding the window open for the control the next step needs.
-    await expect(popoverTitle(page)).toHaveText(ACCOUNT_STEP_TITLES[0]);
+      // The press that was reported. It must move nothing — and, more to the
+      // point, must not commit the tour to a target that is not there.
+      await popoverNext(page).click();
+      await page.waitForTimeout(5_000);
+      await expect(popover(page)).toHaveCount(1);
+      await expect(popoverTitle(page)).toHaveText(set.first);
 
-    // And the moment the user does the thing, the tour is there.
-    await page.locator('[data-tour="account-new"]').click();
-    await expect(popoverTitle(page)).toHaveText(ACCOUNT_STEP_TITLES[1]);
-    await escapeTour(page);
-  });
+      // And the walkthrough is still going somewhere: doing the thing the step
+      // actually asks for carries it on, which is what the dead press cost.
+      await page.locator(set.opener).click();
+      await expect(popoverTitle(page)).toHaveText(set.second);
+      await escapeTour(page);
+    });
+  }
 
   // THE POSITION SET, END TO END — the set this suite never drove, which is how
   // it shipped unfinishable. Creating the position leaves the user on
@@ -495,11 +549,12 @@ test.describe('user onboarding', () => {
     await expect(popoverTitle(page)).toHaveText(POSITION_STEP_TITLES[0]);
     await expectStepClear(page, `position step 1, "${POSITION_STEP_TITLES[0]}"`);
 
-    // The gesture step 1 asks for, from the control it highlights.
+    // The gesture step 1 asks for, from the control it highlights — and the
+    // whole of the move. No "Next": the field this set's second step names
+    // arrives with the dialog, and that arrival is what advances the step.
     await page.locator('[data-tour="position-new"]').click();
     const dialog = page.getByRole('dialog', { name: 'New Position' });
     await expect(dialog.locator('#symbol')).toBeVisible();
-    await popoverNext(page).click();
     await expect(popoverTitle(page)).toHaveText(POSITION_STEP_TITLES[1]);
     await expectStepClear(page, `position step 2, "${POSITION_STEP_TITLES[1]}", dialog open`);
 


### PR DESCRIPTION
Closes #87.

## The defect

One bug, reported against two walkthrough sets. The first step of the **account**
set and of the **position** set each ask the user to open a dialog, and the step
after each anchors to a field inside it (`#name`, `#symbol`).

That gesture publishes nothing on the event bus, so `withObservableActionsOnly()`
downgraded the step and handed "Next" back. But "Next" can only move a tour onto
a step whose target is on screen. Pressing it moved driver.js onto a target that
did not exist, which parks it in that step's `waitForElement` window **with the
previous popover still up** — fifteen seconds of a live button doing nothing,
then the walkthrough ended with a notice about a step the user never saw.

The **calculator** set was unaffected, because the control its next step names is
already rendered on `/calculator` — which is exactly what the issue's commenter
observed.

## The fix

The dialog arriving *is* the signal.

- `useWalkthrough` names the next step's target as `advanceOnAppearanceOf`, but
  only when that step is on the **same route** — a target reached by navigating
  must not be waited for, because nothing navigates until the tour moves.
- `tour-engine` holds "Next" while that control is absent, exactly as it does for
  an action step with an event behind it, and advances by itself the moment the
  control lands. That is the gesture the step's own copy asks for ("Choose New
  Position").
- Once the control is on screen the gate lifts, so the calculator's two gesture
  steps keep advancing on "Next" precisely as before.

## Verified

Driven in Chromium against a real stack, all four sets end to end:

| Set | Result |
| --- | --- |
| position | 1 → 5, entered from the checklist |
| account | 1 → 8 |
| calculator | 1 → 7 on "Next" alone, unchanged |
| close | 1 → 3, including the partial-exit path that carries on to `/dashboard` |

Checks: 508 onboarding unit tests, 15 onboarding e2e, `check-types` and `eslint`
all green.

## Tests

`e2e/tests/user-onboarding.spec.ts` used to **assert the broken behaviour** — press
Next, wait 5s, expect the tour still on step 1 — which is how this shipped with a
green suite. It is replaced by a parameterised test over both reported sets: the
press must move nothing *and* leave the walkthrough able to continue. The shared
`walkAccountSetTo` helper now asserts the gesture advance on every scenario that
walks the account set.
