### PR TITLE
fix(symbols): keep the ticker dropdown closed after a selection

### DIFF
--- a/apps/web/src/components/SymbolAutocomplete.test.tsx
+++ b/apps/web/src/components/SymbolAutocomplete.test.tsx
@@ -119,4 +119,71 @@ describe('SymbolAutocomplete', () => {
     fireEvent.keyDown(input, { key: 'Escape' });
     await waitFor(() => expect(screen.queryByRole('listbox')).toBeNull());
   });
+
+  // SELECTING CLOSES THE LIST, AND STAYS CLOSED.
+  //
+  // The dismissal used to be undone by the component itself. `commit` sets the
+  // query to the chosen ticker and dismisses; the debounce then delivered that
+  // ticker as a fresh query ~250ms later and the effect watching it cleared the
+  // dismissal, so the list came back showing the single exact match the user had
+  // just chosen. Every existing test here asserted `onChange` fired and none
+  // asserted the list went away, which is why it survived.
+  //
+  // The wait past the debounce window is the whole assertion: a check made
+  // immediately after the click passes either way.
+  it('selecting a result closes the dropdown and it does not come back', async () => {
+    vi.mocked(api.get).mockResolvedValue({ results: [AAPL, AAL] });
+    const { input } = renderAC();
+    type(input, 'aa');
+    const list = await screen.findByRole('listbox');
+
+    fireEvent.mouseDown(within(list).getByText('AAPL').closest('[role="option"]')!);
+    await waitFor(() => expect(screen.queryByRole('listbox')).toBeNull());
+
+    // Past the 250ms debounce of the committed ticker — the moment it reopened.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('stays closed after Enter selects the highlighted ticker', async () => {
+    vi.mocked(api.get).mockResolvedValue({ results: [AAPL, AAL] });
+    const { input } = renderAC();
+    type(input, 'aa');
+    await screen.findByRole('listbox');
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => expect(screen.queryByRole('listbox')).toBeNull());
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  // The other half of the same rule: typing is what should undo a dismissal, and
+  // it still does. Escape then a keystroke brings the list back.
+  it('typing after a dismissal reopens the dropdown', async () => {
+    vi.mocked(api.get).mockResolvedValue({ results: [AAPL, AAL] });
+    const { input } = renderAC();
+    type(input, 'aa');
+    await screen.findByRole('listbox');
+    fireEvent.keyDown(input, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByRole('listbox')).toBeNull());
+
+    fireEvent.change(input, { target: { value: 'aap' } });
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeNull());
+  });
+
+  // And a correction after a selection: the user picks AAPL, then keeps typing
+  // to search for something else. That is a keystroke, so the list returns.
+  it('typing after a selection reopens the dropdown', async () => {
+    vi.mocked(api.get).mockResolvedValue({ results: [AAPL, AAL] });
+    const { input } = renderAC();
+    type(input, 'aa');
+    const list = await screen.findByRole('listbox');
+    fireEvent.mouseDown(within(list).getByText('AAPL').closest('[role="option"]')!);
+    await waitFor(() => expect(screen.queryByRole('listbox')).toBeNull());
+
+    fireEvent.change(input, { target: { value: 'AAL' } });
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeNull());
+  });
 });

--- a/apps/web/src/components/SymbolAutocomplete.tsx
+++ b/apps/web/src/components/SymbolAutocomplete.tsx
@@ -57,10 +57,21 @@ export function SymbolAutocomplete({
   const results = data?.results ?? [];
   const hasQuery = debouncedQuery.length >= 1;
 
-  // A fresh query invalidates the current highlight and any prior dismissal.
+  // NEW RESULTS INVALIDATE THE HIGHLIGHT, AND NOTHING ELSE.
+  //
+  // This used to clear `dismissed` here as well, and that reopened the dropdown
+  // immediately after a selection. `commit` sets the query to the chosen ticker
+  // and dismisses in the same breath; the debounce then delivers that ticker as
+  // a "fresh query" ~250ms later, this effect cleared the dismissal, and the
+  // list came back showing the one exact match the user had just picked.
+  //
+  // Clearing it here was never what reopened the list for a user who was TYPING
+  // — `handleInputChange` already clears `dismissed` on every keystroke, which
+  // is the gesture that should undo an Escape. So the reset belongs there, where
+  // the user's intent is known, and not on a query change that the component
+  // itself may have caused.
   React.useEffect(() => {
     setActiveIndex(-1);
-    setDismissed(false);
   }, [debouncedQuery]);
 
   // On endpoint error, degrade to a plain text input: no dropdown (REQ-7.3).


### PR DESCRIPTION
Selecting a ticker from the search dropdown closed the list and then reopened it,
showing the single exact match the user had just chosen.

Found while wiring the autocomplete into the position dialog (#92) and confirmed
to be pre-existing and independent — it affects the calculator on `main` today,
which is where I reproduced it before concluding it was not something #92
introduced.

## Cause

`commit()` sets the query to the chosen ticker and dismisses the list in the same
breath:

```ts
setQuery(upper);
onChange(upper);
setDismissed(true);
```

The 250ms debounce then delivers that ticker as a "fresh query", and the effect
watching `debouncedQuery` cleared the dismissal:

```ts
// A fresh query invalidates the current highlight and any prior dismissal.
React.useEffect(() => {
  setActiveIndex(-1);
  setDismissed(false);   // <- undoes the dismissal commit() just set
}, [debouncedQuery]);
```

So the list came back ~250ms after every selection.

## Fix

Clearing the dismissal there was never what reopened the list for someone who was
**typing** — `handleInputChange` already clears it on every keystroke, and that is
the gesture which should undo an Escape. The reset therefore belongs where the
user's intent is known, and must not fire on a query change the component caused
itself. The effect now resets only the highlight, which is genuinely invalidated
by new results.

Behaviour after the change:

| Gesture | Dropdown |
| --- | --- |
| Type | opens |
| Escape | closes |
| Escape, then type | reopens |
| **Select a result (click or Enter)** | **closes, and stays closed** |
| Select, then type again | reopens |

## Why it survived

Every existing test here asserted that `onChange` fired on selection; none
asserted the list went away. Four tests now cover it. Two deliberately wait past
the debounce window, because a check made immediately after the click passes
either way — I verified both new selection tests fail with the one-line defect
restored, on exactly the assertion that matters
(`expected <ul role="listbox"> to be null`).

## Verified

241 tests green across the component and both its consumers (calculator and
positions). Driven in a browser on the calculator: selecting Apple commits
`AAPL`, the list is gone immediately and still gone 1.5s later, and typing again
brings it back.
