### PR TITLE
feat(admin): factory-reset a user's data from the admin portal

### DIFF
--- a/apps/api/src/db/migrations/0030_admin_factory_reset_audit.sql
+++ b/apps/api/src/db/migrations/0030_admin_factory_reset_audit.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "admin_audit_log" DROP CONSTRAINT "admin_audit_log_action_chk";--> statement-breakpoint
+ALTER TABLE "admin_audit_log" ALTER COLUMN "old_value" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "admin_audit_log" ALTER COLUMN "new_value" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "admin_audit_log" ADD COLUMN "detail" jsonb;--> statement-breakpoint
+ALTER TABLE "admin_audit_log" ADD CONSTRAINT "admin_audit_log_toggle_values_chk" CHECK ("admin_audit_log"."action" <> 'admin_toggle' OR ("admin_audit_log"."old_value" IS NOT NULL AND "admin_audit_log"."new_value" IS NOT NULL));--> statement-breakpoint
+ALTER TABLE "admin_audit_log" ADD CONSTRAINT "admin_audit_log_action_chk" CHECK ("admin_audit_log"."action" IN ('admin_toggle', 'factory_reset'));

--- a/apps/api/src/db/migrations/meta/0030_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0030_snapshot.json
@@ -1,0 +1,3453 @@
+{
+  "id": "ec2fbaeb-7d47-41ef-bd11-3e2d1d196b9a",
+  "prevId": "1963d284-2494-4e1c-875c-73affd1bc695",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.exchange_rates": {
+      "name": "exchange_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_currency": {
+          "name": "base_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_currency": {
+          "name": "quote_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(24, 12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exchange_rates_user_pair_date_unique": {
+          "name": "exchange_rates_user_pair_date_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "base_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exchange_rates_user_id_users_id_fk": {
+          "name": "exchange_rates_user_id_users_id_fk",
+          "tableFrom": "exchange_rates",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "exchange_rates_distinct_currencies_chk": {
+          "name": "exchange_rates_distinct_currencies_chk",
+          "value": "\"exchange_rates\".\"base_currency\" <> \"exchange_rates\".\"quote_currency\""
+        },
+        "exchange_rates_rate_positive_chk": {
+          "name": "exchange_rates_rate_positive_chk",
+          "value": "\"exchange_rates\".\"rate\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ledger_entries": {
+      "name": "ledger_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_id": {
+          "name": "position_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reverses_group_id": {
+          "name": "reverses_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ledger_user_id_idx": {
+          "name": "ledger_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_account_id_idx": {
+          "name": "ledger_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_user_account_occurred_pnl_idx": {
+          "name": "ledger_user_account_occurred_pnl_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"occurred_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ledger_entries\".\"entry_type\" IN ('position_pnl', 'position_pnl_reversal', 'balance_adjustment')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_user_account_direction_amount_pnl_idx": {
+          "name": "ledger_user_account_direction_amount_pnl_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ledger_entries\".\"entry_type\" IN ('position_pnl', 'position_pnl_reversal', 'balance_adjustment')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_reverses_group_id_idx": {
+          "name": "ledger_reverses_group_id_idx",
+          "columns": [
+            {
+              "expression": "reverses_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ledger_entries\".\"reverses_group_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ledger_entries_user_id_users_id_fk": {
+          "name": "ledger_entries_user_id_users_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ledger_entries_account_id_accounts_id_fk": {
+          "name": "ledger_entries_account_id_accounts_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "ledger_entries_position_id_positions_id_fk": {
+          "name": "ledger_entries_position_id_positions_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "positions",
+          "columnsFrom": ["position_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ledger_amount_nonneg_chk": {
+          "name": "ledger_amount_nonneg_chk",
+          "value": "\"ledger_entries\".\"amount\" >= 0"
+        },
+        "ledger_direction_chk": {
+          "name": "ledger_direction_chk",
+          "value": "\"ledger_entries\".\"direction\" IN ('credit', 'debit')"
+        },
+        "ledger_entry_type_chk": {
+          "name": "ledger_entry_type_chk",
+          "value": "\"ledger_entries\".\"entry_type\" IN ('position_pnl', 'position_pnl_reversal', 'balance_adjustment')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "brokerage_id": {
+          "name": "brokerage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_balance": {
+          "name": "starting_balance",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "default_risk_percent": {
+          "name": "default_risk_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_demo": {
+          "name": "is_demo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_id_name_unique": {
+          "name": "accounts_user_id_name_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_brokerage_id_idx": {
+          "name": "accounts_brokerage_id_idx",
+          "columns": [
+            {
+              "expression": "brokerage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_brokerage_id_brokerages_id_fk": {
+          "name": "accounts_brokerage_id_brokerages_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "brokerages",
+          "columnsFrom": ["brokerage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_email": {
+          "name": "target_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_created_idx": {
+          "name": "admin_audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_actor_user_id_users_id_fk": {
+          "name": "admin_audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_users_id_fk": {
+          "name": "admin_audit_log_target_user_id_users_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["target_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "admin_audit_log_action_chk": {
+          "name": "admin_audit_log_action_chk",
+          "value": "\"admin_audit_log\".\"action\" IN ('admin_toggle', 'factory_reset')"
+        },
+        "admin_audit_log_toggle_values_chk": {
+          "name": "admin_audit_log_toggle_values_chk",
+          "value": "\"admin_audit_log\".\"action\" <> 'admin_toggle' OR (\"admin_audit_log\".\"old_value\" IS NOT NULL AND \"admin_audit_log\".\"new_value\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.advisor_image_counters": {
+      "name": "advisor_image_counters",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_count": {
+          "name": "image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "advisor_image_counters_user_id_users_id_fk": {
+          "name": "advisor_image_counters_user_id_users_id_fk",
+          "tableFrom": "advisor_image_counters",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "advisor_image_counters_user_id_period_key_pk": {
+          "name": "advisor_image_counters_user_id_period_key_pk",
+          "columns": ["user_id", "period_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_turn_counters": {
+      "name": "advisor_turn_counters",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "allowance_turns": {
+          "name": "allowance_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "advisor_turn_counters_user_id_users_id_fk": {
+          "name": "advisor_turn_counters_user_id_users_id_fk",
+          "tableFrom": "advisor_turn_counters",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "advisor_turn_counters_user_id_period_key_pk": {
+          "name": "advisor_turn_counters_user_id_period_key_pk",
+          "columns": ["user_id", "period_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_conversations": {
+      "name": "advisor_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_conversations_user_updated_idx": {
+          "name": "advisor_conversations_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_conversations_user_id_users_id_fk": {
+          "name": "advisor_conversations_user_id_users_id_fk",
+          "tableFrom": "advisor_conversations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "advisor_conversations_persona_id_advisor_personas_id_fk": {
+          "name": "advisor_conversations_persona_id_advisor_personas_id_fk",
+          "tableFrom": "advisor_conversations",
+          "tableTo": "advisor_personas",
+          "columnsFrom": ["persona_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_messages": {
+      "name": "advisor_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_parts": {
+          "name": "content_parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_message_id": {
+          "name": "client_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_messages_conv_created_idx": {
+          "name": "advisor_messages_conv_created_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "advisor_messages_idem": {
+          "name": "advisor_messages_idem",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "role = 'user' AND client_message_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "advisor_messages_assistant_pair_uniq": {
+          "name": "advisor_messages_assistant_pair_uniq",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "role = 'assistant' AND client_message_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_messages_conversation_id_advisor_conversations_id_fk": {
+          "name": "advisor_messages_conversation_id_advisor_conversations_id_fk",
+          "tableFrom": "advisor_messages",
+          "tableTo": "advisor_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "advisor_messages_role_chk": {
+          "name": "advisor_messages_role_chk",
+          "value": "\"advisor_messages\".\"role\" IN ('user', 'assistant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.advisor_personas": {
+      "name": "advisor_personas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_personas_one_default_per_user": {
+          "name": "advisor_personas_one_default_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true AND user_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_personas_user_id_users_id_fk": {
+          "name": "advisor_personas_user_id_users_id_fk",
+          "tableFrom": "advisor_personas",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_provider_keys": {
+      "name": "advisor_provider_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hint_tail": {
+          "name": "key_hint_tail",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_provider_keys_user_provider_uniq": {
+          "name": "advisor_provider_keys_user_provider_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_provider_keys_user_id_users_id_fk": {
+          "name": "advisor_provider_keys_user_id_users_id_fk",
+          "tableFrom": "advisor_provider_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_summaries": {
+      "name": "advisor_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prose": {
+          "name": "prose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trade_data_figures": {
+          "name": "trade_data_figures",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered_through_message_id": {
+          "name": "covered_through_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered_through_created_at": {
+          "name": "covered_through_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_summaries_conversation_uniq": {
+          "name": "advisor_summaries_conversation_uniq",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_summaries_conversation_id_advisor_conversations_id_fk": {
+          "name": "advisor_summaries_conversation_id_advisor_conversations_id_fk",
+          "tableFrom": "advisor_summaries",
+          "tableTo": "advisor_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_api_keys": {
+      "name": "external_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hint_tail": {
+          "name": "key_hint_tail",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_api_keys_user_provider_uniq": {
+          "name": "external_api_keys_user_provider_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_api_keys_user_id_users_id_fk": {
+          "name": "external_api_keys_user_id_users_id_fk",
+          "tableFrom": "external_api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brokerages": {
+      "name": "brokerages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brokerages_user_id_idx": {
+          "name": "brokerages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brokerages_user_id_name_unique": {
+          "name": "brokerages_user_id_name_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"brokerages\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brokerages_system_name_unique": {
+          "name": "brokerages_system_name_unique",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"brokerages\".\"is_system\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brokerages_user_id_users_id_fk": {
+          "name": "brokerages_user_id_users_id_fk",
+          "tableFrom": "brokerages",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_schedules": {
+      "name": "fee_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "brokerage_id": {
+          "name": "brokerage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_per_share_commission": {
+          "name": "stock_per_share_commission",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "stock_min_per_fill": {
+          "name": "stock_min_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "stock_max_per_fill": {
+          "name": "stock_max_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_per_contract_commission": {
+          "name": "options_per_contract_commission",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_per_contract_exchange_fee": {
+          "name": "options_per_contract_exchange_fee",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_min_per_fill": {
+          "name": "options_min_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_max_per_fill": {
+          "name": "options_max_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_schedules_brokerage_id_brokerages_id_fk": {
+          "name": "fee_schedules_brokerage_id_brokerages_id_fk",
+          "tableFrom": "fee_schedules",
+          "tableTo": "brokerages",
+          "columnsFrom": ["brokerage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_schedules_brokerage_id_unique": {
+          "name": "fee_schedules_brokerage_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["brokerage_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.csv_import_counters": {
+      "name": "csv_import_counters",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "committed_count": {
+          "name": "committed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "csv_import_counters_user_id_users_id_fk": {
+          "name": "csv_import_counters_user_id_users_id_fk",
+          "tableFrom": "csv_import_counters",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.csv_import_staging": {
+      "name": "csv_import_staging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'staged'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committed_result": {
+          "name": "committed_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "csv_import_staging_one_active_per_user_idx": {
+          "name": "csv_import_staging_one_active_per_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"csv_import_staging\".\"status\" IN ('staged', 'committing')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "csv_import_staging_user_id_idx": {
+          "name": "csv_import_staging_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "csv_import_staging_expires_at_idx": {
+          "name": "csv_import_staging_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "csv_import_staging_user_id_users_id_fk": {
+          "name": "csv_import_staging_user_id_users_id_fk",
+          "tableFrom": "csv_import_staging",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "csv_import_staging_account_id_accounts_id_fk": {
+          "name": "csv_import_staging_account_id_accounts_id_fk",
+          "tableFrom": "csv_import_staging",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_layouts": {
+      "name": "dashboard_layouts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgets": {
+          "name": "widgets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_layouts_user_id_users_id_fk": {
+          "name": "dashboard_layouts_user_id_users_id_fk",
+          "tableFrom": "dashboard_layouts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_tokens": {
+      "name": "email_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_tokens_user_purpose_idx": {
+          "name": "email_tokens_user_purpose_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_tokens_one_live_per_user_purpose": {
+          "name": "email_tokens_one_live_per_user_purpose",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "consumed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_tokens_user_id_users_id_fk": {
+          "name": "email_tokens_user_id_users_id_fk",
+          "tableFrom": "email_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_tokens_token_hash_unique": {
+          "name": "email_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_tokens_purpose_chk": {
+          "name": "email_tokens_purpose_chk",
+          "value": "\"email_tokens\".\"purpose\" IN ('password_reset','email_verification')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.expenses": {
+      "name": "expenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "expenses_user_id_idx": {
+          "name": "expenses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "expenses_user_occurred_idx": {
+          "name": "expenses_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"occurred_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "expenses_user_id_users_id_fk": {
+          "name": "expenses_user_id_users_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "expenses_amount_positive_chk": {
+          "name": "expenses_amount_positive_chk",
+          "value": "\"expenses\".\"amount\" > 0"
+        },
+        "expenses_category_chk": {
+          "name": "expenses_category_chk",
+          "value": "category IN ('data_subscription', 'platform_fee', 'software', 'education', 'hardware', 'other')"
+        },
+        "expenses_currency_chk": {
+          "name": "expenses_currency_chk",
+          "value": "currency IN ('USD', 'EUR', 'GBP', 'CAD', 'AUD', 'JPY', 'CHF', 'HKD', 'SGD', 'NZD', 'SEK', 'NOK', 'DKK', 'MXN', 'BRL', 'INR', 'KRW', 'TWD', 'ZAR')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public._post_migrations_journal": {
+      "name": "_post_migrations_journal",
+      "schema": "",
+      "columns": {
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fills": {
+      "name": "fills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "position_id": {
+          "name": "position_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fees": {
+          "name": "fees",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filled_at": {
+          "name": "filled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fills_position_id_idx": {
+          "name": "fills_position_id_idx",
+          "columns": [
+            {
+              "expression": "position_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fills_position_id_positions_id_fk": {
+          "name": "fills_position_id_positions_id_fk",
+          "tableFrom": "fills",
+          "tableTo": "positions",
+          "columnsFrom": ["position_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.positions": {
+      "name": "positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_price": {
+          "name": "target_price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_loss": {
+          "name": "stop_loss",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_flat_at": {
+          "name": "last_flat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_flat_net_pnl": {
+          "name": "last_flat_net_pnl",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "positions_user_id_idx": {
+          "name": "positions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "positions_account_id_idx": {
+          "name": "positions_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "positions_user_id_status_updated_at_idx": {
+          "name": "positions_user_id_status_updated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "positions_user_status_closed_at_idx": {
+          "name": "positions_user_status_closed_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "positions_user_id_users_id_fk": {
+          "name": "positions_user_id_users_id_fk",
+          "tableFrom": "positions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "positions_account_id_accounts_id_fk": {
+          "name": "positions_account_id_accounts_id_fk",
+          "tableFrom": "positions",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "positions_closed_at_when_closed_chk": {
+          "name": "positions_closed_at_when_closed_chk",
+          "value": "\"positions\".\"status\" <> 'closed' OR \"positions\".\"closed_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.symbol_sync_state": {
+      "name": "symbol_sync_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "smallint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncing": {
+          "name": "syncing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "syncing_started_at": {
+          "name": "syncing_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "symbol_count": {
+          "name": "symbol_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "symbol_sync_state_singleton": {
+          "name": "symbol_sync_state_singleton",
+          "value": "\"symbol_sync_state\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.symbols": {
+      "name": "symbols",
+      "schema": "",
+      "columns": {
+        "ticker": {
+          "name": "ticker",
+          "type": "varchar(16)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exchange": {
+          "name": "exchange",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cik": {
+          "name": "cik",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "symbols_ticker_prefix_idx": {
+          "name": "symbols_ticker_prefix_idx",
+          "columns": [
+            {
+              "expression": "ticker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "varchar_pattern_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed": {
+          "name": "last_accessed",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_currency": {
+          "name": "display_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_jurisdiction": {
+          "name": "tax_jurisdiction",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "buying_power_basis": {
+          "name": "buying_power_basis",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cash'"
+        },
+        "advisor_default_persona_id": {
+          "name": "advisor_default_persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advisor_trade_data_consent": {
+          "name": "advisor_trade_data_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "writable_account_id": {
+          "name": "writable_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changelog_viewed_at": {
+          "name": "changelog_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding": {
+          "name": "onboarding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_tax_jurisdiction_chk": {
+          "name": "users_tax_jurisdiction_chk",
+          "value": "\"users\".\"tax_jurisdiction\" IS NULL OR \"users\".\"tax_jurisdiction\" IN ('US', 'CA', 'other')"
+        },
+        "users_theme_chk": {
+          "name": "users_theme_chk",
+          "value": "\"users\".\"theme\" IN ('light','dark','system')"
+        },
+        "users_buying_power_basis_chk": {
+          "name": "users_buying_power_basis_chk",
+          "value": "\"users\".\"buying_power_basis\" IN ('cash','balance')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_customers": {
+      "name": "billing_customers",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_customers_user_id_users_id_fk": {
+          "name": "billing_customers_user_id_users_id_fk",
+          "tableFrom": "billing_customers",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_customers_stripe_customer_id_unique": {
+          "name": "billing_customers_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_customer_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_unit_amount": {
+          "name": "price_unit_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_currency": {
+          "name": "price_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_created_at": {
+          "name": "stripe_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entered_past_due_at": {
+          "name": "entered_past_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_created": {
+          "name": "last_event_created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_subscription_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_cost": {
+          "name": "credit_cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_cost": {
+          "name": "raw_cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_records_user_created_idx": {
+          "name": "usage_records_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_records_created_idx": {
+          "name": "usage_records_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_user_id_users_id_fk": {
+          "name": "usage_records_user_id_users_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_records_conversation_id_advisor_conversations_id_fk": {
+          "name": "usage_records_conversation_id_advisor_conversations_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "advisor_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "usage_records_message_id_advisor_messages_id_fk": {
+          "name": "usage_records_message_id_advisor_messages_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "advisor_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_transactions": {
+      "name": "wallet_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_record_id": {
+          "name": "usage_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_transactions_user_created_idx": {
+          "name": "wallet_transactions_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transactions_payment_intent_idx": {
+          "name": "wallet_transactions_payment_intent_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_transactions_user_id_users_id_fk": {
+          "name": "wallet_transactions_user_id_users_id_fk",
+          "tableFrom": "wallet_transactions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_transactions_usage_record_id_usage_records_id_fk": {
+          "name": "wallet_transactions_usage_record_id_usage_records_id_fk",
+          "tableFrom": "wallet_transactions",
+          "tableTo": "usage_records",
+          "columnsFrom": ["usage_record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "wallet_transactions_kind_chk": {
+          "name": "wallet_transactions_kind_chk",
+          "value": "\"wallet_transactions\".\"kind\" IN ('credit', 'debit', 'reversal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "reserved": {
+          "name": "reserved",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallets_user_id_users_id_fk": {
+          "name": "wallets_user_id_users_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "wallets_reserved_nonneg_chk": {
+          "name": "wallets_reserved_nonneg_chk",
+          "value": "\"wallets\".\"reserved\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_events_stripe_event_id_unique": {
+          "name": "webhook_events_stripe_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_event_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webhook_events_status_chk": {
+          "name": "webhook_events_status_chk",
+          "value": "\"webhook_events\".\"status\" IN ('received', 'processed', 'ignored', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1786136740902,
       "tag": "0029_account_is_demo",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1788120859351,
+      "tag": "0030_admin_factory_reset_audit",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema/admin.schema.ts
+++ b/apps/api/src/db/schema/admin.schema.ts
@@ -9,10 +9,21 @@ import {
   timestamp,
   index,
   check,
+  jsonb,
   primaryKey,
 } from 'drizzle-orm/pg-core';
 
 import { users } from './users.schema';
+
+/**
+ * What a `factory_reset` audit entry carries. `deleted` is keyed by table name
+ * with the row count removed from each, so the entry answers "what did this
+ * destroy?" without the rows it destroyed.
+ */
+export interface AdminAuditDetail {
+  removeSettings: boolean;
+  deleted: Record<string, number>;
+}
 
 // REQ-6.2: append-only per-user advisor-turn counter, keyed by UTC calendar month
 // ('YYYY-MM'). Rows are never decremented and never deleted by application flows
@@ -61,6 +72,14 @@ export const advisorImageCounters = pgTable(
 // REQ-3.5: append-only admin-action audit. Emails are snapshotted so entries stay
 // meaningful after user deletion (FKs are ON DELETE SET NULL). No read endpoint/UI
 // ships in admin-platform — operator SQL is the read path (design Component 4).
+//
+// TWO ACTIONS NOW, AND THEY DO NOT HAVE THE SAME SHAPE. `admin_toggle` is a
+// boolean transition and says everything it needs to in `old_value`/`new_value`.
+// `factory_reset` has no before/after boolean — what it has is a list of what it
+// destroyed — so those two columns became NULLABLE and `detail` was added to
+// carry the per-action payload. A partial CHECK keeps `admin_toggle` honest
+// rather than letting the relaxation apply to it as well: an entry for the one
+// action that IS a transition must still record both ends of it.
 export const adminAuditLog = pgTable(
   'admin_audit_log',
   {
@@ -70,12 +89,27 @@ export const adminAuditLog = pgTable(
     actorEmail: varchar('actor_email', { length: 255 }).notNull(),
     targetUserId: uuid('target_user_id').references(() => users.id, { onDelete: 'set null' }),
     targetEmail: varchar('target_email', { length: 255 }).notNull(),
-    oldValue: boolean('old_value').notNull(),
-    newValue: boolean('new_value').notNull(),
+    oldValue: boolean('old_value'),
+    newValue: boolean('new_value'),
+    /**
+     * Action-specific payload. NULL for `admin_toggle`, which needs none.
+     *
+     * For `factory_reset` it is the ONLY record of what the reset destroyed —
+     * the row counts per table and whether settings were included — and it is
+     * written in the same transaction as the deletes, so an audited reset and a
+     * performed reset are the same event. Nothing reconstructs those counts
+     * afterwards: the rows are gone.
+     */
+    detail: jsonb('detail').$type<AdminAuditDetail>(),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
-    check('admin_audit_log_action_chk', sql`${t.action} IN ('admin_toggle')`),
+    check('admin_audit_log_action_chk', sql`${t.action} IN ('admin_toggle', 'factory_reset')`),
+    // The transition columns stay mandatory for the action that IS a transition.
+    check(
+      'admin_audit_log_toggle_values_chk',
+      sql`${t.action} <> 'admin_toggle' OR (${t.oldValue} IS NOT NULL AND ${t.newValue} IS NOT NULL)`,
+    ),
     index('admin_audit_log_created_idx').on(t.createdAt),
   ],
 );

--- a/apps/api/src/features/admin/admin.query.ts
+++ b/apps/api/src/features/admin/admin.query.ts
@@ -1,8 +1,20 @@
-import { and, eq, gt, gte, lt, sql } from 'drizzle-orm';
+import { and, eq, gt, gte, inArray, isNotNull, lt, sql } from 'drizzle-orm';
+import type { PgColumn, PgTable } from 'drizzle-orm/pg-core';
 
 import type { Database, Transaction } from '@/db';
 import {
+  accounts,
   adminAuditLog,
+  advisorConversations,
+  advisorPersonas,
+  advisorProviderKeys,
+  brokerages,
+  csvImportStaging,
+  dashboardLayouts,
+  expenses,
+  externalApiKeys,
+  fills,
+  ledgerEntries,
   positions,
   sessions,
   usageRecords,
@@ -10,6 +22,7 @@ import {
   walletTransactions,
   wallets,
 } from '@/db/schema';
+import type { AdminAuditDetail } from '@/db/schema/admin.schema';
 
 import { currentPeriodKeyUtc, getTurnCount } from './gating.query';
 
@@ -378,15 +391,30 @@ export async function updateUserIsAdmin(
   return row;
 }
 
-export interface AdminAuditEntryInsert {
-  action: 'admin_toggle';
-  actorUserId: string;
-  actorEmail: string;
-  targetUserId: string;
-  targetEmail: string;
-  oldValue: boolean;
-  newValue: boolean;
-}
+/**
+ * A discriminated union, not one shape with optional fields, so the DB's own
+ * `admin_audit_log_toggle_values_chk` cannot be violated from TypeScript: a
+ * toggle entry without both boolean ends does not typecheck, and a reset entry
+ * cannot claim ones it does not have.
+ */
+export type AdminAuditEntryInsert =
+  | {
+      action: 'admin_toggle';
+      actorUserId: string;
+      actorEmail: string;
+      targetUserId: string;
+      targetEmail: string;
+      oldValue: boolean;
+      newValue: boolean;
+    }
+  | {
+      action: 'factory_reset';
+      actorUserId: string;
+      actorEmail: string;
+      targetUserId: string;
+      targetEmail: string;
+      detail: AdminAuditDetail;
+    };
 
 /**
  * Append the audit row in the SAME transaction as the flag flip (REQ-3.5).
@@ -623,4 +651,298 @@ export async function sumPeriodRevenue(
   const credited = BigInt((creditedRow?.sum as string | undefined) ?? 0);
   const reversed = BigInt((reversedRow?.sum as string | undefined) ?? 0);
   return { credited, reversed, net: credited + reversed };
+}
+
+// --- Component 13: factory reset --------------------------------------------
+//
+// WHAT A RESET DOES NOT TOUCH IS THE PART WORTH READING, because the deletes
+// below are unremarkable and the omissions are load-bearing:
+//
+// - BILLING AND WALLET (`wallets`, `wallet_transactions`, `usage_records`,
+//   `subscriptions`, `billing_customers`, `webhook_events`). `subscriptions` and
+//   `billing_customers` are local MIRRORS of Stripe, so deleting them cancels
+//   nothing — it orphans a live Stripe Customer and leaves the next webhook
+//   writing rows for a subscription the app no longer believes in. The wallet
+//   holds credit the user paid real money for. A journal reset is not a refund
+//   and must not look like one.
+// - QUOTA COUNTERS (`csv_import_counters`, `advisor_turn_counters`,
+//   `advisor_image_counters`). Their own schema comments say they are "never
+//   decremented and never deleted by application flows (non-evasion)", with the
+//   user-deletion CASCADE as the only removal path. Resetting them would turn
+//   this button into a way to refill a free-tier allowance on demand — exactly
+//   the evasion those comments exist to prevent.
+// - IDENTITY (`email`, `password_hash`, `is_admin`, `email_verified`,
+//   `created_at`) and `sessions`. The user is returned to the state they were in
+//   just after registering and verifying: the account still exists, still
+//   belongs to them, and stays logged in.
+//
+// ORDER IS NOT COSMETIC. Three FKs into this graph are ON DELETE RESTRICT —
+// `positions.account_id`, `ledger_entries.account_id` and
+// `accounts.brokerage_id` — so PostgreSQL refuses to delete an account while a
+// position or ledger entry still points at it, and refuses to delete a
+// user-owned brokerage while an account still points at that. The sequence below
+// is the topological one those constraints force; reordering it does not lose
+// data, it aborts the transaction.
+
+/** Rows removed, keyed by table name. */
+export type ResetDeleteCounts = Record<string, number>;
+
+/** `COUNT(*)` over one table for one user — the shape all twelve counts share. */
+async function countBy(
+  db: Database | Transaction,
+  table: PgTable,
+  column: PgColumn,
+  userId: string,
+): Promise<number> {
+  const [row] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(table)
+    .where(eq(column, userId));
+  return row?.count ?? 0;
+}
+
+/** `fills` has no `user_id`; it is reached through the user's positions. */
+async function countFillsForUser(db: Database | Transaction, userId: string): Promise<number> {
+  const [row] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(fills)
+    .where(
+      inArray(
+        fills.positionId,
+        db.select({ id: positions.id }).from(positions).where(eq(positions.userId, userId)),
+      ),
+    );
+  return row?.count ?? 0;
+}
+
+/**
+ * The always-deleted half: everything the user has journalled.
+ *
+ * `fills` and `fee_schedules` are not deleted directly — they CASCADE from
+ * `positions` and `brokerages` — so the fill count is taken before the parent
+ * goes, which is the only moment it can be.
+ */
+export async function deleteTradingData(
+  tx: Transaction,
+  userId: string,
+): Promise<ResetDeleteCounts> {
+  const counts: ResetDeleteCounts = {};
+
+  // Counted before the cascade takes them.
+  counts.fills = await countFillsForUser(tx, userId);
+
+  // 1. Ledger entries — RESTRICT on accounts, so they go first.
+  counts.ledger_entries = (
+    await tx
+      .delete(ledgerEntries)
+      .where(eq(ledgerEntries.userId, userId))
+      .returning({ id: ledgerEntries.id })
+  ).length;
+
+  // 2. Positions — RESTRICT on accounts; cascades fills.
+  counts.positions = (
+    await tx.delete(positions).where(eq(positions.userId, userId)).returning({ id: positions.id })
+  ).length;
+
+  // 3. Staged CSV rows — cascade from accounts anyway, deleted explicitly so the
+  //    count is reported rather than silently absorbed.
+  counts.csv_import_staging = (
+    await tx
+      .delete(csvImportStaging)
+      .where(eq(csvImportStaging.userId, userId))
+      .returning({ id: csvImportStaging.id })
+  ).length;
+
+  counts.expenses = (
+    await tx.delete(expenses).where(eq(expenses.userId, userId)).returning({ id: expenses.id })
+  ).length;
+
+  // 4. Accounts — now unblocked. `users.writable_account_id` is ON DELETE SET
+  //    NULL, so the free-tier writable-account designation clears itself.
+  counts.accounts = (
+    await tx.delete(accounts).where(eq(accounts.userId, userId)).returning({ id: accounts.id })
+  ).length;
+
+  // 5. The user's OWN brokerages only. `brokerages.user_id` is nullable: NULL
+  //    marks the system brokerages every user shares, and deleting those would
+  //    empty the picker for the whole instance. `isNotNull` is redundant against
+  //    `eq` — NULL never equals — and kept as the statement of intent, because
+  //    the cost of that line being wrong is instance-wide.
+  counts.brokerages = (
+    await tx
+      .delete(brokerages)
+      .where(and(eq(brokerages.userId, userId), isNotNull(brokerages.userId)))
+      .returning({ id: brokerages.id })
+  ).length;
+
+  return counts;
+}
+
+/**
+ * The opt-in half: configuration the operator chose to remove as well.
+ *
+ * Deliberately NOT including `users.onboarding` — that is reset on every run by
+ * `resetUserPreferences` below, whatever the flag says, because a reset user
+ * whose walkthrough still believes it has been completed cannot do the one thing
+ * this feature exists for.
+ */
+export async function deleteUserSettings(
+  tx: Transaction,
+  userId: string,
+): Promise<ResetDeleteCounts> {
+  const counts: ResetDeleteCounts = {};
+
+  counts.advisor_provider_keys = (
+    await tx
+      .delete(advisorProviderKeys)
+      .where(eq(advisorProviderKeys.userId, userId))
+      .returning({ id: advisorProviderKeys.id })
+  ).length;
+
+  counts.external_api_keys = (
+    await tx
+      .delete(externalApiKeys)
+      .where(eq(externalApiKeys.userId, userId))
+      .returning({ id: externalApiKeys.id })
+  ).length;
+
+  // Cascades advisor_messages and advisor_summaries.
+  counts.advisor_conversations = (
+    await tx
+      .delete(advisorConversations)
+      .where(eq(advisorConversations.userId, userId))
+      .returning({ id: advisorConversations.id })
+  ).length;
+
+  // `users.advisor_default_persona_id` is ON DELETE SET NULL, so the default
+  // clears itself rather than pointing at a persona that no longer exists.
+  counts.advisor_personas = (
+    await tx
+      .delete(advisorPersonas)
+      .where(eq(advisorPersonas.userId, userId))
+      .returning({ id: advisorPersonas.id })
+  ).length;
+
+  counts.dashboard_layouts = (
+    await tx
+      .delete(dashboardLayouts)
+      .where(eq(dashboardLayouts.userId, userId))
+      .returning({ userId: dashboardLayouts.userId })
+  ).length;
+
+  return counts;
+}
+
+/**
+ * Return the `users` row to its post-registration state.
+ *
+ * `onboarding` is reset UNCONDITIONALLY — see `deleteUserSettings`. The
+ * preference columns go back to their schema defaults only when the operator
+ * asked for settings to be removed, and the values written are the ones a
+ * brand-new row carries, so "reset" and "newly registered" mean the same thing.
+ *
+ * Never touched: `email`, `password_hash`, `is_admin`, `email_verified`,
+ * `created_at`. The account is being emptied, not re-created.
+ */
+export async function resetUserPreferences(
+  tx: Transaction,
+  userId: string,
+  removeSettings: boolean,
+): Promise<void> {
+  await tx
+    .update(users)
+    .set({
+      // Always: the walkthrough status, the first-calculator-use stamp and the
+      // set of coach marks seen. '{}' is what a brand-new row carries.
+      onboarding: {},
+      ...(removeSettings
+        ? {
+            displayCurrency: null,
+            timezone: null,
+            taxJurisdiction: null,
+            theme: 'system',
+            buyingPowerBasis: 'cash',
+            advisorTradeDataConsent: false,
+            changelogViewedAt: null,
+          }
+        : {}),
+      updatedAt: new Date(),
+    })
+    .where(eq(users.id, userId));
+}
+
+/**
+ * Count what a reset WOULD remove, without removing it.
+ *
+ * Both halves are always counted, whatever the operator has ticked, so the
+ * dialog can show what including settings would add without a second request
+ * that could come back with different numbers.
+ */
+export async function countResettableData(
+  db: Database | Transaction,
+  userId: string,
+): Promise<{
+  tradingData: {
+    accounts: number;
+    positions: number;
+    fills: number;
+    ledgerEntries: number;
+    expenses: number;
+    brokerages: number;
+    csvImportStaging: number;
+  };
+  settings: {
+    providerKeys: number;
+    externalApiKeys: number;
+    advisorPersonas: number;
+    advisorConversations: number;
+    dashboardLayouts: number;
+  };
+}> {
+  const [
+    accountCount,
+    positionCount,
+    fillCount,
+    ledgerCount,
+    expenseCount,
+    brokerageCount,
+    stagingCount,
+    providerKeyCount,
+    externalKeyCount,
+    personaCount,
+    conversationCount,
+    layoutCount,
+  ] = await Promise.all([
+    countBy(db, accounts, accounts.userId, userId),
+    countBy(db, positions, positions.userId, userId),
+    countFillsForUser(db, userId),
+    countBy(db, ledgerEntries, ledgerEntries.userId, userId),
+    countBy(db, expenses, expenses.userId, userId),
+    countBy(db, brokerages, brokerages.userId, userId),
+    countBy(db, csvImportStaging, csvImportStaging.userId, userId),
+    countBy(db, advisorProviderKeys, advisorProviderKeys.userId, userId),
+    countBy(db, externalApiKeys, externalApiKeys.userId, userId),
+    countBy(db, advisorPersonas, advisorPersonas.userId, userId),
+    countBy(db, advisorConversations, advisorConversations.userId, userId),
+    countBy(db, dashboardLayouts, dashboardLayouts.userId, userId),
+  ]);
+
+  return {
+    tradingData: {
+      accounts: accountCount,
+      positions: positionCount,
+      fills: fillCount,
+      ledgerEntries: ledgerCount,
+      expenses: expenseCount,
+      brokerages: brokerageCount,
+      csvImportStaging: stagingCount,
+    },
+    settings: {
+      providerKeys: providerKeyCount,
+      externalApiKeys: externalKeyCount,
+      advisorPersonas: personaCount,
+      advisorConversations: conversationCount,
+      dashboardLayouts: layoutCount,
+    },
+  };
 }

--- a/apps/api/src/features/admin/admin.route.ts
+++ b/apps/api/src/features/admin/admin.route.ts
@@ -1,14 +1,26 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 
-import { AdminUsageQuerySchema, ToggleAdminRequestSchema } from '@tradr/shared';
+import {
+  AdminResetRequestSchema,
+  AdminUsageQuerySchema,
+  ToggleAdminRequestSchema,
+} from '@tradr/shared';
 
 import { validate } from '@/lib/validation';
 import { adminMiddleware } from '@/middleware/admin.middleware';
 import { authMiddleware } from '@/middleware/auth.middleware';
 import { createRateLimiter } from '@/middleware/rate-limit.middleware';
 
-import { getPlatformStats, getUsage, getUserDetail, listUsers, toggleAdmin } from './admin.service';
+import {
+  factoryResetUser,
+  getPlatformStats,
+  getResetPreview,
+  getUsage,
+  getUserDetail,
+  listUsers,
+  toggleAdmin,
+} from './admin.service';
 
 // ---------------------------------------------------------------------------
 // Admin API routes (admin-platform design Components 1, 9, 12).
@@ -20,9 +32,11 @@ import { getPlatformStats, getUsage, getUserDetail, listUsers, toggleAdmin } fro
 // re-assertion. The limiter sits AFTER the gate so non-admin probes consume
 // no bucket and are indistinguishable from any other 403.
 //
-// Handlers are thin: validate, call the admin.service function, return. The
-// only write is the PATCH toggle — non-GET per the SameSite=Lax CSRF posture
-// (REQ-3.3).
+// Handlers are thin: validate, call the admin.service function, return. Two
+// writes — the PATCH admin toggle and the POST factory reset — both non-GET per
+// the SameSite=Lax CSRF posture (REQ-3.3). The reset is the only DESTRUCTIVE
+// endpoint on the surface; its confirmation is enforced in the service, not
+// here, because a check that lives in the client is not a check.
 //
 // Convention: hand-authored JSDoc `@swagger` blocks (billing/advisor route
 // style), NOT `@hono/zod-openapi` (not a dependency) — design Component 9.
@@ -236,3 +250,106 @@ adminRouter.get('/usage', validate('query', AdminUsageQuerySchema), async (c) =>
 });
 
 export { adminRouter };
+
+/**
+ * @swagger
+ * /api/admin/users/{id}/reset-preview:
+ *   get:
+ *     summary: What a factory reset would delete for this user (admin only).
+ *     description: >
+ *       Admin-gated (403 `ADMIN_REQUIRED`). Read-only. Returns the row counts a
+ *       factory reset would remove, split into `tradingData` (always removed) and
+ *       `settings` (removed only when the reset is requested with
+ *       `removeSettings: true`). Both halves are always counted, so a client can show
+ *       what including settings would add without a second request. Counts are a
+ *       snapshot and are not a promise about a later reset — `POST .../reset`
+ *       re-counts from its own deletes.
+ *     tags: [Admin]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     responses:
+ *       200: { description: 'AdminResetPreview — { userId, email, tradingData, settings }.' }
+ *       400: { description: VALIDATION_ERROR — id is not a UUID. }
+ *       401: { description: Not authenticated. }
+ *       403: { description: ADMIN_REQUIRED — authenticated but not an admin. }
+ *       404: { description: NOT_FOUND — no such user. }
+ *       429: { description: Admin rate limit reached (60 / 60 s per user). }
+ */
+adminRouter.get('/users/:id/reset-preview', validate('param', IdParamSchema), async (c) => {
+  const { id } = c.req.valid('param');
+  return c.json(await getResetPreview(id), 200);
+});
+
+/**
+ * @swagger
+ * /api/admin/users/{id}/reset:
+ *   post:
+ *     summary: Factory-reset a user's data to their post-registration state (admin only).
+ *     description: >
+ *       Admin-gated (403 `ADMIN_REQUIRED`). DESTRUCTIVE AND IRREVERSIBLE — there is no
+ *       undo and no backup taken. POST (never GET) per the SameSite=Lax CSRF posture.
+ *
+ *       `confirmEmail` must equal the target user's email (case-insensitive) or the
+ *       request is a 400 `VALIDATION_ERROR` and nothing is changed; the check is
+ *       enforced here, not only in the UI that collects it.
+ *
+ *       ALWAYS DELETED: accounts, positions, fills, ledger entries, expenses, the
+ *       user's own brokerages and their fee schedules, and staged CSV rows. ALWAYS
+ *       RESET: the user's onboarding state, so the walkthrough can be walked again.
+ *       DELETED ONLY WHEN `removeSettings` IS TRUE (default false): BYOK provider and
+ *       external API keys, advisor personas/conversations/messages/summaries, the
+ *       dashboard layout, and the user's preference columns.
+ *
+ *       NEVER TOUCHED: billing and wallet state (`wallets`, `wallet_transactions`,
+ *       `usage_records`, `subscriptions`, `billing_customers`) — these mirror Stripe
+ *       and hold purchased credit; the non-evasion quota counters
+ *       (`csv_import_counters`, `advisor_turn_counters`, `advisor_image_counters`);
+ *       and the user's identity (email, password, admin flag, verified flag,
+ *       created-at) and sessions — the user stays logged in.
+ *
+ *       Deletes and the `admin_audit_log` entry recording them commit in one
+ *       transaction. That entry's `detail` is the only surviving record of what was
+ *       removed.
+ *     tags: [Admin]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [confirmEmail]
+ *             properties:
+ *               confirmEmail:
+ *                 type: string
+ *                 format: email
+ *                 description: Must match the target user's email, case-insensitively.
+ *               removeSettings:
+ *                 type: boolean
+ *                 default: false
+ *                 description: Also delete BYOK keys, advisor data, dashboard layout and preferences.
+ *     responses:
+ *       200: { description: 'AdminResetResult — { userId, email, removeSettings, deleted }.' }
+ *       400: { description: 'VALIDATION_ERROR — id is not a UUID, body malformed, or confirmEmail does not match.' }
+ *       401: { description: Not authenticated. }
+ *       403: { description: ADMIN_REQUIRED — authenticated but not an admin. }
+ *       404: { description: NOT_FOUND — no such user. }
+ *       429: { description: Admin rate limit reached (60 / 60 s per user). }
+ */
+adminRouter.post(
+  '/users/:id/reset',
+  validate('param', IdParamSchema),
+  validate('json', AdminResetRequestSchema),
+  async (c) => {
+    const { id } = c.req.valid('param');
+    const { confirmEmail, removeSettings } = c.req.valid('json');
+    return c.json(await factoryResetUser(c.get('userId'), id, confirmEmail, removeSettings), 200);
+  },
+);

--- a/apps/api/src/features/admin/admin.service.ts
+++ b/apps/api/src/features/admin/admin.service.ts
@@ -1,5 +1,7 @@
 import {
   AdminUsageQuerySchema,
+  type AdminResetPreview,
+  type AdminResetResult,
   type AdminStats,
   type AdminUsage,
   type AdminUserDetail,
@@ -15,6 +17,10 @@ import { withTransaction } from '@/lib/transaction';
 import {
   countActiveUsersNow,
   countAdmins,
+  countResettableData,
+  deleteTradingData,
+  deleteUserSettings,
+  resetUserPreferences,
   countAllPositionsByStatus,
   countAllUsers,
   decodeAdminUserCursor,
@@ -281,4 +287,94 @@ export async function getUsage(from?: string, to?: string): Promise<AdminUsage> 
       net: revenue.net.toString(),
     },
   };
+}
+
+/**
+ * What a factory reset would destroy for this user (REQ-13.1).
+ *
+ * Read-only and unlocked: it feeds the confirmation dialog, and the numbers are
+ * a description of the account rather than a promise about a future transaction.
+ * The reset itself re-counts from its own DELETEs, so a row added between the
+ * preview and the press is still removed and still reported — the preview being
+ * a few rows stale cannot cause the wrong thing to be deleted.
+ */
+export async function getResetPreview(userId: string): Promise<AdminResetPreview> {
+  const row = await selectAdminUserById(db, userId);
+  if (!row) throw new NotFoundError('User', userId);
+  const counts = await countResettableData(db, userId);
+  return { userId, email: row.email, ...counts };
+}
+
+/**
+ * Return a user's journal to its post-registration state (REQ-13.2).
+ *
+ * THE TYPED EMAIL IS CHECKED HERE, not only in the dialog that collected it. A
+ * confirmation implemented in the client is a courtesy to whoever uses the
+ * client; this endpoint is reachable by anything holding an admin session, and
+ * the whole value of "type the address" is that a request aimed at the wrong id
+ * cannot destroy the wrong account. Compared case-insensitively because
+ * registration lowercases what it stores and an operator reading an address off
+ * the screen should not be punished for capitalising it.
+ *
+ * ONE TRANSACTION COVERS THE DELETES *AND* THE AUDIT ROW, which is the only way
+ * the two can be trusted to agree: the audit entry's `detail` is the sole record
+ * of what was destroyed — nothing can reconstruct those counts once the rows are
+ * gone — so a commit that dropped the rows but not the entry would leave the
+ * destruction unexplained, and one that wrote the entry but not the rows would
+ * describe a reset that never happened.
+ *
+ * Order inside the transaction is forced by ON DELETE RESTRICT — see
+ * `deleteTradingData` in admin.query.ts.
+ */
+export async function factoryResetUser(
+  actorId: string,
+  targetId: string,
+  confirmEmail: string,
+  removeSettings: boolean,
+): Promise<AdminResetResult> {
+  return withTransaction(db, async (tx) => {
+    // Actor email for the audit snapshot, resolved inside the tx — the
+    // `toggleAdmin` precedent: authMiddleware exposes userId/isAdmin, not email.
+    const actorEmail = await selectUserEmailById(tx, actorId);
+    if (actorEmail === null) {
+      throw new InvariantViolationError(`Reset actor ${actorId} has no user row`);
+    }
+
+    const targetEmail = await selectUserEmailById(tx, targetId);
+    if (targetEmail === null) throw new NotFoundError('User', targetId);
+
+    if (confirmEmail.trim().toLowerCase() !== targetEmail.toLowerCase()) {
+      throw new ValidationError(
+        'The typed email does not match the account being reset. Nothing was changed.',
+      );
+    }
+
+    const deleted = await deleteTradingData(tx, targetId);
+    if (removeSettings) {
+      Object.assign(deleted, await deleteUserSettings(tx, targetId));
+    }
+    // Always last, and always run: `onboarding` is cleared whether or not
+    // settings were included, because a user whose walkthrough still thinks it
+    // has been completed cannot walk it again — which is what a reset is for.
+    await resetUserPreferences(tx, targetId, removeSettings);
+
+    await insertAdminAuditEntry(tx, {
+      action: 'factory_reset',
+      actorUserId: actorId,
+      actorEmail,
+      targetUserId: targetId,
+      targetEmail,
+      detail: { removeSettings, deleted },
+    });
+
+    logger.warn('admin factory reset', {
+      feature: 'admin',
+      actorUserId: actorId,
+      targetUserId: targetId,
+      removeSettings,
+      deleted,
+    });
+
+    return { userId: targetId, email: targetEmail, removeSettings, deleted };
+  });
 }

--- a/apps/api/src/features/admin/admin.test.ts
+++ b/apps/api/src/features/admin/admin.test.ts
@@ -50,7 +50,12 @@ import { db } from '@/db';
 import {
   accounts,
   adminAuditLog,
+  advisorProviderKeys,
   advisorTurnCounters,
+  brokerages,
+  dashboardLayouts,
+  expenses,
+  fills,
   ledgerEntries,
   positions,
   sessions,
@@ -228,6 +233,17 @@ function patchAdminFlag(targetId: string, isAdmin: unknown, token?: string) {
       ...(token ? { Cookie: `session=${token}` } : {}),
     },
     body: JSON.stringify({ isAdmin }),
+  });
+}
+
+function postReset(targetId: string, body: Record<string, unknown>, token?: string) {
+  return app.request(`/api/admin/users/${targetId}/reset`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Cookie: `session=${token}` } : {}),
+    },
+    body: JSON.stringify(body),
   });
 }
 
@@ -1070,5 +1086,390 @@ describe('bootstrapFirstAdmin', () => {
     config.SEED_ADMIN_EMAIL = undefined;
     await expect(bootstrapFirstAdmin()).resolves.toBeUndefined();
     expect(await isAdminFlag(user.id)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Factory reset — the admin surface's one destructive endpoint.
+//
+// The assertions worth reading are the NEGATIVE ones. That a reset deletes
+// positions is the easy half and would survive almost any implementation; that
+// it leaves the wallet, the Stripe mirror and the non-evasion quota counters
+// alone is the half that makes it safe to expose, and none of it is visible from
+// the endpoint's own response. So the survivors are asserted by name, from the
+// database, after the reset has run.
+// ---------------------------------------------------------------------------
+
+/** A user with one of everything the reset can reach. */
+async function seedFullUser(): Promise<{
+  id: string;
+  email: string;
+  accountId: string;
+  positionId: string;
+}> {
+  const user = await seedUser();
+  const accountId = await seedAccount(user.id);
+
+  // Direct insert per the seedPosition precedent above: CHECK-safe (an `open`
+  // row carries openedAt and no closedAt), and the reset is about rows existing,
+  // not about how they were created.
+  // eslint-disable-next-line no-restricted-syntax
+  const [position] = await db
+    .insert(positions)
+    .values({
+      userId: user.id,
+      accountId,
+      symbol: 'AAPL',
+      side: 'long',
+      assetType: 'stock',
+      status: 'open',
+      openedAt: new Date(),
+    })
+    .returning({ id: positions.id });
+
+  await db.insert(fills).values({
+    positionId: position!.id,
+    type: 'entry',
+    price: '100.00',
+    quantity: '10',
+    fees: '0',
+    filledAt: new Date(),
+  });
+
+  await db.insert(ledgerEntries).values({
+    userId: user.id,
+    accountId,
+    positionId: position!.id,
+    entryType: 'position_pnl',
+    direction: 'credit',
+    amount: '25.0000',
+    currency: 'USD',
+    occurredAt: new Date(),
+    groupId: randomUUID(),
+  });
+
+  await db.insert(expenses).values({
+    userId: user.id,
+    category: 'data_subscription',
+    description: 'data feed',
+    amount: '9.9900',
+    currency: 'USD',
+    occurredAt: '2026-01-15',
+  });
+
+  await db.insert(brokerages).values({ userId: user.id, name: `custom-${++seedCounter}` });
+  await db.insert(dashboardLayouts).values({ userId: user.id, widgets: [] });
+  await db.insert(advisorProviderKeys).values({
+    userId: user.id,
+    providerId: 'openai',
+    encryptedKey: 'enc',
+    keyVersion: 1,
+    defaultModel: 'gpt-4o',
+    keyHintTail: 'abcd',
+  });
+
+  return { id: user.id, email: user.email, accountId, positionId: position!.id };
+}
+
+describe('POST /api/admin/users/:id/reset', () => {
+  it('deletes the trading data and reports what it deleted', async () => {
+    const admin = await seedAdmin();
+    const target = await seedFullUser();
+
+    const res = await postReset(target.id, { confirmEmail: target.email }, admin.token);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { deleted: Record<string, number>; removeSettings: boolean };
+    expect(body.removeSettings).toBe(false);
+    expect(body.deleted).toMatchObject({
+      accounts: 1,
+      positions: 1,
+      fills: 1,
+      ledger_entries: 1,
+      expenses: 1,
+      brokerages: 1,
+    });
+
+    expect(await db.select().from(accounts).where(eq(accounts.userId, target.id))).toHaveLength(0);
+    expect(await db.select().from(positions).where(eq(positions.userId, target.id))).toHaveLength(
+      0,
+    );
+    expect(await db.select().from(expenses).where(eq(expenses.userId, target.id))).toHaveLength(0);
+    // Cascaded from the position rather than deleted directly.
+    expect(
+      await db.select().from(fills).where(eq(fills.positionId, target.positionId)),
+    ).toHaveLength(0);
+  });
+
+  // THE POINT OF THE FEATURE. A user whose onboarding state survived would be
+  // shown a completed checklist on an empty account, which is the one outcome
+  // that makes the whole reset pointless.
+  it('always clears onboarding state, even when settings are kept', async () => {
+    const admin = await seedAdmin();
+    const target = await seedFullUser();
+    await db
+      .update(users)
+      .set({ onboarding: { status: 'done', calculatorFirstUsedAt: '2026-01-01' } })
+      .where(eq(users.id, target.id));
+
+    await postReset(target.id, { confirmEmail: target.email, removeSettings: false }, admin.token);
+
+    const [row] = await db.select().from(users).where(eq(users.id, target.id));
+    expect(row!.onboarding).toEqual({});
+  });
+
+  it('keeps settings by default — BYOK keys, dashboard layout and preferences survive', async () => {
+    const admin = await seedAdmin();
+    const target = await seedFullUser();
+    await db.update(users).set({ theme: 'dark' }).where(eq(users.id, target.id));
+
+    const res = await postReset(target.id, { confirmEmail: target.email }, admin.token);
+    expect(res.status).toBe(200);
+
+    expect(
+      await db.select().from(advisorProviderKeys).where(eq(advisorProviderKeys.userId, target.id)),
+    ).toHaveLength(1);
+    expect(
+      await db.select().from(dashboardLayouts).where(eq(dashboardLayouts.userId, target.id)),
+    ).toHaveLength(1);
+    const [row] = await db.select().from(users).where(eq(users.id, target.id));
+    expect(row!.theme).toBe('dark');
+  });
+
+  it('removes settings when asked, and returns preferences to their defaults', async () => {
+    const admin = await seedAdmin();
+    const target = await seedFullUser();
+    await db
+      .update(users)
+      .set({ theme: 'dark', buyingPowerBasis: 'balance', timezone: 'Europe/London' })
+      .where(eq(users.id, target.id));
+
+    const res = await postReset(
+      target.id,
+      { confirmEmail: target.email, removeSettings: true },
+      admin.token,
+    );
+    expect(res.status).toBe(200);
+
+    expect(
+      await db.select().from(advisorProviderKeys).where(eq(advisorProviderKeys.userId, target.id)),
+    ).toHaveLength(0);
+    expect(
+      await db.select().from(dashboardLayouts).where(eq(dashboardLayouts.userId, target.id)),
+    ).toHaveLength(0);
+    const [row] = await db.select().from(users).where(eq(users.id, target.id));
+    expect(row!.theme).toBe('system');
+    expect(row!.buyingPowerBasis).toBe('cash');
+    expect(row!.timezone).toBeNull();
+  });
+
+  // THE SURVIVORS. None of this is observable from the endpoint's response, and
+  // all of it is the reason the button can exist at all.
+  it('never touches the wallet, the Stripe mirror, or the non-evasion quota counters', async () => {
+    const admin = await seedAdmin();
+    const target = await seedFullUser();
+    await db.insert(wallets).values({ userId: target.id, balance: 5_000_000n });
+    await seedWalletTx(target.id, 'credit', 5_000_000n);
+    await seedUsageRecord(target.id, {
+      inputTokens: 10n,
+      outputTokens: 20n,
+      creditCost: 30n,
+      rawCost: 15n,
+      createdAt: new Date(),
+    });
+    await db
+      .insert(advisorTurnCounters)
+      .values({ userId: target.id, periodKey: currentPeriodKeyUtc(), turnCount: 7 });
+
+    await postReset(target.id, { confirmEmail: target.email, removeSettings: true }, admin.token);
+
+    const [wallet] = await db.select().from(wallets).where(eq(wallets.userId, target.id));
+    expect(wallet!.balance).toBe(5_000_000n);
+    expect(
+      await db.select().from(walletTransactions).where(eq(walletTransactions.userId, target.id)),
+    ).toHaveLength(1);
+    expect(
+      await db.select().from(usageRecords).where(eq(usageRecords.userId, target.id)),
+    ).toHaveLength(1);
+    const [counter] = await db
+      .select()
+      .from(advisorTurnCounters)
+      .where(eq(advisorTurnCounters.userId, target.id));
+    expect(counter!.turnCount).toBe(7);
+  });
+
+  it('keeps identity: the account, its password, admin flag and verified flag all survive', async () => {
+    const admin = await seedAdmin();
+    const target = await seedFullUser();
+
+    await postReset(target.id, { confirmEmail: target.email, removeSettings: true }, admin.token);
+
+    const [row] = await db.select().from(users).where(eq(users.id, target.id));
+    expect(row).toBeDefined();
+    expect(row!.email).toBe(target.email);
+    expect(row!.passwordHash).toBe(SEEDED_PASSWORD_HASH);
+    expect(row!.emailVerified).toBe(true);
+  });
+
+  // The system brokerages every user shares are `user_id IS NULL`. Deleting
+  // those would empty the picker for the whole instance, not just this user.
+  it("deletes the user's own brokerages and leaves the system ones alone", async () => {
+    const admin = await seedAdmin();
+    const target = await seedFullUser();
+    await db.insert(brokerages).values({ userId: null, name: `system-${++seedCounter}` });
+    // Counted rather than pinned to a number: the instance ships seeded system
+    // brokerages, and the assertion is that the reset changed none of them.
+    const systemBefore = (await db.select().from(brokerages)).filter(
+      (b) => b.userId === null,
+    ).length;
+
+    await postReset(target.id, { confirmEmail: target.email }, admin.token);
+
+    expect(await db.select().from(brokerages).where(eq(brokerages.userId, target.id))).toHaveLength(
+      0,
+    );
+    const systemAfter = (await db.select().from(brokerages)).filter(
+      (b) => b.userId === null,
+    ).length;
+    expect(systemAfter).toBe(systemBefore);
+  });
+
+  // The confirmation is a server-side guard, not a dialog convenience: a request
+  // that skips the UI must still be refused.
+  it('refuses a mismatched confirmEmail and deletes nothing', async () => {
+    const admin = await seedAdmin();
+    const target = await seedFullUser();
+
+    const res = await postReset(
+      target.id,
+      { confirmEmail: 'someone-else@example.com' },
+      admin.token,
+    );
+    expect(res.status).toBe(400);
+    await errorBody(res);
+
+    expect(await db.select().from(accounts).where(eq(accounts.userId, target.id))).toHaveLength(1);
+    expect(await db.select().from(positions).where(eq(positions.userId, target.id))).toHaveLength(
+      1,
+    );
+    expect(await auditRows()).toHaveLength(0);
+  });
+
+  it('accepts the confirmation regardless of case', async () => {
+    const admin = await seedAdmin();
+    const target = await seedFullUser();
+
+    const res = await postReset(
+      target.id,
+      { confirmEmail: target.email.toUpperCase() },
+      admin.token,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  // The audit entry's `detail` is the ONLY surviving record of what was
+  // destroyed — the rows it counted are gone — so it commits with the deletes.
+  it('writes one audit row carrying what it deleted', async () => {
+    const admin = await seedAdmin();
+    const target = await seedFullUser();
+
+    await postReset(target.id, { confirmEmail: target.email, removeSettings: true }, admin.token);
+
+    const audit = await auditRows();
+    expect(audit).toHaveLength(1);
+    expect(audit[0]).toMatchObject({
+      action: 'factory_reset',
+      actorUserId: admin.id,
+      actorEmail: admin.email,
+      targetUserId: target.id,
+      targetEmail: target.email,
+      // Nullable now, and null for this action — it is not a transition.
+      oldValue: null,
+      newValue: null,
+    });
+    expect(audit[0]!.detail).toMatchObject({
+      removeSettings: true,
+      deleted: { accounts: 1, positions: 1, fills: 1 },
+    });
+  });
+
+  it('404s an unknown user and 400s a non-uuid id', async () => {
+    const admin = await seedAdmin();
+
+    const missing = await postReset(
+      randomUUID(),
+      { confirmEmail: 'nobody@example.com' },
+      admin.token,
+    );
+    expect(missing.status).toBe(404);
+
+    const malformed = await postReset(
+      'not-a-uuid',
+      { confirmEmail: 'nobody@example.com' },
+      admin.token,
+    );
+    expect(malformed.status).toBe(400);
+  });
+
+  it('is 401 unauthenticated and 403 for a non-admin, deleting nothing either way', async () => {
+    const target = await seedFullUser();
+    const plain = await seedUser();
+    const plainToken = await seedSession(plain.id);
+
+    expect((await postReset(target.id, { confirmEmail: target.email })).status).toBe(401);
+
+    const forbidden = await postReset(target.id, { confirmEmail: target.email }, plainToken);
+    expect(forbidden.status).toBe(403);
+    expect((await errorBody(forbidden)).code).toBe('ADMIN_REQUIRED');
+
+    expect(await db.select().from(accounts).where(eq(accounts.userId, target.id))).toHaveLength(1);
+  });
+
+  it('is idempotent — a second reset succeeds and deletes nothing', async () => {
+    const admin = await seedAdmin();
+    const target = await seedFullUser();
+
+    await postReset(target.id, { confirmEmail: target.email }, admin.token);
+    const second = await postReset(target.id, { confirmEmail: target.email }, admin.token);
+
+    expect(second.status).toBe(200);
+    const body = (await second.json()) as { deleted: Record<string, number> };
+    expect(body.deleted).toMatchObject({ accounts: 0, positions: 0, fills: 0 });
+  });
+});
+
+describe('GET /api/admin/users/:id/reset-preview', () => {
+  it('counts both halves without deleting anything', async () => {
+    const admin = await seedAdmin();
+    const target = await seedFullUser();
+
+    const res = await get(`/api/admin/users/${target.id}/reset-preview`, admin.token);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      email: string;
+      tradingData: Record<string, number>;
+      settings: Record<string, number>;
+    };
+
+    expect(body.email).toBe(target.email);
+    expect(body.tradingData).toMatchObject({
+      accounts: 1,
+      positions: 1,
+      fills: 1,
+      ledgerEntries: 1,
+      expenses: 1,
+      brokerages: 1,
+    });
+    // Always counted, whatever the caller intends to do with the flag.
+    expect(body.settings).toMatchObject({ providerKeys: 1, dashboardLayouts: 1 });
+
+    // Read-only.
+    expect(await db.select().from(accounts).where(eq(accounts.userId, target.id))).toHaveLength(1);
+  });
+
+  it('404s an unknown user', async () => {
+    const admin = await seedAdmin();
+    const res = await get(`/api/admin/users/${randomUUID()}/reset-preview`, admin.token);
+    expect(res.status).toBe(404);
   });
 });

--- a/apps/docs/src/content/docs/self-hosting/reference/db-schema.mdx
+++ b/apps/docs/src/content/docs/self-hosting/reference/db-schema.mdx
@@ -6,9 +6,9 @@ description: Every table Tradr creates, its columns, and how they reference each
 {/* GENERATED FILE — do not edit.
     Source: apps/api/src/db/migrations/meta/ (latest snapshot) · Generator: apps/docs/scripts/gen-db-schema.mjs */}
 
-Tradr's schema is **32 tables**, created by **30 migrations** that run
+Tradr's schema is **32 tables**, created by **31 migrations** that run
 automatically when the api boots. This page is generated from the Drizzle snapshot
-for the latest schema-changing migration (`0029_account_is_demo`), so it describes the schema the migrations
+for the latest schema-changing migration (`0030_admin_factory_reset_audit`), so it describes the schema the migrations
 actually produce.
 
 You do not need any of this to run Tradr. It is here for writing queries against
@@ -438,8 +438,9 @@ a query you write against these tables may need updating on any release.
 | `actor_email` | `varchar(255)` | not null |
 | `target_user_id` | `uuid` | — |
 | `target_email` | `varchar(255)` | not null |
-| `old_value` | `boolean` | not null |
-| `new_value` | `boolean` | not null |
+| `old_value` | `boolean` | — |
+| `new_value` | `boolean` | — |
+| `detail` | `jsonb` | — |
 | `created_at` | `timestamp with time zone` | not null, default `now()` |
 
 **References**

--- a/apps/docs/src/openapi/tradr-api.json
+++ b/apps/docs/src/openapi/tradr-api.json
@@ -568,6 +568,111 @@
         ]
       }
     },
+    "/api/admin/users/{id}/reset": {
+      "post": {
+        "description": "Admin-gated (403 `ADMIN_REQUIRED`). DESTRUCTIVE AND IRREVERSIBLE — there is no undo and no backup taken. POST (never GET) per the SameSite=Lax CSRF posture.\n`confirmEmail` must equal the target user's email (case-insensitive) or the request is a 400 `VALIDATION_ERROR` and nothing is changed; the check is enforced here, not only in the UI that collects it.\nALWAYS DELETED: accounts, positions, fills, ledger entries, expenses, the user's own brokerages and their fee schedules, and staged CSV rows. ALWAYS RESET: the user's onboarding state, so the walkthrough can be walked again. DELETED ONLY WHEN `removeSettings` IS TRUE (default false): BYOK provider and external API keys, advisor personas/conversations/messages/summaries, the dashboard layout, and the user's preference columns.\nNEVER TOUCHED: billing and wallet state (`wallets`, `wallet_transactions`, `usage_records`, `subscriptions`, `billing_customers`) — these mirror Stripe and hold purchased credit; the non-evasion quota counters (`csv_import_counters`, `advisor_turn_counters`, `advisor_image_counters`); and the user's identity (email, password, admin flag, verified flag, created-at) and sessions — the user stays logged in.\nDeletes and the `admin_audit_log` entry recording them commit in one transaction. That entry's `detail` is the only surviving record of what was removed.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "confirmEmail": {
+                    "description": "Must match the target user's email, case-insensitively.",
+                    "format": "email",
+                    "type": "string"
+                  },
+                  "removeSettings": {
+                    "default": false,
+                    "description": "Also delete BYOK keys, advisor data, dashboard layout and preferences.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "confirmEmail"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "AdminResetResult — { userId, email, removeSettings, deleted }."
+          },
+          "400": {
+            "description": "VALIDATION_ERROR — id is not a UUID, body malformed, or confirmEmail does not match."
+          },
+          "401": {
+            "description": "Not authenticated."
+          },
+          "403": {
+            "description": "ADMIN_REQUIRED — authenticated but not an admin."
+          },
+          "404": {
+            "description": "NOT_FOUND — no such user."
+          },
+          "429": {
+            "description": "Admin rate limit reached (60 / 60 s per user)."
+          }
+        },
+        "summary": "Factory-reset a user's data to their post-registration state (admin only).",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/api/admin/users/{id}/reset-preview": {
+      "get": {
+        "description": "Admin-gated (403 `ADMIN_REQUIRED`). Read-only. Returns the row counts a factory reset would remove, split into `tradingData` (always removed) and `settings` (removed only when the reset is requested with `removeSettings: true`). Both halves are always counted, so a client can show what including settings would add without a second request. Counts are a snapshot and are not a promise about a later reset — `POST .../reset` re-counts from its own deletes.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AdminResetPreview — { userId, email, tradingData, settings }."
+          },
+          "400": {
+            "description": "VALIDATION_ERROR — id is not a UUID."
+          },
+          "401": {
+            "description": "Not authenticated."
+          },
+          "403": {
+            "description": "ADMIN_REQUIRED — authenticated but not an admin."
+          },
+          "404": {
+            "description": "NOT_FOUND — no such user."
+          },
+          "429": {
+            "description": "Admin rate limit reached (60 / 60 s per user)."
+          }
+        },
+        "summary": "What a factory reset would delete for this user (admin only).",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
     "/api/auth/login": {
       "post": {
         "description": "Public. On success sets the `session` cookie; every authenticated endpoint reads it. Rate limited to 10 requests per 15 minutes per client, tightening to 5 while the shared rate-limit store is unavailable. A wrong email and a wrong password are answered identically, so the response does not reveal whether an address is registered. A user may hold 5 concurrent sessions; signing in a sixth time ends the oldest one.\n",

--- a/apps/web/src/features/admin/components/FactoryResetDialog.tsx
+++ b/apps/web/src/features/admin/components/FactoryResetDialog.tsx
@@ -1,0 +1,221 @@
+// FactoryResetDialog — the confirmation in front of the admin surface's one
+// destructive action.
+//
+// THE DIALOG IS NOT THE SAFETY MECHANISM. The typed email is re-checked by the
+// service before anything is deleted, so this component is what makes the guard
+// usable, not what makes it a guard. It is written on that assumption: nothing
+// here is load-bearing, and nothing here needs to be defended against a caller
+// who skips it.
+//
+// What it IS for is the operator noticing they are about to reset the wrong
+// account. Three things do that work, in the order they are read:
+//
+//  1. THE COUNTS. "Cannot be undone" is a sentence anyone can click past.
+//     "3 accounts · 47 positions · 112 fills" is the same statement in a form
+//     that can be checked against the account they think they are looking at,
+//     and it is the last moment such a check is possible.
+//  2. WHAT SURVIVES, said as plainly as what does not. An operator who is unsure
+//     whether this cancels a subscription or burns a wallet balance will click
+//     nothing, and be right to.
+//  3. THE TYPED ADDRESS. Deliberately not a checkbox: the point is to make the
+//     hand type the identity of the row, so a reset aimed at the wrong user
+//     fails at the keyboard rather than at the confirm button.
+//
+// The settings switch is "Remove user settings?" and defaults OFF, so the
+// conservative half is what a hurried operator gets.
+
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+import type { AdminUserListItem } from '@tradr/shared/schemas/admin';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Switch } from '@/components/ui/switch';
+
+import { useFactoryReset, useResetPreview } from '../hooks/useFactoryReset';
+
+interface FactoryResetDialogProps {
+  /** The user to reset, or `null` when the dialog is closed. */
+  user: AdminUserListItem | null;
+  onClose: () => void;
+}
+
+/** "3 accounts", "1 position" — a count with its unit, or nothing at zero. */
+function countLabel(n: number, singular: string, plural = `${singular}s`): string | null {
+  if (n === 0) return null;
+  return `${n.toLocaleString()} ${n === 1 ? singular : plural}`;
+}
+
+export function FactoryResetDialog({ user, onClose }: FactoryResetDialogProps) {
+  const [typedEmail, setTypedEmail] = useState('');
+  const [removeSettings, setRemoveSettings] = useState(false);
+
+  const preview = useResetPreview(user?.id);
+  const reset = useFactoryReset();
+
+  // Both inputs start clean for every user the dialog is opened on. Carrying a
+  // typed address across a close would mean the confirm button was already armed
+  // the next time it opened — on a different row.
+  useEffect(() => {
+    setTypedEmail('');
+    setRemoveSettings(false);
+  }, [user?.id]);
+
+  const tradingCounts = preview.data
+    ? [
+        countLabel(preview.data.tradingData.accounts, 'account'),
+        countLabel(preview.data.tradingData.positions, 'position'),
+        countLabel(preview.data.tradingData.fills, 'fill'),
+        countLabel(preview.data.tradingData.ledgerEntries, 'ledger entry', 'ledger entries'),
+        countLabel(preview.data.tradingData.expenses, 'expense'),
+        countLabel(preview.data.tradingData.brokerages, 'custom brokerage'),
+      ].filter((label): label is string => label !== null)
+    : [];
+
+  const settingsCounts = preview.data
+    ? [
+        countLabel(preview.data.settings.providerKeys, 'AI provider key'),
+        countLabel(preview.data.settings.externalApiKeys, 'external API key'),
+        countLabel(preview.data.settings.advisorPersonas, 'advisor persona'),
+        countLabel(preview.data.settings.advisorConversations, 'advisor conversation'),
+        countLabel(preview.data.settings.dashboardLayouts, 'dashboard layout'),
+      ].filter((label): label is string => label !== null)
+    : [];
+
+  // Case-insensitive, as the server compares it: an operator reading the address
+  // off the row above should not be defeated by a capital letter.
+  const confirmed =
+    user !== null && typedEmail.trim().toLowerCase() === user.email.toLowerCase().trim();
+
+  const submit = () => {
+    if (!user || !confirmed) return;
+    reset.mutate(
+      { userId: user.id, confirmEmail: typedEmail.trim(), removeSettings },
+      {
+        onSuccess: (result) => {
+          const total = Object.values(result.deleted).reduce((sum, n) => sum + n, 0);
+          toast.success(
+            `Reset ${result.email} — ${total.toLocaleString()} ${total === 1 ? 'row' : 'rows'} deleted.`,
+          );
+          onClose();
+        },
+        onError: () => {
+          toast.error('The reset failed. Nothing was deleted.');
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog
+      open={user !== null}
+      onOpenChange={(open) => {
+        if (!open && !reset.isPending) onClose();
+      }}
+    >
+      <DialogContent data-testid="factory-reset-dialog">
+        <DialogHeader>
+          <DialogTitle>Factory reset {user?.email}</DialogTitle>
+          <DialogDescription>
+            This returns the account to the state it was in just after registering. It cannot be
+            undone, and no backup is taken.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 text-sm">
+          <div>
+            <p className="font-medium">Permanently deletes</p>
+            {preview.isLoading && <Skeleton className="mt-2 h-5 w-full" />}
+            {preview.isError && (
+              <p className="text-destructive mt-1">
+                Could not read what this would delete. Not safe to continue — close and try again.
+              </p>
+            )}
+            {preview.data && (
+              <p className="text-muted-foreground mt-1" data-testid="reset-trading-counts">
+                {tradingCounts.length > 0
+                  ? tradingCounts.join(' · ')
+                  : 'Nothing — no trading data.'}
+              </p>
+            )}
+          </div>
+
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <Label htmlFor="remove-settings" className="cursor-pointer font-medium">
+                Remove user settings?
+              </Label>
+              <p className="text-muted-foreground mt-1" data-testid="reset-settings-counts">
+                {removeSettings
+                  ? settingsCounts.length > 0
+                    ? `Also deletes ${settingsCounts.join(' · ')}, and resets their preferences.`
+                    : 'Also resets their preferences. There is nothing else stored.'
+                  : 'Keeps their API keys, advisor data, dashboard layout and preferences.'}
+              </p>
+            </div>
+            <Switch
+              id="remove-settings"
+              className="cursor-pointer"
+              checked={removeSettings}
+              onCheckedChange={setRemoveSettings}
+            />
+          </div>
+
+          {/* Said whether or not settings are included: the two most alarming
+              things an operator might fear this touches are the two it never
+              touches, and leaving that to be inferred is how a useful button
+              goes unused. */}
+          <p className="text-muted-foreground">
+            Billing, subscription and wallet credit are never affected. Their login, password and
+            email verification are kept, and the onboarding walkthrough is reset either way.
+          </p>
+
+          <div className="space-y-2">
+            <Label htmlFor="confirm-email">
+              Type <span className="font-mono">{user?.email}</span> to confirm
+            </Label>
+            <Input
+              id="confirm-email"
+              autoComplete="off"
+              value={typedEmail}
+              onChange={(e) => setTypedEmail(e.target.value)}
+              placeholder={user?.email}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            className="cursor-pointer"
+            onClick={onClose}
+            disabled={reset.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            className="cursor-pointer"
+            // Gated on the preview too: a reset fired while the counts are
+            // unknown is one the operator was never shown the size of.
+            disabled={!confirmed || reset.isPending || !preview.data}
+            onClick={submit}
+          >
+            {reset.isPending ? 'Resetting…' : 'Reset this account'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/admin/components/UserTable.tsx
+++ b/apps/web/src/features/admin/components/UserTable.tsx
@@ -15,6 +15,10 @@
 //   house envelope the api client throws).
 // - Row "Details" opens a dialog over useAdminUser (positions, advisor turns,
 //   usage sums, wallet balance).
+// - Row "Reset" opens <FactoryResetDialog>, which owns the whole destructive
+//   flow (preview counts, the settings switch, the typed-email confirmation).
+//   This component only decides WHICH user it is about — the confirmation that
+//   matters is enforced server-side either way.
 
 import { Check, Info } from 'lucide-react';
 import { useState } from 'react';
@@ -50,6 +54,8 @@ import { useAdminUsers } from '../hooks/useAdminUsers';
 import { useToggleAdmin } from '../hooks/useToggleAdmin';
 import { formatMicroUsd } from '../lib/format';
 
+import { FactoryResetDialog } from './FactoryResetDialog';
+
 const LAST_SEEN_CAVEAT = 'Last recorded session activity — may be arbitrarily old';
 
 function formatDate(iso: string): string {
@@ -66,11 +72,12 @@ function getErrorCode(err: unknown): string | undefined {
 interface RowActions {
   onToggle: (user: AdminUserListItem) => void;
   onDetails: (user: AdminUserListItem) => void;
+  onReset: (user: AdminUserListItem) => void;
 }
 
 // One mounted component per loaded page so every page refetches on
 // invalidation (the cache is shared with the parent's nextCursor query).
-function UserTableRows({ cursor, onToggle, onDetails }: RowActions & { cursor?: string }) {
+function UserTableRows({ cursor, onToggle, onDetails, onReset }: RowActions & { cursor?: string }) {
   const { data, isLoading, isError } = useAdminUsers(cursor);
 
   if (isLoading) {
@@ -136,14 +143,27 @@ function UserTableRows({ cursor, onToggle, onDetails }: RowActions & { cursor?: 
             </div>
           </TableCell>
           <TableCell>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="cursor-pointer"
-              onClick={() => onDetails(u)}
-            >
-              Details
-            </Button>
+            <div className="flex items-center justify-end gap-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="cursor-pointer"
+                onClick={() => onDetails(u)}
+              >
+                Details
+              </Button>
+              {/* Destructive, so it is styled as such and sits last — the
+                  rightmost control in a row is the one a mis-aimed click is
+                  least likely to land on. */}
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-destructive hover:text-destructive cursor-pointer"
+                onClick={() => onReset(u)}
+              >
+                Reset
+              </Button>
+            </div>
           </TableCell>
         </TableRow>
       ))}
@@ -208,6 +228,7 @@ export function UserTable() {
   const [pendingToggle, setPendingToggle] = useState<AdminUserListItem | null>(null);
   const [toggleError, setToggleError] = useState<string | null>(null);
   const [detailUser, setDetailUser] = useState<AdminUserListItem | null>(null);
+  const [resetUser, setResetUser] = useState<AdminUserListItem | null>(null);
 
   // Same query key as the last mounted page — shared cache, no extra fetch.
   const lastPage = useAdminUsers(cursors[cursors.length - 1]);
@@ -271,6 +292,7 @@ export function UserTable() {
               cursor={cursor}
               onToggle={openConfirm}
               onDetails={setDetailUser}
+              onReset={setResetUser}
             />
           ))}
         </TableBody>
@@ -287,6 +309,8 @@ export function UserTable() {
           </Button>
         </div>
       )}
+
+      <FactoryResetDialog user={resetUser} onClose={() => setResetUser(null)} />
 
       <Dialog
         open={pendingToggle !== null}

--- a/apps/web/src/features/admin/components/__tests__/FactoryResetDialog.test.tsx
+++ b/apps/web/src/features/admin/components/__tests__/FactoryResetDialog.test.tsx
@@ -1,0 +1,249 @@
+// @vitest-environment jsdom
+// FactoryResetDialog — the confirmation in front of the admin surface's one
+// destructive action.
+//
+// The dialog is a usability layer over a guard that lives on the server, so
+// these tests are about what it SHOWS and what it REFUSES TO ARM, not about
+// whether it can be bypassed — bypassing it is covered by the API suite, which
+// asserts the service rejects a mismatched confirmEmail on its own.
+//
+// Covers: the counts that make a wrong-row click noticeable; the settings switch
+// defaulting to OFF and saying what each position means; the typed-email gate on
+// the destructive button (including the case-insensitive match the server also
+// applies); both fields resetting when the dialog is re-opened on another user;
+// and the button staying disabled while the counts are unknown.
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { api } from '@/lib/api';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@/lib/api', () => ({
+  api: { get: vi.fn(), post: vi.fn() },
+}));
+
+const toast = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn() }));
+vi.mock('sonner', () => ({ toast }));
+
+import { FactoryResetDialog } from '../FactoryResetDialog';
+
+const USER = {
+  id: '11111111-1111-1111-1111-111111111111',
+  email: 'target@x.com',
+  isAdmin: false,
+  emailVerified: true,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  lastActiveAt: null,
+};
+
+const PREVIEW = {
+  userId: USER.id,
+  email: USER.email,
+  tradingData: {
+    accounts: 3,
+    positions: 47,
+    fills: 112,
+    ledgerEntries: 89,
+    expenses: 0,
+    brokerages: 1,
+    csvImportStaging: 0,
+  },
+  settings: {
+    providerKeys: 2,
+    externalApiKeys: 0,
+    advisorPersonas: 1,
+    advisorConversations: 5,
+    dashboardLayouts: 1,
+  },
+};
+
+function mockPreview(response: unknown = PREVIEW) {
+  vi.mocked(api.get).mockImplementation((url: string) => {
+    if (url.endsWith('/reset-preview')) return Promise.resolve(response as never);
+    return Promise.reject(new Error(`unexpected GET ${url}`));
+  });
+}
+
+function renderDialog(user: typeof USER | null = USER, onClose = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
+  const utils = render(<FactoryResetDialog user={user} onClose={onClose} />, { wrapper });
+  return { ...utils, onClose, qc };
+}
+
+const resetButton = () =>
+  screen.getByRole('button', { name: /reset this account/i }) as HTMLButtonElement;
+const settingsSwitch = () => screen.getByRole('switch', { name: /remove user settings/i });
+const confirmInput = () => screen.getByLabelText(/type .* to confirm/i);
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('FactoryResetDialog — what it shows', () => {
+  // THE COUNTS ARE THE WARNING. They are the only thing in the dialog that can
+  // tell an operator they are about to reset the wrong account, and the last
+  // moment such a check is possible.
+  it('lists what will be deleted, with counts, omitting the empty tables', async () => {
+    mockPreview();
+    renderDialog();
+
+    const counts = await screen.findByTestId('reset-trading-counts');
+    expect(counts.textContent).toContain('3 accounts');
+    expect(counts.textContent).toContain('47 positions');
+    expect(counts.textContent).toContain('112 fills');
+    expect(counts.textContent).toContain('89 ledger entries');
+    expect(counts.textContent).toContain('1 custom brokerage');
+    // Zero-count tables are left out rather than shown as "0 expenses" — the
+    // list is meant to be read, not audited.
+    expect(counts.textContent).not.toContain('expense');
+  });
+
+  // Said whether or not settings are included: the two things an operator is
+  // most likely to fear this touches are the two it never touches.
+  it('states that billing and login are never affected', async () => {
+    mockPreview();
+    renderDialog();
+
+    await screen.findByTestId('reset-trading-counts');
+    expect(
+      screen.getByText(/billing, subscription and wallet credit are never affected/i),
+    ).toBeTruthy();
+    expect(screen.getByText(/onboarding walkthrough is reset either way/i)).toBeTruthy();
+  });
+});
+
+describe('FactoryResetDialog — the settings switch', () => {
+  it('defaults to off and says what keeping settings means', async () => {
+    mockPreview();
+    renderDialog();
+
+    await screen.findByTestId('reset-trading-counts');
+    expect(settingsSwitch().getAttribute('aria-checked')).toBe('false');
+    expect(screen.getByTestId('reset-settings-counts').textContent).toMatch(
+      /keeps their api keys/i,
+    );
+  });
+
+  it('names the settings it would delete once switched on', async () => {
+    mockPreview();
+    renderDialog();
+    await screen.findByTestId('reset-trading-counts');
+
+    await userEvent.click(settingsSwitch());
+
+    const settings = screen.getByTestId('reset-settings-counts');
+    expect(settings.textContent).toContain('2 AI provider keys');
+    expect(settings.textContent).toContain('1 advisor persona');
+    expect(settings.textContent).toContain('5 advisor conversations');
+  });
+});
+
+describe('FactoryResetDialog — the confirmation gate', () => {
+  it('keeps the destructive button disabled until the email is typed exactly', async () => {
+    mockPreview();
+    renderDialog();
+    await screen.findByTestId('reset-trading-counts');
+
+    expect(resetButton().disabled).toBe(true);
+
+    await userEvent.type(confirmInput(), 'target@x.co');
+    expect(resetButton().disabled).toBe(true);
+
+    await userEvent.type(confirmInput(), 'm');
+    expect(resetButton().disabled).toBe(false);
+  });
+
+  // The server compares case-insensitively; an operator reading the address off
+  // the row above should not be defeated by a capital letter.
+  it('accepts the address in any case', async () => {
+    mockPreview();
+    renderDialog();
+    await screen.findByTestId('reset-trading-counts');
+
+    await userEvent.type(confirmInput(), 'TARGET@X.COM');
+    expect(resetButton().disabled).toBe(false);
+  });
+
+  // A reset fired while the counts are unknown is one the operator was never
+  // shown the size of.
+  it('stays disabled when the preview could not be read, even with the email typed', async () => {
+    vi.mocked(api.get).mockRejectedValue(new Error('boom'));
+    renderDialog();
+
+    await screen.findByText(/could not read what this would delete/i);
+    await userEvent.type(confirmInput(), USER.email);
+    expect(resetButton().disabled).toBe(true);
+  });
+
+  it('posts the confirmation and the flag, then closes', async () => {
+    mockPreview();
+    vi.mocked(api.post).mockResolvedValue({
+      userId: USER.id,
+      email: USER.email,
+      removeSettings: true,
+      deleted: { accounts: 3, positions: 47 },
+    } as never);
+    const { onClose } = renderDialog();
+    await screen.findByTestId('reset-trading-counts');
+
+    await userEvent.click(settingsSwitch());
+    await userEvent.type(confirmInput(), USER.email);
+    await userEvent.click(resetButton());
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(api.post).toHaveBeenCalledWith(`/admin/users/${USER.id}/reset`, {
+      confirmEmail: USER.email,
+      removeSettings: true,
+    });
+    expect(toast.success).toHaveBeenCalledWith(expect.stringContaining('50 rows deleted'));
+  });
+
+  it('reports a failure as having deleted nothing, and stays open', async () => {
+    mockPreview();
+    vi.mocked(api.post).mockRejectedValue(new Error('boom'));
+    const { onClose } = renderDialog();
+    await screen.findByTestId('reset-trading-counts');
+
+    await userEvent.type(confirmInput(), USER.email);
+    await userEvent.click(resetButton());
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('Nothing was deleted')),
+    );
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+describe('FactoryResetDialog — reopening', () => {
+  // A typed address carried across a close would mean the confirm button was
+  // already armed the next time it opened — on a different row.
+  it('clears the typed email and the switch when opened on another user', async () => {
+    mockPreview();
+    const { rerender, qc } = renderDialog();
+    await screen.findByTestId('reset-trading-counts');
+
+    await userEvent.click(settingsSwitch());
+    await userEvent.type(confirmInput(), USER.email);
+    expect(resetButton().disabled).toBe(false);
+
+    const other = { ...USER, id: '22222222-2222-2222-2222-222222222222', email: 'other@x.com' };
+    vi.mocked(api.get).mockResolvedValue({ ...PREVIEW, userId: other.id, email: other.email });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: qc }, children);
+    rerender(
+      createElement(wrapper, {
+        children: <FactoryResetDialog user={other} onClose={vi.fn()} />,
+      }),
+    );
+
+    await waitFor(() => expect(resetButton().disabled).toBe(true));
+    expect(settingsSwitch().getAttribute('aria-checked')).toBe('false');
+  });
+});

--- a/apps/web/src/features/admin/hooks/useFactoryReset.ts
+++ b/apps/web/src/features/admin/hooks/useFactoryReset.ts
@@ -1,0 +1,50 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  type AdminResetPreview,
+  AdminResetPreviewSchema,
+  type AdminResetRequest,
+  type AdminResetResult,
+} from '@tradr/shared/schemas/admin';
+
+import { api } from '@/lib/api';
+
+/**
+ * What a factory reset would delete, for the confirmation dialog.
+ *
+ * `enabled` on an id rather than fetched with the row: the preview is only worth
+ * a request once someone has opened the dialog, and the counts are the one part
+ * of that dialog that must be fresh. `staleTime: 0` (the app default) means
+ * re-opening it re-reads rather than showing what the account looked like the
+ * last time the operator considered this.
+ */
+export function useResetPreview(userId: string | undefined) {
+  return useQuery<AdminResetPreview>({
+    queryKey: ['admin', 'users', 'reset-preview', userId],
+    queryFn: async () => {
+      const raw = await api.get<unknown>(`/admin/users/${userId}/reset-preview`);
+      return AdminResetPreviewSchema.parse(raw);
+    },
+    enabled: !!userId,
+  });
+}
+
+/**
+ * Perform the reset.
+ *
+ * EVERY ADMIN QUERY IS INVALIDATED, not just the user list: a reset changes the
+ * platform position counts on the stats card and the target's detail row, and an
+ * operator who has just destroyed data should not be shown a cached copy of it.
+ * The blunt prefix invalidation is right here — this runs at most once per
+ * deliberate, confirmed action, so there is nothing to optimise.
+ */
+export function useFactoryReset() {
+  const queryClient = useQueryClient();
+  return useMutation<AdminResetResult, unknown, { userId: string } & AdminResetRequest>({
+    mutationFn: ({ userId, confirmEmail, removeSettings }) =>
+      api.post<AdminResetResult>(`/admin/users/${userId}/reset`, { confirmEmail, removeSettings }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['admin'] });
+    },
+  });
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -238,6 +238,9 @@ export {
   AdminUserListResponseSchema,
   AdminUserDetailSchema,
   ToggleAdminRequestSchema,
+  AdminResetPreviewSchema,
+  AdminResetRequestSchema,
+  AdminResetResultSchema,
   AdminUsageQuerySchema,
   AdminUsageSchema,
 } from './schemas/admin';
@@ -247,6 +250,9 @@ export type {
   AdminUserListResponse,
   AdminUserDetail,
   ToggleAdminRequest,
+  AdminResetPreview,
+  AdminResetRequest,
+  AdminResetResult,
   AdminUsageQuery,
   AdminUsage,
 } from './schemas/admin';

--- a/packages/shared/src/schemas/admin.ts
+++ b/packages/shared/src/schemas/admin.ts
@@ -92,6 +92,78 @@ export const ToggleAdminRequestSchema = z.object({
 });
 export type ToggleAdminRequest = z.infer<typeof ToggleAdminRequestSchema>;
 
+// --- GET /api/admin/users/:id/reset-preview ----------------------------------
+
+/**
+ * What a factory reset would destroy, counted before anything is destroyed.
+ *
+ * THE COUNTS ARE THE WARNING. "This cannot be undone" is a sentence anyone can
+ * click past; "47 positions, 112 fills" is the same statement in a form the
+ * operator can check against the account they think they are resetting. It is
+ * also the only chance to notice the wrong row was clicked, because afterwards
+ * there is nothing left to compare against.
+ *
+ * `settings` is counted separately and always returned, so the dialog can say
+ * what ticking "Remove user settings?" would add WITHOUT a second round trip
+ * that could disagree with the first.
+ */
+export const AdminResetPreviewSchema = z.object({
+  userId: z.string().uuid(),
+  email: z.string().email(),
+  /** Always destroyed. Keyed by the table each count came from. */
+  tradingData: z.object({
+    accounts: z.number().int().nonnegative(),
+    positions: z.number().int().nonnegative(),
+    fills: z.number().int().nonnegative(),
+    ledgerEntries: z.number().int().nonnegative(),
+    expenses: z.number().int().nonnegative(),
+    brokerages: z.number().int().nonnegative(),
+    csvImportStaging: z.number().int().nonnegative(),
+  }),
+  /** Destroyed only when `removeSettings` is true. */
+  settings: z.object({
+    providerKeys: z.number().int().nonnegative(),
+    externalApiKeys: z.number().int().nonnegative(),
+    advisorPersonas: z.number().int().nonnegative(),
+    advisorConversations: z.number().int().nonnegative(),
+    dashboardLayouts: z.number().int().nonnegative(),
+  }),
+});
+export type AdminResetPreview = z.infer<typeof AdminResetPreviewSchema>;
+
+// --- POST /api/admin/users/:id/reset -----------------------------------------
+
+/**
+ * `confirmEmail` IS THE SAFETY MECHANISM, AND IT IS CHECKED ON THE SERVER.
+ *
+ * The dialog asks the operator to type the target's address, but a dialog is a
+ * convenience, not a guard — anything that can reach the endpoint can skip it.
+ * The service compares this against the email of the user it is about to reset
+ * and refuses on a mismatch, so the confirmation holds for a curl as well as for
+ * the button, and a request built against the wrong id cannot destroy the wrong
+ * account.
+ *
+ * `removeSettings` DEFAULTS TO FALSE, matching the unticked box: the common case
+ * is an operator resetting their own journal to walk onboarding again, and
+ * re-pasting a BYOK key every time is friction with no safety value. A caller
+ * that omits it gets the conservative half.
+ */
+export const AdminResetRequestSchema = z.object({
+  confirmEmail: z.string().email(),
+  removeSettings: z.boolean().default(false),
+});
+export type AdminResetRequest = z.infer<typeof AdminResetRequestSchema>;
+
+/** What the reset actually removed — the preview, re-counted from the deletes. */
+export const AdminResetResultSchema = z.object({
+  userId: z.string().uuid(),
+  email: z.string().email(),
+  removeSettings: z.boolean(),
+  /** Rows deleted per table. Absent keys deleted nothing. */
+  deleted: z.record(z.string(), z.number().int().nonnegative()),
+});
+export type AdminResetResult = z.infer<typeof AdminResetResultSchema>;
+
 // --- GET /api/admin/usage ----------------------------------------------------
 
 const MAX_RANGE_MS = 366 * 24 * 60 * 60 * 1000;


### PR DESCRIPTION
Adds a factory reset to the admin portal: return a user's journal to the state it
was in just after registering and verifying, so onboarding can be walked again
against a real account.

`POST /api/admin/users/:id/reset` and `GET /api/admin/users/:id/reset-preview`,
both behind the existing `authMiddleware → adminMiddleware → per-user rate limit`
router gate. A `Reset` action on each row of the admin user table opens a
confirmation dialog.

## What it deletes, and what it deliberately does not

| | Tables |
| --- | --- |
| **Always deleted** | `accounts`, `positions`, `fills`, `ledger_entries`, `expenses`, the user's own `brokerages` + their `fee_schedules`, `csv_import_staging` |
| **Always reset** | `users.onboarding` |
| **Deleted only with "Remove user settings?"** | `advisor_provider_keys`, `external_api_keys`, `advisor_personas`, `advisor_conversations` (+ messages/summaries), `dashboard_layouts`, the `users` preference columns |
| **Never touched** | `wallets`, `wallet_transactions`, `usage_records`, `subscriptions`, `billing_customers`, `webhook_events`, `csv_import_counters`, `advisor_turn_counters`, `advisor_image_counters`, `sessions`, and identity (`email`, `password_hash`, `is_admin`, `email_verified`, `created_at`) |

That last row is the part worth reviewing.

- **Billing and wallet.** `subscriptions` and `billing_customers` are local mirrors
  of Stripe. Deleting them cancels nothing — it orphans a live Stripe Customer and
  leaves the next webhook writing rows for a subscription the app no longer
  believes in. `wallets` holds credit the user paid real money for. A journal
  reset is not a refund and must not look like one.
- **The quota counters.** Their own schema comments say they are *"never
  decremented and never deleted by application flows (non-evasion)"*, with the
  user-deletion CASCADE as the only removal path. Resetting them would turn this
  button into a way to refill a free-tier allowance on demand, which is exactly
  what those comments exist to prevent.

**`users.onboarding` resets regardless of the settings toggle.** It is technically
a preference, so "keep settings" would naively preserve it — and then the reset
user lands on a dashboard that thinks they have already completed onboarding,
which defeats the entire point.

## Two things that are load-bearing

**Delete order is forced, not stylistic.** `positions.account_id`,
`ledger_entries.account_id` and `accounts.brokerage_id` are all `ON DELETE
RESTRICT`, so cascades do not save you here: PostgreSQL refuses to delete an
account while a position still points at it. Reordering `deleteTradingData` does
not lose data, it aborts the transaction.

**The typed-email confirmation is enforced in the service, not the dialog.** A
check that lives in the client is a courtesy to whoever uses the client; this
endpoint is reachable by anything holding an admin session. A `curl` with a
mismatched `confirmEmail` gets a 400 and deletes nothing.

Deletes and the `admin_audit_log` row commit in one transaction. That row's new
`detail` column is the only surviving record of what was destroyed — nothing can
reconstruct those counts once the rows are gone.

## Migration 0030

`admin_audit_log` had `CHECK (action IN ('admin_toggle'))` with `old_value` /
`new_value` as `NOT NULL boolean`. A reset is not a boolean transition, so those
two columns become nullable and a `detail jsonb` carries the per-action payload.
A partial CHECK keeps both booleans mandatory for `admin_toggle`, so the
relaxation does not silently apply to the action that *is* a transition. Expand-only.

## Scope note

The admin portal is **not** hosted-gated (`FEATURE_GATING` defaults off, and there
is a first-admin bootstrap), so this ships to self-hosters too, and an admin can
reset any user — including another admin. That was a deliberate call over the
narrower self-only option.

## Verified

Driven in a browser against a real stack: created an account, position and fill,
marked onboarding `done`, then reset from `/admin`. The dialog showed
`1 account · 1 position · 1 fill`; a near-miss address left the button disabled and
a differently-cased one enabled it; after the reset the user was still logged in,
onboarding was back to `pending`, `/dashboard` rendered the zero-state at
`0 of 4 complete`, and the audit row carried the per-table counts.

Checks: 149 api + web tests in the touched suites (43 in `admin.test.ts`, 13 of
them new; 46 admin web tests, 15 new), `app.self-host-parity.test.ts` green,
`check:migrations` OK, `check-types` and `eslint` clean across api/web/shared.
The generated OpenAPI artifact and the `db-schema` reference page are regenerated
in this change, as their CI gates require.
