### PR TITLE
feat(onboarding): disable Next on a held step and name the action

### DIFF
--- a/apps/web/src/features/onboarding/lib/steps/account.ts
+++ b/apps/web/src/features/onboarding/lib/steps/account.ts
@@ -85,6 +85,14 @@ export const accountSteps: readonly WalkthroughStepSource[] = [
     // the tour would exit `target-missing` before the screen it is describing
     // has finished arriving.
     waitForMs: 5000,
+    // BESIDE THE BUTTON, NOT UNDER IT. The control sits at the top right of the
+    // page and the popover is tall enough that driver.js's default placement
+    // clamps it back up over its own anchor — measured at 1280x720, the tour
+    // stood on the very control it was telling the user to press. To the left it
+    // clears the anchor with room to spare.
+    side: 'left',
+    align: 'start',
+    actionHint: 'Choose New Account',
     advanceOnAction: true,
     title: 'Start with an account',
     body:
@@ -178,8 +186,9 @@ export const accountSteps: readonly WalkthroughStepSource[] = [
     // left; this one cannot, because Cancel is what is immediately to the left
     // of the control it highlights, and the popover reached 68px across it.
     // Above and end-aligned, the popover clears the whole footer row.
-    side: 'top',
+    side: 'right',
     align: 'end',
+    actionHint: 'Choose Create',
     advanceOnAction: true,
     title: 'Create the account',
     body:

--- a/apps/web/src/features/onboarding/lib/steps/calculator.ts
+++ b/apps/web/src/features/onboarding/lib/steps/calculator.ts
@@ -109,6 +109,7 @@ export const calculatorSteps: readonly WalkthroughStepSource[] = [
     route: '/calculator',
     docs: 'gettingStarted',
     side: 'right',
+    actionHint: 'Choose the Percent basis',
     advanceOnAction: true,
     title: 'Risk',
     body:
@@ -122,6 +123,7 @@ export const calculatorSteps: readonly WalkthroughStepSource[] = [
     docs: 'gettingStarted',
     waitForMs: 3000,
     side: 'right',
+    actionHint: 'Pick an account',
     advanceOnAction: true,
     title: 'Account',
     body:

--- a/apps/web/src/features/onboarding/lib/steps/close.ts
+++ b/apps/web/src/features/onboarding/lib/steps/close.ts
@@ -56,13 +56,29 @@ export const closeSteps: readonly WalkthroughStepSource[] = [
     // exit fill this step waits for is recorded in the fill dialog, and the
     // default placement to the LEFT of Add Fill reaches x=850 at 1280x720 while
     // the dialog runs to x=896, covering 21px of that dialog's Add button.
-    side: 'top',
+    // ABOVE, AND THE STEP IS WRITTEN TO A HEIGHT BUDGET BECAUSE OF IT. This
+    // anchor is the most cramped in any set, and both of its states are measured:
+    // to the LEFT the popover clears the button but lands on the fill dialog it
+    // just told the user to open, and BELOW or RIGHT it leaves the viewport. That
+    // leaves above, where driver.js pins the popover's top at y=386 over a button
+    // at y=554 — 168px, for the title, the body, the "read more" line and the
+    // line naming the action. The body is one line for that reason, not for
+    // style: a second one puts the popover on the button. The quantity nuance it
+    // used to carry is the whole subject of the next step.
+    // LEFT AND NARROW, AND BOTH HALVES ARE MEASURED. This anchor is the most
+    // cramped in any set: "Add Fill" sits at the bottom right of the page and
+    // opens a dialog centred beside it, so the step is asserted clear in two
+    // states. At the full 300px width nothing satisfies both — above lands 12px
+    // inside the button, below and right leave the viewport, and left reaches
+    // x=862 across a dialog running to x=896. At 240px the left side fits: the
+    // popover starts at x=922, clear of the dialog and clear of the button.
+    side: 'left',
+    align: 'end',
+    narrow: true,
+    actionHint: 'Add the exit fill',
     advanceOnAction: true,
     title: 'Record the exit',
-    body:
-      'Add a fill with the type set to Exit, at the price and quantity you actually closed at. ' +
-      'Partial exits are ordinary — one fill per exit, averaged for you — and the one that ' +
-      'leaves nothing open is the one that finishes the trade.',
+    body: 'Set the type to Exit, at the price and quantity you closed at.',
   },
   {
     target: '[data-tour="position-close"]',
@@ -70,6 +86,7 @@ export const closeSteps: readonly WalkthroughStepSource[] = [
     routeParams: ['positionId'],
     docs: 'positions',
     waitForMs: 3000,
+    actionHint: 'Choose Close Position',
     advanceOnAction: true,
     title: 'It closes itself',
     body:

--- a/apps/web/src/features/onboarding/lib/steps/position.ts
+++ b/apps/web/src/features/onboarding/lib/steps/position.ts
@@ -54,6 +54,14 @@ export const positionSteps: readonly WalkthroughStepSource[] = [
     // the tagged enabled one once it has: without this the tour exits
     // `target-missing` on a screen that was about to be ready.
     waitForMs: 5000,
+    // BESIDE THE BUTTON, NOT UNDER IT. The control sits at the top right of the
+    // page and the popover is tall enough that driver.js's default placement
+    // clamps it back up over its own anchor — measured at 1280x720, the tour
+    // stood on the very control it was telling the user to press. To the left it
+    // clears the anchor with room to spare.
+    side: 'left',
+    align: 'start',
+    actionHint: 'Choose New Position',
     advanceOnAction: true,
     title: 'Log the position',
     body:
@@ -102,6 +110,7 @@ export const positionSteps: readonly WalkthroughStepSource[] = [
     // the placement the field step above already proves clears this dialog.
     side: 'right',
     align: 'end',
+    actionHint: 'Choose Create',
     advanceOnAction: true,
     title: 'Create the position',
     body:
@@ -122,13 +131,12 @@ export const positionSteps: readonly WalkthroughStepSource[] = [
     // popover across Add and across the Notes field above it. Placed above, the
     // popover stays clear of the dialog it just told the user to open.
     side: 'top',
+    actionHint: 'Add the entry fill',
     advanceOnAction: true,
     title: 'It starts as a draft',
     body:
-      'What you just made is a draft: a plan, not a trade. It posts nothing to your ledger and ' +
-      'leaves the account balance exactly where it was, so you can plan a trade you never take. ' +
-      'Add Fill is what turns it into one — the price and quantity you actually got, plus any ' +
-      'fees.',
+      'A draft is a plan, not a trade: it posts nothing to your ledger and leaves the balance ' +
+      'where it was. Add Fill records what you actually got.',
   },
   {
     target: '[data-tour="position-open"]',
@@ -136,6 +144,13 @@ export const positionSteps: readonly WalkthroughStepSource[] = [
     routeParams: ['positionId'],
     docs: 'positions',
     waitForMs: 3000,
+    // BESIDE THE BUTTON. Open Position sits at the top right of the detail page,
+    // and driver.js's default places the popover below it starting 12px inside
+    // the button — measured at 1280x720, popover y 48 against a button ending at
+    // y 60. The same shape, and the same fix, as the two sets' opening steps.
+    side: 'left',
+    align: 'start',
+    actionHint: 'Choose Open Position',
     advanceOnAction: true,
     title: 'Open the position',
     body:

--- a/apps/web/src/features/onboarding/lib/steps/steps.test.ts
+++ b/apps/web/src/features/onboarding/lib/steps/steps.test.ts
@@ -240,6 +240,8 @@ describe('walkthrough step definitions', () => {
       'align',
       'waitForMs',
       'advanceOnAction',
+      'actionHint',
+      'narrow',
       'docs',
       'route',
       'routeParams',
@@ -248,6 +250,39 @@ describe('walkthrough step definitions', () => {
       for (const key of Object.keys(step)) {
         expect(allowed.has(key), `${name} carries unexpected key ${key}`).toBe(true);
       }
+    }
+  });
+
+  // EVERY STEP THAT CAN HOLD THE USER SAYS WHAT IT IS HOLDING THEM FOR.
+  //
+  // A step gated on an action ignores "Next" — the engine disables the button
+  // for exactly that reason — so the popover has to name the gesture instead, or
+  // the user is left with a dead control and no instruction. That was the
+  // reported defect, twice, and this is the rule that stops a new action step
+  // shipping without its half of the fix.
+  //
+  // Keyed on the AUTHORED flag rather than on what the engine ends up gating,
+  // because `useWalkthrough` may downgrade a step at runtime and may gate it
+  // again on `advanceOnAppearanceOf`. The flag is the honest question: does this
+  // step's author believe an action is required?
+  it('gives every action step the gesture it is waiting for', () => {
+    const gated = allSteps.filter(([, step]) => step.advanceOnAction === true);
+    expect(gated.length).toBeGreaterThan(0);
+    for (const [name, step] of gated) {
+      expect(typeof step.actionHint, `${name} has no actionHint`).toBe('string');
+      expect(step.actionHint!.length, `${name} has an empty actionHint`).toBeGreaterThan(0);
+    }
+  });
+
+  // The engine renders "To continue: <hint>", so the hint is a bare gesture. A
+  // hint carrying its own framing reads as "To continue: Click X to continue".
+  it('writes action hints as a bare imperative', () => {
+    for (const [name, step] of allSteps) {
+      if (step.actionHint === undefined) continue;
+      expect(step.actionHint, `${name} ends with punctuation`).not.toMatch(/[.!]$/);
+      expect(step.actionHint.toLowerCase(), `${name} re-states the frame`).not.toContain(
+        'to continue',
+      );
     }
   });
 });

--- a/apps/web/src/features/onboarding/lib/tour-engine.test.ts
+++ b/apps/web/src/features/onboarding/lib/tour-engine.test.ts
@@ -207,6 +207,139 @@ describe('action steps', () => {
 });
 
 /**
+ * THE POPOVER TELLS THE TRUTH ABOUT WHETHER "NEXT" WORKS.
+ *
+ * A gated step ignoring "Next" is correct and always was; the button going on
+ * LOOKING pressable is what made correct behaviour read as a bug, twice. The
+ * disabled state and the instruction come from the same `isGatedStep` reading as
+ * the press itself, so they cannot disagree with what a press would do.
+ */
+describe('a held step disables Next and says what it wants', () => {
+  const steps: TourStep[] = [
+    {
+      target: '#one',
+      title: 'Do it',
+      description: 'Create the thing.',
+      advanceOnAction: true,
+      actionHint: 'Choose New Thing',
+    },
+    { target: '#two', title: 'Done', description: 'Here it is.' },
+  ];
+
+  const nextBtn = () =>
+    document.querySelector<HTMLButtonElement>('.driver-popover-next-btn') ?? undefined;
+  // WHAT THE USER CAN SEE, not what is in the DOM. The hint is rendered with
+  // every step that has one — that is what lets driver.js measure it before
+  // placing the popover — and shown only while the step is held, via the
+  // `tradr-tour-held` class. jsdom applies no stylesheet, so asking for the node
+  // would report a hint the user is not being shown.
+  const isHeld = () =>
+    document.querySelector('.driver-popover')?.classList.contains('tradr-tour-held') ?? false;
+  const hint = () =>
+    isHeld()
+      ? (document.querySelector('.tradr-tour-action-hint')?.textContent ?? undefined)
+      : undefined;
+
+  it('disables "Next" and shows the gesture', async () => {
+    startTour(steps);
+
+    // The popover is written by driver.js AFTER `onHighlightStarted`, so the
+    // affordance lands on the watch that sees it appear. That is a microtask —
+    // before any paint, and after this call returns.
+    await vi.waitFor(() => expect(nextBtn()?.disabled).toBe(true));
+    expect(nextBtn()?.getAttribute('aria-disabled')).toBe('true');
+    expect(nextBtn()?.classList.contains('driver-popover-btn-disabled')).toBe(true);
+    expect(hint()).toBe('To continue: Choose New Thing');
+  });
+
+  it('leaves an ordinary step alone', async () => {
+    startTour(TWO_STEPS);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(nextBtn()?.disabled).toBe(false);
+    expect(hint()).toBeUndefined();
+  });
+
+  // THE CASE THAT MATTERS MOST. The gate releases on a control the user cannot
+  // press, because the rest of the page is inert and a held step pointing at a
+  // disabled button would leave Escape as the only way on. The instruction has
+  // to go with it: telling somebody to choose a greyed-out control is worse than
+  // saying nothing.
+  it('re-enables "Next" and drops the hint when the control goes disabled', async () => {
+    startTour(steps);
+    await vi.waitFor(() => expect(nextBtn()?.disabled).toBe(true));
+
+    document.querySelector<HTMLButtonElement>('#one')!.disabled = true;
+
+    await vi.waitFor(() => expect(nextBtn()?.disabled).toBe(false));
+    expect(hint()).toBeUndefined();
+  });
+
+  it('takes "Next" back when the control becomes pressable again', async () => {
+    const target = document.querySelector<HTMLButtonElement>('#one')!;
+    target.disabled = true;
+    startTour(steps);
+    await vi.waitFor(() => expect(nextBtn()?.disabled).toBe(false));
+
+    target.disabled = false;
+
+    await vi.waitFor(() => expect(nextBtn()?.disabled).toBe(true));
+    expect(hint()).toBe('To continue: Choose New Thing');
+  });
+
+  // A step held only because the control it is waiting for has not arrived —
+  // the account and position sets' opening steps — is held the same way and
+  // says so the same way.
+  it('holds an appearance step the same way', async () => {
+    const appearanceSteps: TourStep[] = [
+      {
+        target: '#one',
+        title: 'Open it',
+        description: 'Choose the button.',
+        advanceOnAppearanceOf: '#late',
+        actionHint: 'Choose New Thing',
+      },
+      { target: '#late', title: 'The field', description: 'Fill this in.' },
+    ];
+    startTour(appearanceSteps);
+
+    await vi.waitFor(() => expect(nextBtn()?.disabled).toBe(true));
+    expect(hint()).toBe('To continue: Choose New Thing');
+
+    document.body.insertAdjacentHTML('beforeend', '<input id="late" />');
+
+    await vi.waitFor(() => expect(popoverTitle()).toBe('The field'));
+    expect(nextBtn()?.disabled).toBe(false);
+    expect(hint()).toBeUndefined();
+  });
+
+  // A step gated with no hint authored still disables the button — the button
+  // must never lie — it simply has nothing to add.
+  it('disables "Next" even when no hint was authored', async () => {
+    startTour([
+      { target: '#one', title: 'Do it', description: 'Create the thing.', advanceOnAction: true },
+      { target: '#two', title: 'Done', description: 'Here it is.' },
+    ]);
+
+    await vi.waitFor(() => expect(nextBtn()?.disabled).toBe(true));
+    expect(hint()).toBeUndefined();
+  });
+
+  // The sync writes to the same attributes its own watch is filtered on, so an
+  // unconditional write would re-trigger it forever. This is the guard for that:
+  // a tour that settles has stopped calling itself.
+  it('settles instead of driving its own observer', async () => {
+    startTour(steps);
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    expect(isActive()).toBe(true);
+    expect(nextBtn()?.disabled).toBe(true);
+    expect(document.querySelectorAll('.tradr-tour-action-hint')).toHaveLength(1);
+    expect(isHeld()).toBe(true);
+  });
+});
+
+/**
  * A STEP HELD ON A CONTROL THAT IS STILL TO COME.
  *
  * The reported defect: the first step of the account set and of the position set

--- a/apps/web/src/features/onboarding/lib/tour-engine.ts
+++ b/apps/web/src/features/onboarding/lib/tour-engine.ts
@@ -24,6 +24,14 @@ import '../tour.css';
 
 /** Consumed by `tour.css`; also the hook a future restyle can hang off. */
 const POPOVER_CLASS = 'tradr-tour';
+/** The hint element's class, styled in `tour.css`. */
+const HINT_CLASS = 'tradr-tour-action-hint';
+/** driver.js's own disabled-button class — `opacity: .5; pointer-events: none`. */
+const DRIVER_BTN_DISABLED_CLASS = 'driver-popover-btn-disabled';
+/** On the popover while the step cannot be advanced by "Next". */
+const HELD_CLASS = 'tradr-tour-held';
+/** Narrower popover, for the one step with no room at the full width. */
+const NARROW_CLASS = 'tradr-tour-narrow';
 
 export type TourStepSide = 'top' | 'right' | 'bottom' | 'left';
 export type TourStepAlign = 'start' | 'center' | 'end';
@@ -108,6 +116,38 @@ export interface TourStep {
    * never end.
    */
   advanceOnAppearanceOf?: string;
+  /**
+   * WHAT THE USER HAS TO DO, said in the imperative, for a step that cannot be
+   * advanced by "Next".
+   *
+   * Shown in the popover only while the step is ACTUALLY held — not whenever it
+   * is authored — because the gate releases on a control the user cannot press
+   * (see `blockOn`), and telling somebody to choose a button that is greyed out
+   * is worse than saying nothing. It is rendered next to a "Next" that has been
+   * disabled for the same reason at the same moment, so the instruction and the
+   * dead control can never disagree.
+   *
+   * Write the gesture and nothing else — "Choose New Account", not "Click the
+   * New Account button to continue". The engine supplies the frame.
+   */
+  actionHint?: string;
+  /**
+   * Render this step's popover narrow (240px rather than 300px).
+   *
+   * FOR A STEP WITH NO ROOM ANY OTHER WAY, and there is exactly one. The close
+   * set opens on "Add Fill", which sits at the bottom right of the position page
+   * and opens a centred dialog. Measured at 1280x720, every placement fails at
+   * the full width: above lands 12px inside the button, below and right leave the
+   * viewport, and to the left a 300px popover reaches x=862 across a dialog that
+   * runs to x=896. Narrowing it is what makes the left side fit — a 240px
+   * popover starts at x=922, clear of the dialog on one side and of the button
+   * on the other.
+   *
+   * Not a general dial. A narrower popover is a taller one, so this trades a
+   * horizontal problem for a vertical one and is worth it only where the
+   * horizontal problem is the unsolvable one.
+   */
+  narrow?: boolean;
 }
 
 export type TourExitReason =
@@ -216,29 +256,135 @@ let exitReason: TourExitReason = 'dismissed';
 /** Why the tour could not carry on, if it could not — see `TourHandlers.onExit`. */
 let blocked: TourBlock | undefined;
 let pendingStopTimer: number | undefined;
-/** Watches for the step's `advanceOnAppearanceOf` control, while one is awaited. */
-let appearanceObserver: MutationObserver | null = null;
+/**
+ * The one DOM watch a running step needs, for the two things that change under
+ * it: an `advanceOnAppearanceOf` control arriving, and the gate opening or
+ * closing beneath a "Next" button that has to look like the answer.
+ */
+let stepObserver: MutationObserver | null = null;
+/** The step `stepObserver` belongs to; `-1` when nothing is watched. */
+let watchedIndex = -1;
 
 function prefersReducedMotion(): boolean {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
   return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
+/**
+ * THE HINT IS PART OF THE DESCRIPTION, AND THAT IS A PLACEMENT FIX, NOT A
+ * STYLISTIC ONE.
+ *
+ * It was originally inserted into the popover after driver.js had rendered it,
+ * which put ~32px of content into a box whose position had already been
+ * computed for the height it had WITHOUT them. The popover then grew downward
+ * past its own placement: measured at 1280x720, the position set's draft step
+ * ended up with its bottom at y=566 across an "Add Fill" button at y=554 — the
+ * tour standing on the control it was telling the user to press. Every tall step
+ * had the same problem to some degree, and moving them one at a time would have
+ * been fixing the symptom on whichever ones happened to be measured.
+ *
+ * Rendered here it is in the DOM before driver.js positions anything, so the
+ * library measures the real height and places the popover correctly with no
+ * repositioning, no post-render mutation, and nothing for a resize to get wrong.
+ *
+ * It is always rendered when the step has one, and HIDDEN by class while the
+ * step is not held (`syncGateAffordance`). Hiding can only make the popover
+ * shorter than the box driver.js placed, and a shorter popover cannot overlap
+ * something the taller one cleared.
+ */
 function toDriveStep(step: TourStep): DriveStep {
   return {
     element: step.target,
     waitForElement: step.waitForMs,
     popover: {
       title: step.title,
-      description: step.description,
+      description:
+        step.actionHint === undefined
+          ? step.description
+          : `${step.description}<p class="${HINT_CLASS}" role="status">To continue: ${escapeHtml(step.actionHint)}</p>`,
       side: step.side,
       align: step.align,
+      // driver.js REPLACES the global `popoverClass` with a step's own, so the
+      // base class has to be repeated here or the step loses every token style.
+      ...(step.narrow === true ? { popoverClass: `${POPOVER_CLASS} ${NARROW_CLASS}` } : {}),
     },
   };
 }
 
 /**
- * Stop waiting for a step's `advanceOnAppearanceOf` control.
+ * Escape the authored hint before it goes into the description's HTML.
+ *
+ * The hint is repo-authored copy today, so this is not defending against a
+ * hostile value — it is making sure the one interpolation in this file cannot
+ * become the place a future hint carrying an apostrophe or an ampersand renders
+ * as broken markup, or worse if the field ever takes a value from elsewhere.
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * MAKE THE POPOVER TELL THE TRUTH ABOUT WHETHER "NEXT" WORKS.
+ *
+ * A gated step ignores "Next" — that is the whole point of an action step — but
+ * the button went on looking pressable, so the honest behaviour read as a broken
+ * one. Reported twice: a live control that does nothing is indistinguishable
+ * from a bug, and users correctly stopped trusting the walkthrough rather than
+ * looking for the action it wanted.
+ *
+ * So the same `isGatedStep` answer that decides whether the press moves the tour
+ * now also decides what the popover looks like. One reading, two consequences:
+ * "Next" is disabled, and the step's `actionHint` appears saying what to do
+ * instead. They cannot come apart, because there is nothing to keep in step —
+ * both are derived here, together, from the one call.
+ *
+ * RUN AGAIN ON EVERY DOM CHANGE, because the gate is not a property of the step:
+ * it is read live, and it releases the moment the highlighted control becomes
+ * unpressable (`blockOn`). The close set reaches exactly that state — a Close
+ * Position button that stays disabled after a partial exit — and a user who was
+ * told to press it, and handed a dead "Next", would have Escape as their only
+ * way on. When the gate lifts, this puts "Next" back and takes the instruction
+ * away in the same pass.
+ */
+function syncGateAffordance(index: number): void {
+  const popover = document.querySelector('.driver-popover');
+  if (!popover) return;
+
+  const held = isGatedStep(index);
+
+  const next = popover.querySelector<HTMLButtonElement>('.driver-popover-next-btn');
+  if (next) {
+    // WRITTEN ONLY WHEN THE VALUE ACTUALLY CHANGES, and that is not a
+    // micro-optimisation — it is what stops this function driving itself. The
+    // watch that calls it filters on `disabled` and `aria-disabled`, and
+    // `setAttribute` queues a mutation record even when the value it writes is
+    // the one already there. Writing unconditionally therefore re-triggers the
+    // observer, which calls this again, forever.
+    if (next.disabled !== held) next.disabled = held;
+    const announced = String(held);
+    if (next.getAttribute('aria-disabled') !== announced) {
+      next.setAttribute('aria-disabled', announced);
+    }
+    // DRIVER.JS'S OWN DISABLED CLASS, not a treatment of ours. It is what the
+    // library already puts on "Previous" at the first step, so a held "Next"
+    // looks like the disabled control the user has been looking at since the
+    // tour opened rather than a second, different idea of disabled.
+    next.classList.toggle(DRIVER_BTN_DISABLED_CLASS, held);
+  }
+
+  // The hint itself is rendered with the description (`toDriveStep`); this only
+  // decides whether it is shown. A class rather than a node, so the popover's
+  // measured height is the one driver.js placed it for, and so this write cannot
+  // reach the watch — `class` is not in its attribute filter.
+  popover.classList.toggle(HELD_CLASS, held);
+}
+
+/**
+ * Stop watching for the step being left.
  *
  * Called from `advance()` and from the teardown, which is EVERY way a step stops
  * being the current one. A watch that outlived its step would advance the tour
@@ -247,9 +393,10 @@ function toDriveStep(step: TourStep): DriveStep {
  * before it was waiting on, so that is a step skipped rather than a theoretical
  * one.
  */
-function disarmAppearanceAdvance(): void {
-  appearanceObserver?.disconnect();
-  appearanceObserver = null;
+function disarmStepWatch(): void {
+  stepObserver?.disconnect();
+  stepObserver = null;
+  watchedIndex = -1;
 }
 
 /**
@@ -265,21 +412,42 @@ function disarmAppearanceAdvance(): void {
  * being portalled in somewhere we do not own. The callback is cheap: one
  * `querySelector` per mutation batch, for as long as one step is on screen.
  */
-function armAppearanceAdvance(index: number): void {
-  disarmAppearanceAdvance();
-  const selector = activeSteps[index]?.advanceOnAppearanceOf;
-  if (selector === undefined) return;
-  if (document.querySelector(selector) !== null) return;
+function armStepWatch(index: number): void {
+  disarmStepWatch();
+  watchedIndex = index;
 
-  appearanceObserver = new MutationObserver(() => {
-    if (document.querySelector(selector) === null) return;
-    // Through `advanceFromUser`, not `advance`, because this IS the user
-    // advancing — they did the thing the step asked for. It is also what gives
-    // the caller its `onBeforeAdvance`, so the move is prepared the same way a
-    // "Next" press would have been.
-    advanceFromUser();
+  // The appearance selector, when this step has one AND it is still to come. A
+  // step whose next control is already on screen is not waiting for anything,
+  // and arming that half would advance it the instant the tour opened.
+  const selector = activeSteps[index]?.advanceOnAppearanceOf;
+  const awaiting =
+    selector !== undefined && document.querySelector(selector) === null ? selector : undefined;
+
+  stepObserver = new MutationObserver(() => {
+    if (watchedIndex !== index) return;
+    if (awaiting !== undefined && document.querySelector(awaiting) !== null) {
+      // Through `advanceFromUser`, not `advance`, because this IS the user
+      // advancing — they did the thing the step asked for. It is also what gives
+      // the caller its `onBeforeAdvance`, so the move is prepared the same way a
+      // "Next" press would have been.
+      advanceFromUser();
+      return;
+    }
+    syncGateAffordance(index);
   });
-  appearanceObserver.observe(document.body, { childList: true, subtree: true });
+
+  // `attributes` as well as `childList`, and filtered to the three the gate
+  // reads: `blockOn` releases on a control that is disabled, so the button going
+  // from enabled to disabled has to reach this watch or "Next" stays dead on a
+  // step the user can no longer act on.
+  stepObserver.observe(document.body, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['disabled', 'aria-disabled', 'data-disabled'],
+  });
+
+  syncGateAffordance(index);
 }
 
 function clearState(): void {
@@ -287,7 +455,7 @@ function clearState(): void {
     window.clearTimeout(pendingStopTimer);
     pendingStopTimer = undefined;
   }
-  disarmAppearanceAdvance();
+  disarmStepWatch();
   window.removeEventListener('keyup', handleKeyup);
   instance = null;
   activeSteps = [];
@@ -440,7 +608,7 @@ function handleKeyup(event: KeyboardEvent): void {
   if (event.key === 'ArrowLeft' && running.hasPreviousStep()) {
     // Going back leaves the step too, so its watch goes with it — the highlight
     // that re-arms is the one for the step being moved to.
-    disarmAppearanceAdvance();
+    disarmStepWatch();
     running.movePrevious();
   }
 }
@@ -522,8 +690,23 @@ const handleHighlightStarted: DriverHook = (element, _driveStep, opts) => {
 
   // Before the caller hears about the step, so a handler that reads the tour's
   // state finds the watch already in place.
-  armAppearanceAdvance(index);
+  armStepWatch(index);
   activeHandlers.onStepChange?.(index, step);
+};
+
+/**
+ * The popover EXISTS as of this hook, and not before it.
+ *
+ * `onHighlightStarted` runs ahead of the render, so the affordance sync armed
+ * there has no popover to write to — the watch would pick it up a microtask
+ * later when the node lands, but that leaves a frame in which "Next" is on
+ * screen still looking pressable on a step that will not move. Syncing here
+ * closes that window: driver.js has finished putting the popover up, so the
+ * button is disabled and the instruction is present the first time either is
+ * painted.
+ */
+const handleHighlighted: DriverHook = (_element, _driveStep, opts) => {
+  syncGateAffordance(opts.index ?? -1);
 };
 
 const handleNextClick: DriverHook = (_element, _driveStep, opts) => {
@@ -610,6 +793,7 @@ export function startTour(steps: TourStep[], handlers: TourHandlers = {}): void 
     disableActiveInteraction: false,
     popoverClass: POPOVER_CLASS,
     onHighlightStarted: handleHighlightStarted,
+    onHighlighted: handleHighlighted,
     onNextClick: handleNextClick,
     onDoneClick: handleDoneClick,
     onCloseClick: handleCloseClick,
@@ -632,7 +816,7 @@ export function advance(): void {
   // The step being left stops being waited for HERE rather than on the next
   // highlight: a step whose target has to be waited for is highlighted long
   // after the move, and the old watch would be live for all of it.
-  disarmAppearanceAdvance();
+  disarmStepWatch();
   if (instance.isLastStep()) {
     exitReason = 'completed';
     stop();

--- a/apps/web/src/features/onboarding/tour.css
+++ b/apps/web/src/features/onboarding/tour.css
@@ -213,8 +213,53 @@ body.driver-active:has([data-slot='dialog-content'][data-state='open'])
   margin-top: 0.25rem;
 }
 
+/* --- The action a held step is waiting for ---------------------------------
+   Shown only while the step genuinely cannot be advanced by "Next", which the
+   engine decides live (tour-engine.ts, `syncGateAffordance`). It reads as an
+   instruction rather than an error: this is the ordinary way an action step
+   moves, not something the user got wrong.
+
+   FOREGROUND, NOT MUTED, and that is the whole point of the rule. The
+   description above it is muted because it is exposition; this line is the one
+   thing on the popover the user has to act on, so it takes the higher-contrast
+   role. The left border carries the same signal without colour doing it alone,
+   which is what keeps it legible to a reader who cannot separate the two. */
+/* See `narrow` in tour-engine.ts: the one step whose anchor has no room for a
+   300px popover on any side. 240px is what lets it sit to the left of "Add Fill"
+   while still clearing the fill dialog centred beside it. */
+.driver-popover.tradr-tour-narrow {
+  max-width: 240px;
+}
+
+/* Rendered with every step that has one, shown only while the step is actually
+   held — the engine toggles `tradr-tour-held` on the popover. It is rendered
+   rather than injected so driver.js measures it before placing the popover; see
+   `toDriveStep` in tour-engine.ts. */
+.driver-popover:not(.tradr-tour-held) .tradr-tour-action-hint {
+  display: none;
+}
+
+.tradr-tour-action-hint {
+  /* TIGHT ON PURPOSE, AND THE NUMBER IS MEASURED. driver.js pins a top-placed
+     popover's TOP and lets it grow downward, so every pixel this block adds is a
+     pixel closer to the control below it. The close set's first step is the
+     binding case: its popover starts at y=386 above an "Add Fill" button at
+     y=554, which leaves 168px, and the step's own text uses 148 of them. */
+  margin-top: 0.25rem;
+  padding-left: 0.625rem;
+  border-left: 2px solid var(--color-primary);
+  color: var(--color-foreground);
+  font-size: var(--text-caption);
+  line-height: var(--text-caption--line-height);
+  font-weight: 500;
+}
+
+/* 0.5rem rather than the 1rem this used to carry. Popovers gained a line when
+   held steps started naming their action, and the footer's generous gap was the
+   cheapest 8px to give back — it costs nothing legible and it buys that height
+   back on EVERY step rather than only the ones that happen to be measured. */
 .driver-popover-footer {
-  margin-top: 1rem;
+  margin-top: 0.5rem;
   gap: 0.5rem;
 }
 
@@ -262,6 +307,13 @@ body.driver-active:has([data-slot='dialog-content'][data-state='open'])
   font-weight: 500;
   cursor: pointer;
 }
+
+/* A HELD STEP'S "NEXT" IS DISABLED, and it borrows driver.js's own
+   `.driver-popover-btn-disabled` (`opacity: .5; pointer-events: none`) rather
+   than getting a treatment of its own — that is the class the library already
+   puts on "Previous" at the first step, so the two disabled controls in this
+   popover look alike. Nothing is needed here; the note is so the absence reads
+   as a decision. See `syncGateAffordance` in tour-engine.ts. */
 
 /* Hover rides the BORDER, not the fill, for the same reason: it is the only
    channel with room to move here (`border` → `muted-foreground` is 3.36 → 7.44

--- a/e2e/tests/user-onboarding.spec.ts
+++ b/e2e/tests/user-onboarding.spec.ts
@@ -111,6 +111,8 @@ const popover = (page: Page): Locator => page.locator('.driver-popover');
 const popoverTitle = (page: Page): Locator => page.locator('.driver-popover-title');
 const popoverNext = (page: Page): Locator => page.locator('.driver-popover-next-btn');
 const popoverProgress = (page: Page): Locator => page.locator('.driver-popover-progress-text');
+/** The instruction a held step shows in place of a working "Next". */
+const popoverHint = (page: Page): Locator => page.locator('.tradr-tour-action-hint');
 
 /**
  * The account set's nine step titles, in order, from
@@ -434,12 +436,17 @@ test.describe('user onboarding', () => {
     await walkAccountSetTo(page, CREATE_STEP);
     await expect(popoverProgress(page)).toHaveText(gatedStep);
 
-    // THE GATE. This step's action — the account actually being created — is one
-    // the app publishes an event for, so the step is genuinely held: pressing
-    // "Next" must leave the tour exactly where it is. Pressed twice, because a
-    // single press racing an advance would pass either way.
-    await popoverNext(page).click();
-    await popoverNext(page).click();
+    // THE GATE, AND WHAT IT NOW LOOKS LIKE. This step's action — the account
+    // actually being created — is one the app publishes an event for, so the
+    // step is genuinely held. It used to be asserted by pressing "Next" twice
+    // and checking nothing moved, which was true and was also the defect: the
+    // button stayed pressable, so honest behaviour read as a broken control.
+    //
+    // The assertion is now the affordance itself. A disabled button cannot be
+    // clicked by Playwright either, so "the press does not move the tour" is
+    // enforced by the DOM rather than checked after the fact.
+    await expect(popoverNext(page)).toBeDisabled();
+    await expect(popoverHint(page)).toHaveText('To continue: Choose Create');
     await expect(popoverTitle(page)).toHaveText('Create the account');
     await expect(popoverProgress(page)).toHaveText(gatedStep);
 
@@ -492,6 +499,7 @@ test.describe('user onboarding', () => {
       first: ACCOUNT_STEP_TITLES[0],
       second: ACCOUNT_STEP_TITLES[1],
       opener: '[data-tour="account-new"]',
+      hint: 'To continue: Choose New Account',
     },
     {
       name: 'the position set',
@@ -506,6 +514,7 @@ test.describe('user onboarding', () => {
       first: POSITION_STEP_TITLES[0],
       second: POSITION_STEP_TITLES[1],
       opener: '[data-tour="position-new"]',
+      hint: 'To continue: Choose New Position',
     },
   ]) {
     test(`${set.name} survives a Next pressed before the dialog is open`, async ({
@@ -515,9 +524,15 @@ test.describe('user onboarding', () => {
       await set.start(page, request);
       await expect(popoverTitle(page)).toHaveText(set.first);
 
-      // The press that was reported. It must move nothing — and, more to the
-      // point, must not commit the tour to a target that is not there.
-      await popoverNext(page).click();
+      // THE PRESS THAT WAS REPORTED IS NO LONGER AVAILABLE. The step is held on
+      // opening the dialog, so "Next" is disabled and the popover says which
+      // control to use instead — the button can no longer be pressed to no
+      // effect, which is what the report was about.
+      await expect(popoverNext(page)).toBeDisabled();
+      await expect(popoverHint(page)).toHaveText(set.hint);
+
+      // And the tour is still there and still on the step, five seconds later:
+      // a held step must not be a step that quietly expires.
       await page.waitForTimeout(5_000);
       await expect(popover(page)).toHaveCount(1);
       await expect(popoverTitle(page)).toHaveText(set.first);


### PR DESCRIPTION
A step that can only be advanced by doing something in the app now says so, and
its "Next" is disabled instead of pressable-but-inert.

Reported as: *"the Next button in the tutorial overlay box remains active and
clickable but does nothing. There needs to be a clearer message that the user
needs to do this action, and the Next button should be deactivated."*

## What changes

| | Before | After |
| --- | --- | --- |
| "Next" on a held step | live, pressed, nothing happened | disabled, with driver.js's own `driver-popover-btn-disabled` styling |
| What to do instead | nothing on screen | **To continue: Choose New Account** |

The instruction and the disabled state come from **the same `isGatedStep` reading
as the press itself**, so they cannot disagree with what pressing would do. Every
authored action step names its gesture, and `steps.test.ts` fails if a new one
does not — plus a second rule keeping hints a bare imperative, since the engine
supplies the "To continue:" frame.

**The gate releasing matters as much as the gate holding.** It lifts when the
highlighted control is one the user *cannot* press — the close set's partial-exit
path, where the tour would otherwise leave Escape as the only way out. A watch
re-runs the same reading on DOM changes, filtered to `disabled` / `aria-disabled`
/ `data-disabled`, so "Next" comes back and the instruction goes away together.

## Two things this took to get right

**The hint is rendered with the description, not injected after.** Injecting it
grew the popover past a position driver.js had already computed for the shorter
box. Measured at 1280x720, the position set's draft step ended up with its bottom
at y=566 across an "Add Fill" button at y=554 — the tour standing on the control
it was telling the user to press, and the reason two e2e tests timed out trying
to click it. Rendered up front, the library measures the real height.

**Every held step is a line taller, so placement was re-measured.** The
`expectPromptClearOfEveryControl` assertion caught all of it, and the fixes are
the ones its comment demands — move the popover, do not narrow the assertion:

- Three steps whose anchor sits at the top right now go beside it rather than
  under it. driver.js's default put them 12px inside the button.
- The footer's `margin-top` drops 1rem → 0.5rem, giving 8px back on *every* step
  rather than only the measured ones.
- The close set's first step renders **narrow** (240px). It is the one anchor
  where no full-width placement clears both states: above lands on the button,
  below and right leave the viewport, and left reaches x=862 across a fill dialog
  running to x=896. At 240px the left side starts at x=922 and clears both. A new
  `narrow` flag carries that, documented as the exception it is rather than a
  general dial.

Two step bodies also lost a redundant sentence, because the instruction they used
to end on is now the hint.

## A loop worth knowing about

The first version of the sync wrote `disabled` and `aria-disabled`
unconditionally. `setAttribute` queues a mutation record even when the value is
unchanged, and those attributes are in the watch's own filter — so it drove
itself, and the unit suite hung instead of failing. It now writes only on an
actual change, and a test asserts the tour settles.

## Verified

523 onboarding unit tests (9 new in the engine, 2 new step-data rules) and all 15
desktop onboarding e2e. `check-types` and `eslint` clean across web and e2e.
Driven in a browser at 1280x720 across all four sets, checking the disabled
state, the instruction, and clearance at each step.
