### PR TITLE
feat(onboarding): keep the welcome view until core setup is done

### DIFF
--- a/apps/web/src/features/onboarding/components/ZeroState.test.tsx
+++ b/apps/web/src/features/onboarding/components/ZeroState.test.tsx
@@ -671,3 +671,89 @@ describe('ZeroState — mobile widths', () => {
     expect(root.outerHTML).not.toMatch(/\bw-\[\d/);
   });
 });
+
+// The welcome view no longer retires on the first account: the dashboard keeps
+// it up until the core steps are done or the user explicitly skips, so this
+// screen now has a second face. These cases pin what that face says and does —
+// the stage rule itself (derived item 1, so demo data cannot flip it) lives in
+// the component.
+describe('ZeroState — the carry-on stage, once the account exists', () => {
+  function accountDoneChecklist() {
+    return deriveChecklist({
+      accountCount: 1,
+      positionsEverCreatedCount: 0,
+      closedPositionCount: 0,
+    });
+  }
+
+  it('swaps the create-stage furniture for the carry-on card', () => {
+    useHook({ checklist: accountDoneChecklist(), preference: preference('active') });
+    render(<ZeroState />);
+
+    expect(screen.getByText('Your account is ready')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Continue the walkthrough' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Skip to my dashboard' })).toBeTruthy();
+    // The create-stage pieces are gone: the account exists, the seeder would
+    // refuse to run beside it, and the not-connected copy has been met.
+    expect(screen.queryByRole('button', { name: 'Create my first account' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Add sample data' })).toBeNull();
+    expect(screen.queryByTestId('zero-state-not-connected')).toBeNull();
+  });
+
+  it("gives the walkthrough the stage's one amber action", () => {
+    useHook({ checklist: accountDoneChecklist(), preference: preference('active') });
+    render(<ZeroState />);
+
+    expect(screen.getByTestId('zero-state-walkthrough').getAttribute('data-variant')).toBe(
+      'default',
+    );
+    expect(screen.getByTestId('zero-state-skip-setup').getAttribute('data-variant')).toBe(
+      'outline',
+    );
+  });
+
+  it('continue records the opt-in and starts the first outstanding set', async () => {
+    const tour = useTour();
+    const hook = useHook({ checklist: accountDoneChecklist(), preference: preference('active') });
+    render(<ZeroState />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Continue the walkthrough' }));
+
+    expect(hook.setStatus).toHaveBeenCalledExactlyOnceWith('active');
+    expect(tour.start).toHaveBeenCalledExactlyOnceWith(undefined);
+  });
+
+  it("skip writes the checklist's own dismissal value, and starts nothing", async () => {
+    const tour = useTour();
+    const hook = useHook({ checklist: accountDoneChecklist(), preference: preference('active') });
+    render(<ZeroState />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Skip to my dashboard' }));
+
+    expect(hook.dismiss).toHaveBeenCalledTimes(1);
+    expect(tour.start).not.toHaveBeenCalled();
+  });
+
+  it('is still no dead end: the checklist and the docs link stay', () => {
+    useHook({ checklist: accountDoneChecklist(), preference: preference('active') });
+    render(<ZeroState />);
+
+    expect(screen.getByTestId('activation-checklist')).toBeTruthy();
+    expect(screen.getByTestId('zero-state-docs-link')).toBeTruthy();
+  });
+
+  it('a failed runtime blocks the walkthrough with its reason, and leaves the skip live', async () => {
+    useTour({ isUnavailable: true });
+    const hook = useHook({ checklist: accountDoneChecklist(), preference: preference('active') });
+    render(<ZeroState />);
+
+    const walkthrough = screen.getByTestId('zero-state-walkthrough');
+    expect(walkthrough.getAttribute('aria-disabled')).toBe('true');
+    expect(screen.getByTestId('zero-state-guidance-note')).toBeTruthy();
+    await userEvent.click(walkthrough);
+    expect(hook.setStatus).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Skip to my dashboard' }));
+    expect(hook.dismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/onboarding/components/ZeroState.tsx
+++ b/apps/web/src/features/onboarding/components/ZeroState.tsx
@@ -1,13 +1,20 @@
-// ZeroState — the screen a newly-registered user lands on instead of six empty
+// ZeroState — the screen a user still setting up sees instead of six empty
 // widgets.
 //
 // WHAT IT REPLACES. `/dashboard` renders six widgets, and for a user with no
-// accounts every one of them is empty and phrases its emptiness differently:
+// data every one of them is empty and phrases its emptiness differently:
 // "Close a position to see stats." / "No open positions. Create one to get
 // started." / "No accounts yet." Each is individually correct and the screen as
 // a whole reads as broken, because nothing on it says which of the six holes to
 // fill first. This component answers that question once, at the top, in the
-// user's words: you need a brokerage account, and here is how to get one.
+// user's words — and it answers it in TWO STAGES, because creating the account
+// does not fill any of the six holes. Until the account exists, the card is
+// about getting one. Once it exists and the core steps (log a position, close
+// it) are still outstanding, the card carries the user forward instead of
+// vanishing into the very grid of empties it exists to replace — with an
+// explicit skip for the user who would rather have the grid anyway. The
+// dashboard route decides WHEN this screen retires (`checklist.coreComplete`,
+// a skip, or sample data); this component only decides what to say meanwhile.
 //
 // WHY NOT `EmptyState`. The shared `EmptyState` is a centred `max-w-md` card
 // with one string description and one action slot, and the zero-state needs two
@@ -27,15 +34,16 @@
 // one — Tradr never places or executes trades. Say it here, once, before the
 // user types a balance into a form and wonders whose money it is.
 //
-// EXACTLY ONE PRIMARY (AMBER) ACTION, AND IT IS "CREATE MY FIRST ACCOUNT".
-// The design system reserves amber for the single action a view is about, and
-// on this view that is the brokerage account: it is the prerequisite that copy
-// names, the only control here that changes the user's data, and the one that
-// makes this whole screen go away. The walkthrough is a way of doing that same
-// thing with help, not a different outcome, so it takes `outline`; sample data
-// is an aside. `ActivationChecklist` deliberately carries no primary action of
-// its own for exactly this reason — the one amber this composed view is allowed
-// lives here.
+// EXACTLY ONE PRIMARY (AMBER) ACTION PER STAGE. The design system reserves
+// amber for the single action a view is about. Before the account exists that
+// is "Create my first account": the prerequisite the copy names, the only
+// control here that changes the user's data. The walkthrough is a way of doing
+// that same thing with help, not a different outcome, so it takes `outline`;
+// sample data is an aside. Once the account exists the view is about carrying
+// on, and the walkthrough — now the only control here that leads anywhere new —
+// takes the amber; the skip is the aside. `ActivationChecklist` deliberately
+// carries no primary action of its own for exactly this reason — the one amber
+// this composed view is allowed lives here.
 //
 // The docs link is a MUTED underlined link, not the app's usual `text-primary`
 // one (ImportPage, Sidebar). Those surfaces have no amber button competing with
@@ -64,6 +72,13 @@
 // than useless — that value is the checklist's OWN dismissal, and spending it
 // on "I would rather click around myself" would take the checklist away from a
 // user who never asked to lose it.
+//
+// THE CARRY-ON STAGE'S SKIP IS THE ONE PLACE THAT DOES WRITE `skipped`, because
+// there it means exactly what the user pressed: stop showing me the setup view.
+// `skipped` is what retires the welcome at the dashboard's gate AND dismisses
+// the checklist, and using the checklist's own value keeps the two exits one
+// state — the "Reopen setup checklist" row on the ordinary dashboard recovers
+// both at once.
 //
 // "WALK ME THROUGH IT" IS BLOCKED RATHER THAN QUEUED WHEN THERE IS NO STEP TO
 // RUN. `start()` returns silently when the checklist names no outstanding item —
@@ -125,13 +140,24 @@ function guidanceGap(
 }
 
 export function ZeroState() {
-  const { setStatus, isSaving, checklist } = useOnboarding();
+  const { setStatus, dismiss, isSaving, checklist } = useOnboarding();
   const { start, canStart, isUnavailable } = useWalkthrough();
   const { seed, isPending: isSeeding } = useDemoAccount();
   const [accountDialogOpen, setAccountDialogOpen] = useState(false);
 
   const guidanceNote = guidanceGap(isUnavailable, checklist);
   const guidedBlocked = guidanceNote !== null;
+
+  // The stage. Before the user's own account exists this is the classic
+  // zero-state; after, it is the carry-on card. Read from the DERIVED checklist
+  // rather than the raw accounts list so the two stages mean what the checklist
+  // means — `selectOwnRows` strips the sample account before item 1 is derived,
+  // so seeded data cannot flip this to "ready". While the checklist is still
+  // loading this reads as the first stage, which is the same face the route's
+  // skeleton gate makes unreachable in practice — the dashboard only mounts
+  // this component once the checklist is known.
+  const hasOwnAccount =
+    checklist?.items.some((item) => item.id === 'account' && item.done) ?? false;
 
   /**
    * Both ways into the walkthrough, and they are the same three lines.
@@ -186,31 +212,42 @@ export function ZeroState() {
     >
       <Card>
         <CardHeader className="px-4 sm:px-6">
-          <h2 className="text-xl leading-none font-semibold">Welcome to Tradr</h2>
+          <h2 className="text-xl leading-none font-semibold">
+            {hasOwnAccount ? 'Your account is ready' : 'Welcome to Tradr'}
+          </h2>
           <CardDescription>
-            Start with a brokerage account. Every position, fill and ledger entry is booked against
-            one, so there is nothing to show on this dashboard until you create it.
+            {hasOwnAccount
+              ? 'Positions come next: log a trade against your account, then close it, and this ' +
+                'dashboard fills in with real numbers. Follow the guided walkthrough, or skip ' +
+                'ahead to the ordinary dashboard whenever you like.'
+              : 'Start with a brokerage account. Every position, fill and ledger entry is booked ' +
+                'against one, so there is nothing to show on this dashboard until you create it.'}
           </CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-4 px-4 sm:px-6">
           {/* The not-connected statement. Both halves, plainly, before the user
-              meets a form asking for a starting balance. */}
-          <p data-testid="zero-state-not-connected" className="text-sm text-muted-foreground">
-            A Tradr account mirrors a real brokerage account: the same currency, the same starting
-            balance, the same trades. It is not connected to your broker. Tradr never places or
-            executes trades — you record trades you have already made.
-          </p>
+              meets a form asking for a starting balance. First stage only: by
+              the second the user has met that form and typed the balance. */}
+          {!hasOwnAccount && (
+            <p data-testid="zero-state-not-connected" className="text-sm text-muted-foreground">
+              A Tradr account mirrors a real brokerage account: the same currency, the same starting
+              balance, the same trades. It is not connected to your broker. Tradr never places or
+              executes trades — you record trades you have already made.
+            </p>
+          )}
 
           {/* Stacked and full-width on a phone, side by side from `sm` up. The
               row wraps rather than shrinking, so no label is ever truncated. */}
           <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
-            <Button
-              data-testid="zero-state-create-account"
-              className="w-full cursor-pointer motion-reduce:transition-none sm:w-auto"
-              onClick={() => setAccountDialogOpen(true)}
-            >
-              Create my first account
-            </Button>
+            {!hasOwnAccount && (
+              <Button
+                data-testid="zero-state-create-account"
+                className="w-full cursor-pointer motion-reduce:transition-none sm:w-auto"
+                onClick={() => setAccountDialogOpen(true)}
+              >
+                Create my first account
+              </Button>
+            )}
             {/* `aria-disabled`, NEVER the `disabled` attribute, whenever the
                 reason is one the user can do something about. `disabled` takes
                 the control out of the tab order, so a keyboard user never meets
@@ -219,9 +256,13 @@ export function ZeroState() {
                 link uses. `disabled` IS still right for `isSaving`, which is a
                 sub-second window with nothing to explain and no choice to lose.
                 Either way the reason is real markup the control points at, the
-                way the sample-data option does. */}
+                way the sample-data option does.
+
+                One control, two stages: outline beside the create button while
+                the account is the view's own action, amber once carrying on IS
+                the view's action — see the one-primary-per-stage note above. */}
             <Button
-              variant="outline"
+              variant={hasOwnAccount ? 'default' : 'outline'}
               data-testid="zero-state-walkthrough"
               className="w-full cursor-pointer motion-reduce:transition-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 sm:w-auto"
               disabled={isSaving}
@@ -231,33 +272,53 @@ export function ZeroState() {
               // optional item id and a click handler is called with an event.
               onClick={() => beginGuided()}
             >
-              Walk me through it
+              {hasOwnAccount ? 'Continue the walkthrough' : 'Walk me through it'}
             </Button>
-            {/* Sample data is offered ALONGSIDE creating a real account, never
-                instead of it, which is why it sits next to the primary action,
-                takes `outline` rather than the amber, and does not replace
-                anything.
-                NO `disabled` ATTRIBUTE ON THIS CONTROL, in flight or otherwise.
-                It spent a phase disabled while the seeder was unbuilt, and a
-                keyboard user never met it: `disabled` removes a control from the
-                tab order, so the option might as well not have existed for them.
-                The in-flight state uses the same focusable `aria-disabled` +
-                stated-reason pattern as the guided fork above. */}
-            <Button
-              variant="outline"
-              data-testid="zero-state-sample-data"
-              className="w-full cursor-pointer motion-reduce:transition-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 sm:w-auto"
-              aria-disabled={isSeeding || undefined}
-              aria-describedby={isSeeding ? SAMPLE_DATA_NOTE_ID : undefined}
-              // The guard, not just the styling — an `aria-disabled` control is
-              // still clickable, which is the price of leaving it reachable.
-              onClick={() => {
-                if (isSeeding) return;
-                seed();
-              }}
-            >
-              Add sample data
-            </Button>
+            {hasOwnAccount ? (
+              /* The explicit way out this view owes the user: the ordinary
+                 dashboard, empty tiles and all. It writes the checklist's own
+                 dismissal value — see the header — so the "Reopen setup
+                 checklist" row on the dashboard recovers it. Plain `disabled`
+                 while the write is in flight, same as the walkthrough button:
+                 a sub-second window with nothing to explain. */
+              <Button
+                variant="outline"
+                data-testid="zero-state-skip-setup"
+                className="w-full cursor-pointer motion-reduce:transition-none sm:w-auto"
+                disabled={isSaving}
+                onClick={() => dismiss()}
+              >
+                Skip to my dashboard
+              </Button>
+            ) : (
+              /* Sample data is offered ALONGSIDE creating a real account, never
+                 instead of it, which is why it sits next to the primary action,
+                 takes `outline` rather than the amber, and does not replace
+                 anything. First stage only: the seeder refuses to run beside an
+                 account of the user's own, so offering it here in the second
+                 stage would be a button that can only explain itself away.
+                 NO `disabled` ATTRIBUTE ON THIS CONTROL, in flight or otherwise.
+                 It spent a phase disabled while the seeder was unbuilt, and a
+                 keyboard user never met it: `disabled` removes a control from the
+                 tab order, so the option might as well not have existed for them.
+                 The in-flight state uses the same focusable `aria-disabled` +
+                 stated-reason pattern as the guided fork above. */
+              <Button
+                variant="outline"
+                data-testid="zero-state-sample-data"
+                className="w-full cursor-pointer motion-reduce:transition-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 sm:w-auto"
+                aria-disabled={isSeeding || undefined}
+                aria-describedby={isSeeding ? SAMPLE_DATA_NOTE_ID : undefined}
+                // The guard, not just the styling — an `aria-disabled` control is
+                // still clickable, which is the price of leaving it reachable.
+                onClick={() => {
+                  if (isSeeding) return;
+                  seed();
+                }}
+              >
+                Add sample data
+              </Button>
+            )}
           </div>
 
           {/* A runtime that will not load is an ordinary outcome, not an

--- a/apps/web/src/features/onboarding/hooks/useWalkthrough.test.ts
+++ b/apps/web/src/features/onboarding/hooks/useWalkthrough.test.ts
@@ -132,7 +132,11 @@ vi.mock('../lib/tour-engine', async (importOriginal) => {
 function aChecklist(...done: ChecklistItemId[]): Checklist {
   const ids: ChecklistItemId[] = ['account', 'calculator', 'position', 'close'];
   const items = ids.map((id) => ({ id, label: id, done: done.includes(id) }));
-  return { items, allComplete: items.every((i) => i.done) };
+  return {
+    items,
+    allComplete: items.every((i) => i.done),
+    coreComplete: (['account', 'position', 'close'] as const).every((id) => done.includes(id)),
+  };
 }
 
 /** Start a walkthrough and wait for the lazy runtime import to settle. */
@@ -886,6 +890,28 @@ describe('useWalkthrough — action-driven advance', () => {
   });
 
   it('navigates nowhere when the next step is on the same screen', async () => {
+    // The close set's add-fill step: its next step (the close button) lives on
+    // the same position page, so the advance must not re-navigate to it — that
+    // would remount the screen under the dialog the user is working in.
+    await start('close', { positionId: 'pos-1' });
+    navigate.mockClear();
+
+    highlight(
+      WALKTHROUGH_STEPS.close.findIndex((s) => s.target === '[data-tour="position-add-fill"]'),
+    );
+    act(() => {
+      eventBus.publish('positions:cache-invalidate', { reason: 'fill-added', positionId: 'pos-1' });
+    });
+
+    expect(engine.advance).toHaveBeenCalledOnce();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  // Creating the account is the account set's one change of screen: the tour
+  // returns the user to the dashboard it recruited them from, so its closing
+  // aside — and the end of the tour — land on the screen the checklist lives
+  // on rather than leaving them parked on the accounts list.
+  it('returns to the dashboard the moment the account is created', async () => {
     await start('account');
     navigate.mockClear();
 
@@ -897,7 +923,12 @@ describe('useWalkthrough — action-driven advance', () => {
     });
 
     expect(engine.advance).toHaveBeenCalledOnce();
-    expect(navigate).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith({ to: '/dashboard' });
+    // Before the tour moves, so the closing step opens over the screen it
+    // describes rather than over the accounts list it just left.
+    expect(navigate.mock.invocationCallOrder[0]).toBeLessThan(
+      engine.advance.mock.invocationCallOrder[0],
+    );
   });
 
   // `/positions` → `/positions/$positionId`, the position set's one change of

--- a/apps/web/src/features/onboarding/lib/analytics.test.ts
+++ b/apps/web/src/features/onboarding/lib/analytics.test.ts
@@ -63,7 +63,11 @@ function aChecklist(...done: ChecklistItemId[]): ChecklistObservation {
   const ids: ChecklistItemId[] = ['account', 'calculator', 'position', 'close'];
   const items = ids.map((id) => ({ id, label: id, done: done.includes(id) }));
   return {
-    checklist: { items, allComplete: items.every((item) => item.done) },
+    checklist: {
+      items,
+      allComplete: items.every((item) => item.done),
+      coreComplete: (['account', 'position', 'close'] as const).every((id) => done.includes(id)),
+    },
     counts: {
       account: done.includes('account') ? 1 : 0,
       position: done.includes('position') ? 1 : 0,

--- a/apps/web/src/features/onboarding/lib/derive-checklist.test.ts
+++ b/apps/web/src/features/onboarding/lib/derive-checklist.test.ts
@@ -118,6 +118,16 @@ describe('deriveChecklist — truth table', () => {
 
     expect(result.items.map((item) => item.done)).toEqual(signals);
     expect(result.allComplete).toBe(allComplete);
+    // The dashboard's welcome-view flag: the three data-creating items, with
+    // the calculator deliberately left out of the conjunction.
+    expect(result.coreComplete).toBe(signals[0] && signals[2] && signals[3]);
+  });
+
+  it('is coreComplete without the calculator — the one aside must not hold the dashboard', () => {
+    const result = deriveChecklist(inputFor([true, false, true, true]));
+
+    expect(result.coreComplete).toBe(true);
+    expect(result.allComplete).toBe(false);
   });
 
   it('covers every combination of the four signals', () => {

--- a/apps/web/src/features/onboarding/lib/derive-checklist.ts
+++ b/apps/web/src/features/onboarding/lib/derive-checklist.ts
@@ -81,6 +81,14 @@ export interface Checklist {
   items: ChecklistItem[];
   /** When this is true the checklist retires. The UI decides how. */
   allComplete: boolean;
+  /**
+   * The three data-creating items — account, position, close — are all done.
+   * The calculator is deliberately not consulted: it creates no data, so an
+   * unused calculator must not keep the dashboard on its welcome view once the
+   * user's journal genuinely has something to show. The dashboard swaps to the
+   * real grid on this; the checklist itself runs on until `allComplete`.
+   */
+  coreComplete: boolean;
 }
 
 /**
@@ -129,5 +137,9 @@ export function deriveChecklist(input: ChecklistInput): Checklist {
   };
   const items: ChecklistItem[] = CHECKLIST_ITEMS.map((item) => ({ ...item, done: done[item.id] }));
 
-  return { items, allComplete: items.every((item) => item.done) };
+  return {
+    items,
+    allComplete: items.every((item) => item.done),
+    coreComplete: done.account && done.position && done.close,
+  };
 }

--- a/apps/web/src/features/onboarding/lib/steps/account.ts
+++ b/apps/web/src/features/onboarding/lib/steps/account.ts
@@ -12,7 +12,12 @@
  * step below is unchanged, and the set now runs for the user who has finished
  * onboarding as well as the one who has not started.
  *
- * No step navigates: the dialog opens over this route, as it did over the other.
+ * Every FIELD step stays on this route: the dialog opens over it, as it did
+ * over the other. The one navigation is the closing aside, which runs on
+ * `/dashboard` — creating the account is what `bindAdvance` observes, so the
+ * move onto the closing step is also the move that puts the user back on the
+ * dashboard they came from, instead of leaving them stranded on the accounts
+ * list once the tour ends.
  *
  * EVERY CLAIM, AND WHERE IT WAS CHECKED:
  * - Booked against an account, mirrors a real brokerage account, never places
@@ -196,18 +201,22 @@ export const accountSteps: readonly WalkthroughStepSource[] = [
       'you can book positions against it straight away.',
   },
   {
-    // No target: the reporting timezone is not a control on this screen, and the
-    // invitation belongs at the point the account is created rather than as a
-    // detour into settings mid-walkthrough. Centred, so it reads as the aside it
-    // is.
-    route: '/accounts',
+    // No target: nothing on the dashboard is being pointed at, and the two
+    // things this step says — you are back where you started, and there is a
+    // second timezone — are asides, so it is centred. The `/dashboard` route is
+    // what returns the user: `bindAdvance` navigates between the submit step
+    // and this one the moment the account exists, so the tour ends on the
+    // screen the checklist lives on rather than leaving the user parked on the
+    // accounts list wondering what to do next.
+    route: '/dashboard',
     docs: 'gettingStarted',
-    title: 'Your reporting timezone',
+    title: 'Back on your dashboard',
     body:
-      'One more zone, and it is a different one. Separately from the account you just made, ' +
-      'Tradr stores a single reporting timezone for you: the zone your P&amp;L is bucketed into ' +
-      'by day, week and month, so those figures stay the same wherever you open Tradr. One was ' +
-      'stored when you registered. Confirm or correct it under Settings → Profile, where it is ' +
-      'shown prefilled with the zone on record.',
+      'Your account is created, and this is your dashboard again — the setup checklist here ' +
+      'names what to do next. One more zone before you go, and it is a different one: separately ' +
+      'from the trading-day timezone you just set, Tradr stores a single reporting timezone for ' +
+      'you — the zone your P&amp;L is bucketed into by day, week and month, so those figures ' +
+      'stay the same wherever you open Tradr. One was stored when you registered. Confirm or ' +
+      'correct it under Settings → Profile, where it is shown prefilled with the zone on record.',
   },
 ];

--- a/apps/web/src/features/onboarding/lib/steps/close.ts
+++ b/apps/web/src/features/onboarding/lib/steps/close.ts
@@ -34,9 +34,14 @@
  *   past rather than a dead end, and its copy says so. Nothing here claims the
  *   position closed: the last step attributes the figures to the exits
  *   recorded, which is true of a partial exit and of a full one alike.
- * - `[data-grid-mode]` is `DashboardGrid`'s own attribute, set on both the
- *   desktop grid and the mobile stack, so the closing step anchors to the
- *   widgets at any width.
+ * - THE CLOSING STEP IS CENTRED, NOT ANCHORED TO THE GRID, and the partial exit
+ *   is why. A full exit completes the last core setup step, so the dashboard
+ *   greets the user with the populated grid; a partial exit leaves item 4
+ *   outstanding, and the dashboard (correctly) still shows the focused welcome
+ *   view — no `[data-grid-mode]` anywhere. A step anchored to the grid waited
+ *   out its `waitForMs` on that path and ended the walkthrough `target-missing`
+ *   one step from the finish. Centred, the aside opens over whichever dashboard
+ *   the user's data has earned, and its copy is written to be true of both.
  */
 
 import type { WalkthroughStepSource } from './index';
@@ -98,15 +103,16 @@ export const closeSteps: readonly WalkthroughStepSource[] = [
       'from Add Fill whenever you close it out.',
   },
   {
-    target: '[data-grid-mode]',
+    // No target — see the header: a partial exit leaves the dashboard on its
+    // welcome view, where the grid this step used to anchor to does not exist.
     route: '/dashboard',
     docs: 'gettingStarted',
-    waitForMs: 5000,
     title: 'And there it is',
     body:
-      'Back on the dashboard, with figures in it. Everything here is derived from the trades you ' +
-      'log — the stats, the equity curve and your account balance all just moved, because each ' +
-      'exit you recorded booked its share of the result as you recorded it. Log the next one and ' +
-      'they move again.',
+      'Back on the dashboard, which builds itself from the trades you log: each exit you ' +
+      'recorded booked its share of the result as you recorded it, so your account balance has ' +
+      'already moved. With the position fully closed, the stats and the equity curve here draw ' +
+      'from your own figures — and if you exited only part of it, they fill in the moment you ' +
+      'close out the rest. Log the next one and they move again.',
   },
 ];

--- a/apps/web/src/routes/_auth.dashboard.test.tsx
+++ b/apps/web/src/routes/_auth.dashboard.test.tsx
@@ -423,11 +423,11 @@ describe('_auth.dashboard route — the zero-state gate', () => {
     expect(screen.queryByText('Your dashboard is empty')).toBeNull();
   });
 
-  it('swaps to the grid with no reload when the first account is created', async () => {
-    // `useCreateAccount` invalidates ['accounts'] and the route observes
-    // ['accounts', 'list'], so a real create produces exactly this data change.
-    // What is pinned here is the route's reaction to it: the SAME mounted tree
-    // re-renders into the grid — nothing is remounted and no reload happens.
+  it('keeps the welcome view when the first account is created, in its carry-on stage', () => {
+    // Creating the account used to swap this screen for the grid — which handed
+    // a brand-new user exactly the six-empty-widgets view the welcome exists to
+    // replace, with two setup steps still outstanding. Now the same mounted
+    // tree re-renders into the welcome's second stage instead.
     layoutMockValue = baseLayout({ data: populated });
     setOnboarding('pending');
     accountsMock = { data: [], isLoading: false, isError: false };
@@ -435,6 +435,44 @@ describe('_auth.dashboard route — the zero-state gate', () => {
     expect(screen.getByTestId('onboarding-zero-state')).toBeTruthy();
 
     accountsMock = { data: oneAccount, isLoading: false, isError: false };
+    setOnboarding('pending', {
+      checklist: deriveChecklist({
+        accountCount: 1,
+        positionsEverCreatedCount: 0,
+        closedPositionCount: 0,
+      }),
+    });
+    rerenderRoute();
+
+    expect(screen.getByTestId('onboarding-zero-state')).toBeTruthy();
+    expect(screen.getByText('Your account is ready')).toBeTruthy();
+    expect(screen.getByTestId('zero-state-skip-setup')).toBeTruthy();
+    expect(container.querySelector('[data-widget-id]')).toBeNull();
+  });
+
+  it('swaps to the grid with no reload once the core steps are done', async () => {
+    // Account made, position logged, position closed: the checklist observer
+    // refetches on the close's invalidation and this is the data change it
+    // hands the route. The calculator being untried must not hold the grid.
+    layoutMockValue = baseLayout({ data: populated });
+    setOnboarding('active', {
+      checklist: deriveChecklist({
+        accountCount: 1,
+        positionsEverCreatedCount: 1,
+        closedPositionCount: 0,
+      }),
+    });
+    accountsMock = { data: oneAccount, isLoading: false, isError: false };
+    const { container, rerenderRoute } = renderRoute();
+    expect(screen.getByTestId('onboarding-zero-state')).toBeTruthy();
+
+    setOnboarding('active', {
+      checklist: deriveChecklist({
+        accountCount: 1,
+        positionsEverCreatedCount: 1,
+        closedPositionCount: 1,
+      }),
+    });
     rerenderRoute();
 
     await waitFor(() => {
@@ -443,13 +481,16 @@ describe('_auth.dashboard route — the zero-state gate', () => {
     expect(screen.queryByTestId('onboarding-zero-state')).toBeNull();
   });
 
-  it('a user who already has an account never sees the zero-state', () => {
-    layoutMockValue = baseLayout({ data: emptyLayout });
+  it('gives a user with sample data the grid, not the welcome view', () => {
+    // The seeder's account completes nothing — the checklist derives from the
+    // user's own rows — but the populated grid is the whole point of asking for
+    // sample data, so the demo flag on the raw accounts list opens the gate.
+    layoutMockValue = baseLayout({ data: populated });
     setOnboarding('pending');
-    accountsMock = { data: oneAccount, isLoading: false, isError: false };
-    renderRoute();
+    accountsMock = { data: [{ id: 'demo-1', isDemo: true }], isLoading: false, isError: false };
+    const { container } = renderRoute();
     expect(screen.queryByTestId('onboarding-zero-state')).toBeNull();
-    expect(screen.getByText('Your dashboard is empty')).toBeTruthy();
+    expect(container.querySelectorAll('[data-widget-id]').length).toBeGreaterThanOrEqual(1);
   });
 
   it('gives a retired user with zero accounts the empty layout, not the zero-state', () => {
@@ -464,18 +505,18 @@ describe('_auth.dashboard route — the zero-state gate', () => {
     expect(screen.getByText('Your dashboard is empty')).toBeTruthy();
   });
 
-  it('still gives a SKIPPED user with zero accounts the zero-state, and with it the reopen control', () => {
-    // The trap this gate is most likely to fall into. Retiring on
-    // `done || skipped` would look harmless — but ActivationChecklist's
-    // "Reopen setup checklist" row is the only way back from a dismissal
-    // anywhere in the product, and the zero-state is the only screen that
-    // mounts the checklist. Gate on `skipped` too and dismissal stops being
-    // recoverable, with nothing in the checklist's own tests to notice.
+  it('gives a SKIPPED user the ordinary dashboard, with the reopen control still reachable', () => {
+    // `skipped` is the explicit exit the welcome view owes the user — the
+    // checklist's dismiss and the welcome card's skip both write it — so it
+    // retires the welcome even with zero accounts. What keeps the dismissal
+    // recoverable is `ChecklistSlot` on the remaining branches: the reopen row
+    // must be on the screen the skip lands the user on.
     layoutMockValue = baseLayout({ data: emptyLayout });
     setOnboarding('skipped', { checklist: null });
     accountsMock = { data: [], isLoading: false, isError: false };
     renderRoute();
-    expect(screen.getByTestId('onboarding-zero-state')).toBeTruthy();
+    expect(screen.queryByTestId('onboarding-zero-state')).toBeNull();
+    expect(screen.getByText('Your dashboard is empty')).toBeTruthy();
     expect(screen.getByTestId('activation-checklist-reopen')).toBeTruthy();
   });
 
@@ -503,7 +544,7 @@ describe('_auth.dashboard route — the zero-state gate', () => {
 
   it('a failed onboarding read falls through to the dashboard instead of parking on the skeleton', () => {
     layoutMockValue = baseLayout({ data: emptyLayout });
-    setOnboarding(undefined);
+    setOnboarding(undefined, { isError: true });
     onboardingQueryMock = { data: undefined, isLoading: false, isError: true };
     accountsMock = { data: [], isLoading: false, isError: false };
     const { container } = renderRoute();
@@ -564,15 +605,24 @@ describe('_auth.dashboard route — the activation checklist beyond the zero-sta
     calculatorFirstUsedAt: '2026-05-01T00:00:00.000Z',
   });
 
-  it('a user with an account and pending onboarding sees the checklist IN the grid, locked top-right', async () => {
+  // Past the welcome view now means past the CORE steps (account, position,
+  // close) — the calculator is the one item that can still be outstanding on
+  // the grid, and the one this mount exists to keep visible.
+  const coreDone = deriveChecklist({
+    accountCount: 1,
+    positionsEverCreatedCount: 1,
+    closedPositionCount: 1,
+  });
+
+  it('a user past the core steps sees the live checklist IN the grid, locked top-right', async () => {
     layoutMockValue = baseLayout({ data: populated });
-    setOnboarding('pending');
+    setOnboarding('active', { checklist: coreDone });
     accountsMock = { data: oneAccount, isLoading: false, isError: false };
     const { container } = renderRoute();
 
     const checklist = screen.getByTestId('activation-checklist');
-    // Items 2-4 are the outstanding work for this user, so they must be on
-    // screen — that is the whole point of mounting past the zero-state.
+    // The calculator is the outstanding work for this user, so the list must
+    // be on screen — that is the whole point of mounting past the welcome.
     expect(screen.getByText('Size a trade in the calculator')).toBeTruthy();
     expect(screen.getByText('Log a position')).toBeTruthy();
     expect(screen.getByText('Close it and see the stats')).toBeTruthy();
@@ -616,7 +666,7 @@ describe('_auth.dashboard route — the activation checklist beyond the zero-sta
 
   it('the empty-layout branch mounts it too, and keeps its own empty state', () => {
     layoutMockValue = baseLayout({ data: emptyLayout });
-    setOnboarding('pending');
+    setOnboarding('active', { checklist: coreDone });
     accountsMock = { data: oneAccount, isLoading: false, isError: false };
     renderRoute();
     expect(screen.getByTestId('activation-checklist')).toBeTruthy();
@@ -681,7 +731,7 @@ describe('_auth.dashboard route — the activation checklist beyond the zero-sta
     // branch is only reachable via a failed read — and there the checklist must
     // occupy no space rather than paint a card an established user then loses.
     layoutMockValue = baseLayout({ data: populated });
-    setOnboarding(undefined);
+    setOnboarding(undefined, { isError: true });
     onboardingQueryMock = { data: undefined, isLoading: false, isError: true };
     accountsMock = { data: oneAccount, isLoading: false, isError: false };
     const { container } = renderRoute();
@@ -715,83 +765,19 @@ describe('_auth.dashboard route — the activation checklist beyond the zero-sta
   });
 });
 
-// ---- The checklist's loading state holds the card's grid item ---------------
+// ---- The checklist's loading state ------------------------------------------
 //
-// `ActivationChecklist` paints a skeleton while its derived reads are in
-// flight. Mounted bare above the widget grid it was once 28px shorter than the
-// card that replaced it, and the whole grid dropped by that much, once per
-// load, for every user still mid-onboarding — the loading-state layout jump the
-// design system forbids. In the grid the geometry is the item's, not the
-// content's, and the skeleton matches the card row for row besides. jsdom
-// computes no layout, so these cases pin what it CAN see: the skeleton mounts
-// in the aside item, and the card then refills that SAME item.
-
-describe('_auth.dashboard route — the checklist skeleton holds the same grid item as the card', () => {
-  const populated = {
-    widgets: sixDefaultWidgets,
-    theme: 'light',
-    updatedAt: '2026-05-01T00:00:00.000Z',
-  };
-  const emptyLayout = { widgets: [], theme: 'light', updatedAt: '2026-05-01T00:00:00.000Z' };
-  const oneAccount = [{ id: 'acct-1' }];
-  const someChecklist = deriveChecklist({
-    accountCount: 1,
-    positionsEverCreatedCount: 0,
-    closedPositionCount: 0,
-  });
-
-  it('mounts the skeleton in the aside slot, and the card refills that same item', async () => {
-    layoutMockValue = baseLayout({ data: populated });
-    // Preference landed, gated reads still in flight: the one window in which
-    // the skeleton is on screen.
-    setOnboarding('pending', { checklist: undefined });
-    accountsMock = { data: oneAccount, isLoading: false, isError: false };
-    const { container, rerenderRoute } = renderRoute();
-
-    await waitFor(() => {
-      expect(asideItem(container)).not.toBeNull();
-    });
-    const slot = asideItem(container)!;
-    expect(slot.contains(screen.getByTestId('activation-checklist-loading'))).toBe(true);
-    expect(slot.gridstackNode).toMatchObject({ x: 8, y: 0, w: 4, h: 6 });
-
-    // The positions read lands and the card replaces the skeleton.
-    setOnboarding('pending', { checklist: someChecklist });
-    rerenderRoute();
-
-    expect(screen.queryByTestId('activation-checklist-loading')).toBeNull();
-    // SAME item — the grid was told nothing changed, so nothing around it moved.
-    const after = asideItem(container)!;
-    expect(after).toBe(slot);
-    expect(after.contains(screen.getByTestId('activation-checklist'))).toBe(true);
-  });
-
-  it('mounts the skeleton on the empty-layout branch too, above the empty state', () => {
-    layoutMockValue = baseLayout({ data: emptyLayout });
-    setOnboarding('pending', { checklist: undefined });
-    accountsMock = { data: oneAccount, isLoading: false, isError: false };
-    renderRoute();
-
-    expect(screen.getByTestId('activation-checklist-loading')).toBeTruthy();
-    // And the branch's own content is unchanged.
-    expect(screen.getByText('Your dashboard is empty')).toBeTruthy();
-  });
-
-  it('does not reintroduce the flash of four unticked boxes', () => {
-    // The slot must not tempt anyone into rendering the card early to fill it.
-    // While the reads are in flight the user sees a skeleton and the four item
-    // labels are nowhere on screen.
-    layoutMockValue = baseLayout({ data: populated });
-    setOnboarding('pending', { checklist: undefined });
-    accountsMock = { data: oneAccount, isLoading: false, isError: false };
-    renderRoute();
-
-    expect(screen.getByTestId('activation-checklist-loading')).toBeTruthy();
-    expect(screen.queryByTestId('activation-checklist')).toBeNull();
-    expect(screen.queryByText('Create a brokerage account')).toBeNull();
-    expect(screen.queryByText('Log a position')).toBeNull();
-  });
-});
+// There USED to be a describe here pinning the checklist's loading skeleton
+// into the grid's aside item, so the card landing did not move the layout. The
+// welcome-view gate made that window unreachable: a `pending`/`active` user
+// whose checklist is still `undefined` now holds the route-level skeleton — the
+// gate cannot tell the welcome view from the grid until the checklist answers —
+// so the grid only ever mounts with the checklist already known. The aside
+// still accepts the `loading` view defensively (`checklistInGrid`), but there
+// is no state the route can be put in that renders it, in the product or here.
+// The no-flash claims those cases guarded live on in "no flash: nothing is
+// rendered when the route falls through with the status still unknown" above
+// and the gate's own skeleton cases.
 
 // ---- The widget coach mark --------------------------------------------------
 //
@@ -822,7 +808,7 @@ describe('_auth.dashboard route — the widget coach mark', () => {
 
   it('appears beside the header on the populated branch', () => {
     layoutMockValue = baseLayout({ data: populated });
-    setOnboarding('pending');
+    setOnboarding('done');
     accountsMock = { data: oneAccount, isLoading: false, isError: false };
     const { container } = renderRoute();
 
@@ -862,7 +848,7 @@ describe('_auth.dashboard route — the widget coach mark', () => {
 
   it('stays off the empty-layout branch, which renders none of the controls it names', () => {
     layoutMockValue = baseLayout({ data: emptyLayout });
-    setOnboarding('pending');
+    setOnboarding('done');
     accountsMock = { data: oneAccount, isLoading: false, isError: false };
     const { container } = renderRoute();
 

--- a/apps/web/src/routes/_auth.dashboard.tsx
+++ b/apps/web/src/routes/_auth.dashboard.tsx
@@ -24,7 +24,7 @@ import {
 } from '@/features/onboarding/components/ActivationChecklist';
 import { CoachMark } from '@/features/onboarding/components/CoachMark';
 import { ZeroState } from '@/features/onboarding/components/ZeroState';
-import { useOnboarding, useOnboardingQuery } from '@/features/onboarding/hooks/useOnboarding';
+import { useOnboarding } from '@/features/onboarding/hooks/useOnboarding';
 import { useWalkthrough } from '@/features/onboarding/hooks/useWalkthrough';
 import type { ChecklistItemId } from '@/features/onboarding/lib/derive-checklist';
 import { useAuth } from '@/hooks/useAuth';
@@ -148,46 +148,52 @@ function DashboardPage(): ReactElement {
   const { data, isLoading, isError, refetch, flushPending, scheduleLayoutWrite } = layout;
 
   // ===========================================================================
-  // THE ZERO-STATE GATE.
+  // THE WELCOME-VIEW GATE.
   //
-  // A user with no accounts gets a screen that tells them what to do instead of
-  // six widgets that are each individually empty for a different reason.
+  // A user still setting up gets a screen that tells them what to do instead of
+  // six widgets that are each individually empty for a different reason — and
+  // they KEEP it until the three data-creating steps are done (account logged,
+  // position logged, position closed: `checklist.coreComplete`), or until they
+  // explicitly skip. Creating the account alone no longer swaps this screen for
+  // the grid: that handed a brand-new user exactly the six-empty-widgets view
+  // the welcome exists to replace, with two setup steps still outstanding.
   //
-  // THE CHEAP READ FOR THE GATE. `useOnboardingQuery` is the preference read on
-  // its own; the gate below needs only the stored status, and needs it before
-  // anything else. (The full `useOnboarding` hook is read further down for the
-  // checklist's own view — see there.) The accounts list is the one the
-  // dashboard already needs:
+  // THE GATE READS THE FULL `useOnboarding` HOOK, which the route already
+  // mounts for the checklist's view below, so this costs no extra request: the
+  // positions read it derives `coreComplete` from is the same gated read the
+  // checklist needs, live for exactly the `pending`/`active` users this gate
+  // can apply to. The accounts list is also one the dashboard already needs:
   // `account-balances` is one of the six default widgets and calls `useAccounts`
   // itself, so hoisting the same `['accounts', 'list']` query up here shares one
-  // request with it rather than adding a second (Performance NFR).
+  // request with it rather than adding a second (Performance NFR). It is read
+  // raw — demo rows included — because sample data is the one thing that swaps
+  // this screen for the populated grid without completing anything.
+  //
+  // `skipped` RETIRES THE WELCOME VIEW NOW. It is the explicit way out this
+  // gate owes the user: the checklist's dismiss and the welcome card's skip
+  // both write it, and a skipped user gets the ordinary dashboard — empty tiles
+  // and all — with the "Reopen setup checklist" row `ChecklistSlot` renders on
+  // both remaining branches, so the dismissal stays recoverable from here.
   //
   // `enabled: !onboardingRetired` is TRUE on the first render, because the
   // status is unknown until the preference read lands. That is deliberate: the
   // accounts fetch goes out in parallel with the preference and the layout
   // reads rather than waiting a round trip behind one of them. Once the status
-  // comes back `done` the observer switches off — and by then the response has
+  // comes back retired the observer switches off — and by then the response has
   // usually already landed in the cache, where the balances widget picks it up
   // for free. Nothing here is a new blocking request on first paint.
   // ===========================================================================
-  const onboardingQuery = useOnboardingQuery();
-  const preference = onboardingQuery.data;
-  // `done` ONLY. `skipped` is a dismissal of the CHECKLIST, not of
-  // onboarding: a skipped user with no accounts still has nothing to look at,
-  // and the zero-state is where `ActivationChecklist` — hence the product's only
-  // "Reopen setup checklist" control — is mounted. Retiring on `skipped` would
-  // delete that control from the product and make dismissal unrecoverable.
-  const onboardingRetired = preference?.status === 'done';
+  const onboarding = useOnboarding();
+  const preference = onboarding.preference;
+  const onboardingRetired = preference?.status === 'done' || preference?.status === 'skipped';
   const accountsQuery = useAccounts({ enabled: !onboardingRetired });
   const accounts = accountsQuery.data;
 
   // WHETHER THE CHECKLIST IS ON SCREEN, decided once here rather than left to
   // the component, because on the populated branch it is a grid item and the
   // grid has to be told to make room before anything renders. The rules stay in
-  // `resolveChecklistView`; this only reads the answer. The full hook is the
-  // one the checklist itself reads — its two gated reads are shared with that
-  // mount and switched off for a retired user, so this adds no request.
-  const checklistView = resolveChecklistView(useOnboarding());
+  // `resolveChecklistView`; this only reads the answer.
+  const checklistView = resolveChecklistView(onboarding);
   const checklistInGrid = checklistView === 'card' || checklistView === 'loading';
 
   // beforeunload: flush any pending debounced PUT (Req 1.9).
@@ -338,34 +344,37 @@ function DashboardPage(): ReactElement {
     );
   }
 
-  // Zero state — takes precedence over the empty layout below, and sits behind
-  // isLoading/isError so neither of those branches changes.
+  // Welcome view — takes precedence over the empty layout below, and sits
+  // behind isLoading/isError so neither of those branches changes.
   //
-  // NO FLASH IN EITHER DIRECTION, which is the whole reason this is three
-  // conditions and not one. Deciding early would be wrong both ways: `accounts`
-  // is `undefined` before it lands, so `accounts?.length === 0` would show the
-  // zero-state to every established user for a beat; and falling through while
-  // the status is unknown would show the widget grid to a brand-new user for a
-  // beat. So the route stays on the skeleton it is ALREADY showing until both
-  // reads have answered, and only then picks a side. Same component as the
-  // isLoading branch, so the wait is invisible — the screen does not change
-  // twice.
+  // NO FLASH IN EITHER DIRECTION, which is the whole reason this waits on every
+  // read it consults. Deciding early would be wrong both ways: `checklist` is
+  // `undefined` before its reads land, so falling through would show the widget
+  // grid to a brand-new user for a beat, and treating "unknown" as "incomplete"
+  // would show the welcome to an established user for one. So the route stays
+  // on the skeleton it is ALREADY showing until the answer is known, and only
+  // then picks a side. Same component as the isLoading branch, so the wait is
+  // invisible — the screen does not change twice.
   //
   // A FAILED READ FALLS THROUGH rather than parking on the skeleton forever.
   // Onboarding is presentation over data the dashboard owns anyway; if we cannot
   // tell whether this user is new, the right answer is the dashboard they asked
   // for, not a spinner.
-  if (!onboardingQuery.isError && !accountsQuery.isError && !onboardingRetired) {
-    if (preference === undefined || accounts === undefined) {
+  if (!onboarding.isError && !accountsQuery.isError && !onboardingRetired) {
+    if (preference === undefined || accounts === undefined || onboarding.checklist === undefined) {
       return <DashboardSkeleton />;
     }
-    // Leaving this screen on the first account needs nothing extra:
-    // `useCreateAccount` invalidates ['accounts'], this observer refetches, and
-    // the next render falls through to the grid — no reload, no manual swap.
-    if (accounts.length === 0) {
+    // Leaving this screen needs nothing extra: closing the first position
+    // invalidates ['positions'], the checklist observer refetches, and the next
+    // render falls through to the grid — no reload, no manual swap. Sample data
+    // is the other door: the seeder's account arrives on ['accounts'] with
+    // `isDemo`, and the populated grid (with the demo banner) is the whole
+    // point of asking for it, so it must not be trapped behind the welcome.
+    const hasDemoAccount = accounts.some((account) => account.isDemo);
+    if (onboarding.checklist !== null && !onboarding.checklist.coreComplete && !hasDemoAccount) {
       return (
         <>
-          {/* The header grammar covers the zero state too — without it a
+          {/* The header grammar covers the welcome view too — without it a
               fresh user would be the one person with no drawer opener. */}
           <PageHeader page="Dashboard" />
           <ZeroState />
@@ -377,16 +386,15 @@ function DashboardPage(): ReactElement {
   // ===========================================================================
   // THE CHECKLIST'S HOME ON EVERY OTHER PATH.
   //
-  // `ZeroState` composes `ActivationChecklist` itself, so the zero-state branch
-  // above needs nothing — and must not double-mount it. But the zero-state is
-  // the ONLY screen the checklist had, and a user leaves it the instant they
-  // create their first account. That is precisely when items 2-4 (size a trade,
-  // log a position, close it) become the outstanding work, when the "Reopen
-  // setup checklist" row that keeps a dismissal recoverable would otherwise be
-  // unreachable, and when the retirement that fires on the fourth completed
-  // item — which is what finally switches `useOnboarding`'s two expensive gated
-  // reads off for good — would never get a chance to fire. So both remaining
-  // branches mount it.
+  // `ZeroState` composes `ActivationChecklist` itself, so the welcome branch
+  // above needs nothing — and must not double-mount it. But a user reaches
+  // these branches with the checklist possibly still live: skipping, adding
+  // sample data, and finishing the three core steps with the calculator still
+  // untried all land here before the checklist is done. This is where the
+  // "Reopen setup checklist" row that keeps a dismissal recoverable lives, and
+  // where the retirement that fires on the fourth completed item — which is
+  // what finally switches `useOnboarding`'s two expensive gated reads off for
+  // good — gets its chance to fire. So both remaining branches mount it.
   //
   // ON THE POPULATED BRANCH IT IS A GRID ITEM. A card above the grid stretched
   // four short rows across the whole content width, with each row's play button

--- a/e2e/tests/dashboard-event-bus.spec.ts
+++ b/e2e/tests/dashboard-event-bus.spec.ts
@@ -166,6 +166,13 @@ test.describe('Dashboard — cross-tab close-position event bus', () => {
     // position belong to this user (the isolated context is authenticated by
     // register), and loginViaUi below logs the browser in as the SAME user.
     const user = await registerUser(request, 'crosstab');
+    // An established user, not an onboarding one: the dashboard keeps its
+    // focused welcome view until onboarding is done or skipped, and this test
+    // is about the grid's cross-tab refetch behaviour.
+    const onboardingRes = await request.patch('/api/users/me/onboarding', {
+      data: { status: 'done' },
+    });
+    expect(onboardingRes.status(), 'PATCH onboarding').toBe(200);
     const account = await createAccount(request, 'USD Account', 'USD');
     const { positionId } = await createOpenPosition(request, account.id);
 

--- a/e2e/tests/user-onboarding.spec.ts
+++ b/e2e/tests/user-onboarding.spec.ts
@@ -767,11 +767,13 @@ test.describe('user onboarding', () => {
 
     // THE ASSERTION. "Next" is live, because the gate behind it cannot be
     // opened — and it carries the user to the last step, on the dashboard,
-    // exactly as the full exit does.
+    // exactly as the full exit does. With item 4 honestly still outstanding,
+    // that dashboard is the welcome view, not the grid — which is why the
+    // closing aside is centred rather than anchored to `[data-grid-mode]`.
     await popoverNext(page).click();
     await expect(popoverTitle(page)).toHaveText(CLOSE_STEP_TITLES[2]);
     await expect(page).toHaveURL(/\/dashboard/);
-    await expect(page.locator('[data-grid-mode]')).toBeVisible();
+    await expect(page.getByTestId('onboarding-zero-state')).toBeVisible();
 
     await popoverNext(page).click();
     await expect(popover(page)).toHaveCount(0);

--- a/e2e/tests/user-onboarding.spec.ts
+++ b/e2e/tests/user-onboarding.spec.ts
@@ -129,7 +129,7 @@ const ACCOUNT_STEP_TITLES = [
   'Default risk %',
   'Brokerage',
   'Create the account',
-  'Your reporting timezone',
+  'Back on your dashboard',
 ] as const;
 
 /** Index of the one step in the account set that is genuinely action-gated. */
@@ -466,24 +466,25 @@ test.describe('user onboarding', () => {
     await expect(popoverTitle(page)).toHaveText('Create the account');
     await expect(popoverProgress(page)).toHaveText(gatedStep);
 
-    // Doing the thing is what advances it.
+    // Doing the thing is what advances it — and the advance is also the set's
+    // one navigation: the tour returns the user to the dashboard it recruited
+    // them from, so the closing aside opens over the screen the checklist
+    // lives on.
     await createAccountFromDialog(page, 'Guided account');
     await expect(popoverTitle(page)).toHaveText(ACCOUNT_STEP_TITLES[CREATE_STEP + 1]);
+    await expect(page).toHaveURL(/\/dashboard/);
     // The last step of the set, which no `advanceTo` reaches: the tour gets
     // here on the account being created, not on a press.
     await expectStepClear(page, `account step ${ACCOUNT_STEP_TITLES.length}, the closing aside`);
 
-    // Finish, on the Accounts page the set runs on, with the account the user
-    // just made listed behind it.
+    // Finish. The welcome view carries on — its carry-on stage, not the grid
+    // of empty widgets creating an account used to swap in — with item 1
+    // ticked off the user's real data, no flag written.
     await popoverNext(page).click();
     await expect(popover(page)).toHaveCount(0);
-    await expect(page.getByRole('cell', { name: 'Guided account' })).toBeVisible();
-
-    // And the dashboard has swapped to the grid, off the account that now
-    // exists. Item 1 ticked itself off the user's real data, no flag written.
-    await page.goto('/dashboard');
-    await expect(page.getByTestId('onboarding-zero-state')).toHaveCount(0);
-    await expect(page.locator('[data-widget-type]').first()).toBeVisible();
+    await expect(page.getByTestId('onboarding-zero-state')).toBeVisible();
+    await expect(page.getByText('Your account is ready')).toBeVisible();
+    await expect(page.locator('[data-widget-type]')).toHaveCount(0);
     await expect(checklistProgress(page)).toHaveText('1 of 4 complete');
     await expect(checklistItemLabel(page, 'account')).toHaveText(/— completed$/);
   });
@@ -854,8 +855,9 @@ test.describe('user onboarding', () => {
     // nothing the tour does may take it away.
     await walkAccountSetTo(page, CREATE_STEP);
     await createAccountFromDialog(page, 'Exit account');
+    // The create carried the tour — and the user — back onto the dashboard.
     await expect(popoverTitle(page)).toHaveText(ACCOUNT_STEP_TITLES[CREATE_STEP + 1]);
-    await expect(page.getByRole('cell', { name: 'Exit account' })).toBeVisible();
+    await expect(page).toHaveURL(/\/dashboard/);
 
     // Escape — one action, and the tour is abandoned rather than completed.
     await escapeTour(page);
@@ -865,12 +867,14 @@ test.describe('user onboarding', () => {
     expect(accounts.map((account) => account.name)).toEqual(['Exit account']);
 
     // The checklist counted it, on the screen the checklist lives on, and still
-    // does after a reload: an abandoned walkthrough rolls nothing back.
-    await page.goto('/dashboard');
+    // does after a reload: an abandoned walkthrough rolls nothing back. The
+    // welcome view is what the reload comes back to — the account alone no
+    // longer swaps in the grid.
     await expect(checklistProgress(page)).toHaveText('1 of 4 complete');
     await page.reload();
-    await expect(page.locator('[data-widget-type]').first()).toBeVisible();
+    await expect(page.getByTestId('onboarding-zero-state')).toBeVisible();
     await expect(checklistProgress(page)).toHaveText('1 of 4 complete');
+    await expect(checklistItemLabel(page, 'account')).toHaveText(/— completed$/);
   });
 
   // RESUMING ONTO A LATER SET, DRIVEN THE WAY A USER WOULD DRIVE IT. This
@@ -892,9 +896,10 @@ test.describe('user onboarding', () => {
     await createAccount(request, 'Resume account');
     await loginViaUi(page, email);
 
-    // Past the zero-state, on the populated dashboard, with the checklist as the
-    // only way into a walkthrough — the state this whole test is about.
-    await expect(page.getByTestId('onboarding-zero-state')).toHaveCount(0);
+    // On the welcome view's carry-on stage — an account, nothing else — with
+    // the checklist's per-item buttons as the way into a walkthrough: the
+    // state this whole test is about.
+    await expect(page.getByTestId('onboarding-zero-state')).toBeVisible();
     await expect(checklistProgress(page)).toHaveText('1 of 4 complete');
 
     // Start a set OTHER than the first, off the checklist, so "where the user
@@ -1117,13 +1122,27 @@ test.describe('user onboarding', () => {
   test('no coach mark stands on a control the user can press', async ({ page, request }) => {
     const email = await registerUser(request, 'markclear');
     const accountId = await createAccount(request, 'Mark account');
-    // An open position, so the dashboard has widgets to arrange (the mark's own
-    // gate) and the position detail has an Add Fill for its mark to describe.
+    // An open position, so the position detail has an Add Fill for its mark to
+    // describe.
     const positionId = await createOpenPosition(request, accountId);
+    // And a CLOSED one, so the core setup steps read complete and the dashboard
+    // shows the grid the mark describes — the welcome view otherwise holds the
+    // screen, and mounts none of the widgets the mark is about.
+    const closedId = await createOpenPosition(request, accountId);
+    const exitRes = await request.post(`/api/positions/${closedId}/fills`, {
+      data: {
+        type: 'exit',
+        price: '160.00',
+        quantity: '10',
+        fees: '0',
+        filledAt: '2026-05-02T14:30:00.000Z',
+      },
+    });
+    expect(exitRes.status(), 'POST exit fill (auto-closes the position)').toBe(201);
     await loginViaUi(page, email);
 
     // The dashboard, with the checklist up — the mark and the checklist share
-    // this screen for every user who has not finished setting up.
+    // this screen for every user whose calculator item is still outstanding.
     await expect(page.getByTestId('activation-checklist')).toBeVisible();
     await expect(page.getByTestId('coach-mark-dashboard-widgets')).toBeVisible();
     await expectMarkClear(page, 'the dashboard-widgets coach mark, checklist on screen');

--- a/e2e/tests/visual-design-parity.spec.ts
+++ b/e2e/tests/visual-design-parity.spec.ts
@@ -321,6 +321,13 @@ test.describe('visual-design parity smoke', () => {
     });
     expect(accountRes.status(), 'POST /accounts').toBe(201);
     accountId = ((await accountRes.json()) as { id: string }).id;
+    // An established user, not an onboarding one: the dashboard keeps its
+    // focused welcome view until onboarding is done or skipped, and both cases
+    // below are about the populated grid.
+    const onboardingRes = await request.patch('/api/users/me/onboarding', {
+      data: { status: 'done' },
+    });
+    expect(onboardingRes.status(), 'PATCH onboarding').toBe(200);
   });
 
   test.beforeEach(async ({ page }) => {

--- a/e2e/tests/visual-design-reference.spec.ts
+++ b/e2e/tests/visual-design-reference.spec.ts
@@ -164,6 +164,13 @@ test.describe('visual-design pre-migration reference', () => {
     });
     expect(accountRes.status(), 'POST /accounts').toBe(201);
     const account = (await accountRes.json()) as { id: string };
+    // An established user, not an onboarding one: the dashboard keeps its
+    // focused welcome view until onboarding is done or skipped, and the
+    // dashboard captures here are of the populated grid.
+    const onboardingRes = await page.request.patch('/api/users/me/onboarding', {
+      data: { status: 'done' },
+    });
+    expect(onboardingRes.status(), 'PATCH onboarding').toBe(200);
 
     const posRes = await page.request.post('/api/positions', {
       data: { accountId: account.id, symbol: 'AAPL', side: 'long', assetType: 'stock' },


### PR DESCRIPTION
## What

Two continuity fixes for the guided setup:

- **The account walkthrough returns the user to the dashboard.** The set's closing aside now runs on `/dashboard`, and the walkthrough's own between-step navigation carries the user there the moment the account is created — the tour no longer ends by stranding them on the accounts list.
- **The dashboard keeps its focused welcome view until setup is genuinely done.** The welcome card + checklist stay up until the three data-creating steps (create an account, log a position, close it) are complete, or the user explicitly exits (checklist dismiss ✕, or the new **Skip to my dashboard** button). Creating the account alone no longer dumps the user onto six empty widgets. The welcome card gets a second stage once the account exists ("Your account is ready", continue + skip actions).

Preserved behaviors: sample data still swaps in the populated grid (and completes nothing); the calculator item never gates the dashboard; `skipped` now retires the welcome for good, with the reopen row on the ordinary dashboard keeping dismissal recoverable.

## How

- `deriveChecklist` gains `coreComplete` (account + position + close, calculator excluded) — the rule stays stated once.
- The `_auth.dashboard.tsx` gate reads the full `useOnboarding` result (no extra requests: the same gated reads the checklist already makes) and holds the skeleton until the answer is known — no flash either way.
- `ZeroState` becomes stage-aware off the derived checklist (demo data cannot flip it).

## Tests

- 561 unit/component tests green across `features/onboarding` + the dashboard route suite (new: coreComplete truth-table column, carry-on stage suite, rewritten gate cases).
- e2e `user-onboarding.spec.ts` reworked for the new endings; three other specs' fixture users now retire onboarding via `PATCH /users/me/onboarding` (they test widgets/theme/event-bus, not onboarding).
- `tsc` (web + e2e) and `eslint` clean.