### PR TITLE
fix(onboarding): give the position set a step for creating the position

### DIFF
--- a/apps/web/src/features/onboarding/hooks/useWalkthrough.test.ts
+++ b/apps/web/src/features/onboarding/hooks/useWalkthrough.test.ts
@@ -828,9 +828,11 @@ describe('useWalkthrough — action-driven advance', () => {
     expect(engine.advance).toHaveBeenCalledOnce();
   });
 
-  it('advances the symbol step when the position is created, and not before', async () => {
+  it('advances the create step when the position is created, and not before', async () => {
     await start('position');
-    const index = WALKTHROUGH_STEPS.position.findIndex((s) => s.target === '#symbol');
+    const index = WALKTHROUGH_STEPS.position.findIndex(
+      (s) => s.target === '[data-tour="position-submit"]',
+    );
     highlight(index);
 
     act(() => {
@@ -911,7 +913,9 @@ describe('useWalkthrough — action-driven advance', () => {
     await start('position');
     navigate.mockClear();
 
-    highlight(WALKTHROUGH_STEPS.position.findIndex((s) => s.target === '#symbol'));
+    highlight(
+      WALKTHROUGH_STEPS.position.findIndex((s) => s.target === '[data-tour="position-submit"]'),
+    );
     act(() => {
       eventBus.publish('positions:cache-invalidate', { reason: 'created', positionId: 'pos-new' });
     });
@@ -937,7 +941,9 @@ describe('useWalkthrough — action-driven advance', () => {
     await start('position');
     navigate.mockClear();
 
-    highlight(WALKTHROUGH_STEPS.position.findIndex((s) => s.target === '#symbol'));
+    highlight(
+      WALKTHROUGH_STEPS.position.findIndex((s) => s.target === '[data-tour="position-submit"]'),
+    );
     act(() => {
       eventBus.publish('positions:cache-invalidate', { reason: 'created' });
     });
@@ -951,7 +957,9 @@ describe('useWalkthrough — action-driven advance', () => {
   // would remount the screen under the fill dialog the step before opened.
   it('does not re-navigate once it is already on the position', async () => {
     await start('position');
-    highlight(WALKTHROUGH_STEPS.position.findIndex((s) => s.target === '#symbol'));
+    highlight(
+      WALKTHROUGH_STEPS.position.findIndex((s) => s.target === '[data-tour="position-submit"]'),
+    );
     act(() => {
       eventBus.publish('positions:cache-invalidate', { reason: 'created', positionId: 'pos-new' });
     });
@@ -982,7 +990,9 @@ describe('useWalkthrough — action-driven advance', () => {
 
   it('stops listening once the tour has ended', async () => {
     await start('position');
-    highlight(WALKTHROUGH_STEPS.position.findIndex((s) => s.target === '#symbol'));
+    highlight(
+      WALKTHROUGH_STEPS.position.findIndex((s) => s.target === '[data-tour="position-submit"]'),
+    );
 
     act(() => {
       started?.handlers.onExit?.('dismissed');
@@ -1000,7 +1010,9 @@ describe('useWalkthrough — action-driven advance', () => {
       result.current.start('position');
     });
     await waitFor(() => expect(engine.startTour).toHaveBeenCalledOnce());
-    highlight(WALKTHROUGH_STEPS.position.findIndex((s) => s.target === '#symbol'));
+    highlight(
+      WALKTHROUGH_STEPS.position.findIndex((s) => s.target === '[data-tour="position-submit"]'),
+    );
 
     // The tour navigates off /positions and the zero-state goes with it.
     unmount();
@@ -1038,7 +1050,7 @@ describe('useWalkthrough — action signals', () => {
     resetSession();
     await start('position');
     expect(gatedTargets()).toEqual([
-      '#symbol',
+      '[data-tour="position-submit"]',
       '[data-tour="position-add-fill"]',
       '[data-tour="position-open"]',
     ]);
@@ -1138,7 +1150,9 @@ describe('useWalkthrough — logging out ends the session', () => {
 
   it('stops listening for the events that were advancing it', async () => {
     await start('position');
-    highlight(WALKTHROUGH_STEPS.position.findIndex((s) => s.target === '#symbol'));
+    highlight(
+      WALKTHROUGH_STEPS.position.findIndex((s) => s.target === '[data-tour="position-submit"]'),
+    );
 
     await act(async () => {
       eventBus.publish('auth:logout', {});

--- a/apps/web/src/features/onboarding/hooks/useWalkthrough.ts
+++ b/apps/web/src/features/onboarding/hooks/useWalkthrough.ts
@@ -94,7 +94,7 @@ type StepsModule = typeof import('../lib/steps');
  */
 export const ACTION_SIGNALS: Readonly<Record<string, { event: EventName; reason: string }>> = {
   '[data-tour="account-submit"]': { event: 'accounts:cache-invalidate', reason: 'created' },
-  '#symbol': { event: 'positions:cache-invalidate', reason: 'created' },
+  '[data-tour="position-submit"]': { event: 'positions:cache-invalidate', reason: 'created' },
   '[data-tour="position-add-fill"]': { event: 'positions:cache-invalidate', reason: 'fill-added' },
   '[data-tour="position-open"]': { event: 'positions:cache-invalidate', reason: 'opened' },
   '[data-tour="position-close"]': { event: 'positions:cache-invalidate', reason: 'closed' },

--- a/apps/web/src/features/onboarding/lib/steps/position.ts
+++ b/apps/web/src/features/onboarding/lib/steps/position.ts
@@ -14,7 +14,19 @@
  *   ledger" — and `positions.service.ts` refuses an exit fill while draft.
  * - `CreatePositionDialog` asks for Symbol, Side, Asset Type, Account and
  *   Notes, and nothing else; `#symbol` is the stock-mode id and Stock is the
- *   default asset type.
+ *   default asset type. Symbol is the same `SymbolAutocomplete` the calculator
+ *   uses, so "searches as you type" is true of both screens.
+ * - `[data-tour="position-submit"]` is the dialog's Create button.
+ *
+ * WHY CREATING THE POSITION HAS A STEP OF ITS OWN, and did not always. The
+ * field step used to carry `advanceOnAction` itself: it described four controls
+ * and then waited for the position to be created, which is an instruction it
+ * never actually gave. A gated step ignores "Next" by design, so a user who
+ * filled the form in and pressed the only obvious control got nothing, with
+ * nothing on screen to say what was wanted — the reported stall. The account set
+ * never had this problem because it already separates its field steps from a
+ * final "Choose Create" step, and this set now matches it: the fields advance on
+ * "Next", and the action step points at the button that performs the action.
  * - `FillDialog` offers Type Entry / Exit — Entry only while the position is a
  *   draft — with Price, Quantity, Fees, Date & Time and Notes.
  * - "Open Position" is disabled until an entry fill exists, with the tooltip
@@ -71,11 +83,30 @@ export const positionSteps: readonly WalkthroughStepSource[] = [
     // control is left interactive in the first place.
     side: 'right',
     align: 'start',
-    advanceOnAction: true,
     title: 'Symbol, side and account',
     body:
-      'The ticker, whether you are long or short, and the account it is booked against. Notes ' +
-      'are worth filling in now — why you took the trade is the part you will want back later.',
+      'The ticker, whether you are long or short, and the account it is booked against. Symbol ' +
+      'searches as you type, the same as the calculator does. Notes are worth filling in now — ' +
+      'why you took the trade is the part you will want back later.',
+  },
+  {
+    target: '[data-tour="position-submit"]',
+    route: '/positions',
+    docs: 'positions',
+    // BESIDE THE DIALOG, NOT ABOVE THE FOOTER — and that is a measurement, not a
+    // preference. The account set's submit step goes `top`/`end`, but that
+    // dialog is a tall form whose footer has clear space above it. This one is
+    // short: placed above the Create button the popover came down on the Notes
+    // textarea, the Account select and Cancel — three controls the user can
+    // still press, which `expectPromptClearOfEveryControl` fails on. `right` is
+    // the placement the field step above already proves clears this dialog.
+    side: 'right',
+    align: 'end',
+    advanceOnAction: true,
+    title: 'Create the position',
+    body:
+      'Choose Create. Nothing is committed to your account yet — what you get is a draft, which ' +
+      'is the subject of the next step.',
   },
   {
     target: '[data-tour="position-add-fill"]',

--- a/apps/web/src/features/positions/components/CreatePositionDialog.test.tsx
+++ b/apps/web/src/features/positions/components/CreatePositionDialog.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { createElement, type ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -134,8 +136,16 @@ function createButton(): HTMLButtonElement {
   return screen.getByRole('button', { name: 'Create' }) as HTMLButtonElement;
 }
 
+function withQueryClient() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
+}
+
 function renderDialog() {
-  return render(<CreatePositionDialog open onOpenChange={vi.fn()} />);
+  return render(<CreatePositionDialog open onOpenChange={vi.fn()} />, {
+    wrapper: withQueryClient(),
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -333,6 +343,59 @@ describe('CreatePositionDialog', () => {
 });
 
 // ---------------------------------------------------------------------------
+// The symbol field is a SymbolAutocomplete, not a plain input
+// ---------------------------------------------------------------------------
+
+describe('CreatePositionDialog — symbol entry', () => {
+  // THE TRAP THIS FIELD SETS, AND WHY THE DIALOG WIRES TWO HANDLERS.
+  //
+  // `SymbolAutocomplete` reports a ticker through `onChange` only when it is
+  // COMMITTED — a result is clicked, or Enter is pressed. Blur does not commit.
+  // A dialog with a submit button therefore cannot rely on `onChange` alone:
+  // the ordinary way to fill this form is to type four characters and reach for
+  // Create, and that gesture commits nothing. Before `onQueryChange` was wired,
+  // it submitted an empty symbol.
+  //
+  // This is the assertion that the typed text reaches the form without a
+  // selection, which is what the field did when it was a plain input.
+  it('submits a typed ticker that was never selected from the dropdown', async () => {
+    renderDialog();
+    chooseAccount();
+
+    fireEvent.change(screen.getByLabelText('Symbol'), { target: { value: 'AAPL' } });
+    fireEvent.click(createButton());
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    expect(mutateAsync.mock.calls[0]![0]).toMatchObject({ symbol: 'AAPL' });
+  });
+
+  // The field uppercased on the server before; it does so on the way in now, so
+  // what the user sees is what is submitted.
+  it('uppercases a lowercase ticker', async () => {
+    renderDialog();
+    chooseAccount();
+
+    fireEvent.change(screen.getByLabelText('Symbol'), { target: { value: 'aapl' } });
+    fireEvent.click(createButton());
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    expect(mutateAsync.mock.calls[0]![0]).toMatchObject({ symbol: 'AAPL' });
+  });
+
+  // The walkthrough anchors its "Symbol, side and account" step to `#symbol`.
+  // The autocomplete forwards `id` to its inner input, so the anchor survived
+  // the swap — but nothing else guarantees that, and a tour that points at
+  // nothing ends without a word.
+  it('keeps the #symbol id the walkthrough anchors to', () => {
+    renderDialog();
+
+    const field = document.querySelector('#symbol');
+    expect(field).not.toBeNull();
+    expect(field!.tagName).toBe('INPUT');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Plan tiers (design Component 12; REQ-6.4, REQ-11.5/11.6)
 // ---------------------------------------------------------------------------
 
@@ -392,7 +455,9 @@ describe('CreatePositionDialog — plan tiers', () => {
       error: { code: 'TIER_LIMIT_POSITIONS', message: 'server text is not branched on' },
     });
     const onOpenChange = vi.fn();
-    render(<CreatePositionDialog open onOpenChange={onOpenChange} />);
+    render(<CreatePositionDialog open onOpenChange={onOpenChange} />, {
+      wrapper: withQueryClient(),
+    });
 
     submitStock();
 

--- a/apps/web/src/features/positions/components/CreatePositionDialog.tsx
+++ b/apps/web/src/features/positions/components/CreatePositionDialog.tsx
@@ -5,9 +5,9 @@ import { z } from 'zod';
 
 import type { CreatePositionInput } from '@tradr/shared';
 
+import { SymbolAutocomplete } from '@/components/SymbolAutocomplete';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
   Select,
@@ -263,7 +263,30 @@ export function CreatePositionDialog({ open, onOpenChange }: Props) {
           {assetType === 'stock' ? (
             <div className="space-y-2">
               <Label htmlFor="symbol">Symbol</Label>
-              <Input id="symbol" {...form.register('symbol')} placeholder="e.g., AAPL" />
+              {/* The same control the calculator uses, for the reason above the
+                  import.
+
+                  BOTH HANDLERS ARE WIRED, AND THE SECOND ONE IS NOT OPTIONAL
+                  HERE. `onChange` fires only when the ticker is COMMITTED — a
+                  result is clicked, or Enter is pressed — and blur does not
+                  commit. This dialog has a submit button, so a user who types
+                  AAPL and goes straight for Create never commits anything, and
+                  without `onQueryChange` the form would submit an empty symbol.
+                  Keeping the field value in step with the raw text preserves the
+                  plain-text-entry behaviour this input had before the dropdown
+                  was added; selecting a result still overwrites it with the
+                  canonical ticker. */}
+              <SymbolAutocomplete
+                id="symbol"
+                value={form.watch('symbol') ?? ''}
+                onQueryChange={(raw) =>
+                  form.setValue('symbol', raw.toUpperCase(), { shouldDirty: true })
+                }
+                onChange={(ticker) =>
+                  form.setValue('symbol', ticker, { shouldValidate: true, shouldDirty: true })
+                }
+                placeholder="e.g., AAPL"
+              />
               {form.formState.errors.symbol && (
                 <p className="text-sm text-destructive">{form.formState.errors.symbol.message}</p>
               )}
@@ -361,7 +384,16 @@ export function CreatePositionDialog({ open, onOpenChange }: Props) {
             >
               Cancel
             </Button>
-            <Button type="submit" className="cursor-pointer" disabled={createPosition.isPending}>
+            <Button
+              type="submit"
+              // The walkthrough's anchor for its "Choose Create" step — the
+              // account dialog's `account-submit` precedent. Without it the
+              // position set had no step for the action it was waiting on, so
+              // the tour described four fields and then appeared to stall.
+              data-tour="position-submit"
+              className="cursor-pointer"
+              disabled={createPosition.isPending}
+            >
               {createPosition.isPending ? 'Creating...' : 'Create'}
             </Button>
           </div>

--- a/e2e/tests/user-onboarding.spec.ts
+++ b/e2e/tests/user-onboarding.spec.ts
@@ -317,13 +317,20 @@ const checklistItemLabel = (page: Page, id: string): Locator =>
   page.locator(`[data-checklist-item="${id}"] > span`).first();
 
 /**
- * The position set's five step titles, in order, from
+ * The position set's six step titles, in order, from
  * `features/onboarding/lib/steps/position.ts`. It is the only set that changes
  * screen onto a row the user creates while the tour is running.
+ *
+ * "Create the position" is a step of its own, and did not used to be. The field
+ * step carried the create gate itself, so it described four controls and then
+ * waited for an action it never asked for — "Next" was correctly inert and there
+ * was nothing on screen saying to press Create. The set now matches the account
+ * set: fields advance on "Next", and the action step points at the button.
  */
 const POSITION_STEP_TITLES = [
   'Log the position',
   'Symbol, side and account',
+  'Create the position',
   'It starts as a draft',
   'Open the position',
   'That is a position logged',
@@ -567,13 +574,28 @@ test.describe('user onboarding', () => {
     await page.getByRole('option', { name: 'Position account (USD)' }).click();
     await dialog.locator('#symbol').click();
     await dialog.locator('#symbol').fill('AAPL');
+
+    // THE STEP THAT ASKS FOR THE ACTION. The field step advances on "Next" now,
+    // onto a step that highlights Create and says to press it — which is the
+    // instruction the set used to be missing entirely.
+    await popoverNext(page).click();
+    await expect(popoverTitle(page)).toHaveText(POSITION_STEP_TITLES[2]);
+    await expectStepClear(page, `position step 3, "${POSITION_STEP_TITLES[2]}", dialog open`);
+    // The control the step names has to be pressable, not merely visible: the
+    // popover sits above the footer precisely so it clears Cancel and Create.
+    await expectClearOfPopover(
+      page,
+      dialog.getByRole('button', { name: 'Create', exact: true }),
+      "the position dialog's Create button, on 'Create the position'",
+    );
+
     await dialog.getByRole('button', { name: 'Create', exact: true }).click();
 
     // THE ASSERTION THIS TEST EXISTS FOR. The tour follows the position onto its
     // own page, which nothing but the walkthrough was going to do.
     await expect(popoverTitle(page)).toHaveText(POSITION_STEP_TITLES[2]);
     await expect(page).toHaveURL(/\/positions\/[0-9a-f-]{36}/);
-    await expectStepClear(page, `position step 3, "${POSITION_STEP_TITLES[2]}"`);
+    await expectStepClear(page, `position step 4, "${POSITION_STEP_TITLES[3]}"`);
 
     // Draft → open, through the two controls the remaining steps highlight.
     await page.locator('[data-tour="position-add-fill"]').click();
@@ -582,7 +604,7 @@ test.describe('user onboarding', () => {
     // this step is finished by. In that order, because the general measurement
     // is the one that reports the whole picture and the named one is a
     // narrower, louder restatement of part of it.
-    await expectStepClear(page, `position step 3, "${POSITION_STEP_TITLES[2]}", fill dialog open`);
+    await expectStepClear(page, `position step 4, "${POSITION_STEP_TITLES[3]}", fill dialog open`);
     await expectClearOfPopover(
       page,
       page.getByRole('button', { name: 'Add', exact: true }),
@@ -591,13 +613,13 @@ test.describe('user onboarding', () => {
     await page.locator('#price').fill('150.00');
     await page.locator('#quantity').fill('10');
     await page.getByRole('button', { name: 'Add', exact: true }).click();
-    await expect(popoverTitle(page)).toHaveText(POSITION_STEP_TITLES[3]);
-    await expectStepClear(page, `position step 4, "${POSITION_STEP_TITLES[3]}"`);
+    await expect(popoverTitle(page)).toHaveText(POSITION_STEP_TITLES[4]);
+    await expectStepClear(page, `position step 5, "${POSITION_STEP_TITLES[4]}"`);
 
     await page.locator('[data-tour="position-open"]').click();
-    await expect(popoverTitle(page)).toHaveText(POSITION_STEP_TITLES[4]);
-    await expect(popoverProgress(page)).toHaveText(`5 of ${POSITION_STEP_TITLES.length}`);
-    await expectStepClear(page, `position step 5, "${POSITION_STEP_TITLES[4]}"`);
+    await expect(popoverTitle(page)).toHaveText(POSITION_STEP_TITLES[5]);
+    await expect(popoverProgress(page)).toHaveText(`6 of ${POSITION_STEP_TITLES.length}`);
+    await expectStepClear(page, `position step 6, "${POSITION_STEP_TITLES[5]}"`);
 
     // "Done" finishes it, and item 3 ticks off the user's real data. The set
     // ends on the position rather than the dashboard, so the checklist is read


### PR DESCRIPTION
Fixes the "Log a position" walkthrough stalling on the Symbol step, and wires the
ticker search into the position dialog.

Reported as *"will not progress past the Symbol entry step — clicking Next does
nothing, and typing a symbol does not cause a search-result dropdown to appear."*
Two separate causes.

## 1. The stall — a missing step, not a broken engine

The `#symbol` step carried `advanceOnAction` itself, gated on the position
actually being created. So `Next` was **correctly** inert — but the copy only
*described* four fields and never asked for the action:

> The ticker, whether you are long or short, and the account it is booked
> against. Notes are worth filling in now…

Fill the form, press the only obvious control, nothing happens, no instruction on
screen. The **account** set never had this problem because it already separates
its field steps from a final `[data-tour="account-submit"]` step whose copy is
"Choose Create." The position set had no equivalent, and the position dialog's
Create button had no `data-tour` anchor at all.

The set now matches the account set:

| | Before | After |
| --- | --- | --- |
| `#symbol` | gated on `created`, no instruction | advances on `Next` |
| `[data-tour="position-submit"]` | *did not exist* | gated on `created`, copy says "Choose Create" |

`ACTION_SIGNALS` moves the `positions:cache-invalidate` / `created` signal from
`#symbol` onto the new step. The set goes 5 → 6 steps.

**Placement is a measurement, not a preference.** The account set's submit step
sits `top`/`end`; copying that here put the popover on the Notes textarea, the
Account select and Cancel — three controls the user can still press, which
`expectPromptClearOfEveryControl` failed on. It goes `right`, the placement the
field step above it already proves clears this dialog.

## 2. The missing dropdown — a real inconsistency

`SymbolAutocomplete` exists, works, and is backed by a populated table, but was
wired only into `CalculatorForm`. `CreatePositionDialog` used a plain `<Input>`,
so typing fired zero search requests. Since the checklist walks people through
*sizing* a trade before *logging* one, the walkthrough itself teaches the ticker
search on one screen and removes it on the next.

The stock branch now uses the same control. `id` is forwarded to the inner input,
so the walkthrough's `#symbol` anchor is unchanged.

**Both handlers are wired, and the second one is not optional here.** `onChange`
fires only when a ticker is *committed* — a result clicked, or Enter pressed —
and **blur does not commit**. This dialog has a submit button, so the ordinary
gesture (type four characters, reach for Create) commits nothing. Without
`onQueryChange` keeping the field value in step with the raw text, the form
submitted an **empty symbol**. An existing test caught this; three new tests pin
it, including one that pins the `#symbol` id the walkthrough anchors to.

## Verified

Driven in a browser against a real stack. Typing `AAP` now returns Advance Auto
Parts, Ascentage Pharma and Apple; clicking Apple commits `AAPL`. The walkthrough
runs 2 of 6 → Next → **3 of 6 "Create the position"** with the Create button
highlighted → Create → 4 of 6 → through to 6 of 6.

Checks: 514 onboarding + 173 positions unit tests, 15 onboarding e2e (desktop),
`check-types` and `eslint` clean.

## Found, not fixed

Selecting a result leaves the dropdown open showing the exact match, because
`commit()` sets the new query and the debounced-query effect then clears
`dismissed`. It is **pre-existing and shared** — the calculator does the same, and
I confirmed it there before concluding. Out of scope for this fix; happy to do it
separately.
