### PR TITLE
feat(onboarding): move focus with the walkthrough's field steps

### DIFF
--- a/apps/web/src/features/onboarding/lib/tour-engine.test.ts
+++ b/apps/web/src/features/onboarding/lib/tour-engine.test.ts
@@ -559,6 +559,96 @@ describe('keyboard control', () => {
   });
 });
 
+/**
+ * FOCUS FOLLOWS THE TOUR ONTO A FIELD THE USER IS ASKED TO TYPE IN.
+ *
+ * The account set highlights `#name`, then `#startingBalance`, and the caret
+ * used to stay wherever the user last clicked — the popover moved, the typing
+ * did not. A text-entry target now takes focus when its step is highlighted
+ * (after driver.js has focused the popover's own button, so this write wins),
+ * and the arrows pressed IN that field belong to the caret, not the tour.
+ */
+describe('focus follows a text-entry step', () => {
+  const fieldSteps: TourStep[] = [
+    { target: '#field', title: 'The field', description: 'Type here.' },
+    { target: '#two', title: 'Second', description: 'The second control.' },
+  ];
+
+  function mountField(markup: string): void {
+    document.body.innerHTML = `${markup}<button id="two">two</button>`;
+  }
+
+  it('moves focus into a highlighted text input', async () => {
+    mountField('<input id="field" />');
+    startTour(fieldSteps);
+
+    await vi.waitFor(() => expect(document.activeElement?.id).toBe('field'));
+  });
+
+  it('selects a prefilled value so typing replaces it', async () => {
+    mountField('<input id="field" value="0" />');
+    startTour(fieldSteps);
+
+    const field = document.querySelector<HTMLInputElement>('#field')!;
+    await vi.waitFor(() => expect(document.activeElement).toBe(field));
+    expect(field.selectionStart).toBe(0);
+    expect(field.selectionEnd).toBe(1);
+  });
+
+  it('does not move focus onto a button target', async () => {
+    // The default harness: both targets are buttons.
+    startTour(TWO_STEPS);
+    await new Promise((resolve) => setTimeout(resolve, 40));
+
+    expect(document.activeElement?.id).not.toBe('one');
+  });
+
+  it('leaves a disabled field alone', async () => {
+    mountField('<input id="field" disabled />');
+    startTour(fieldSteps);
+    await new Promise((resolve) => setTimeout(resolve, 40));
+
+    expect(document.activeElement?.id).not.toBe('field');
+  });
+
+  it('keeps an arrow pressed in the field as caret movement, not navigation', async () => {
+    mountField('<input id="field" />');
+    startTour(fieldSteps);
+    const field = document.querySelector<HTMLInputElement>('#field')!;
+    await vi.waitFor(() => expect(document.activeElement).toBe(field));
+
+    field.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowRight', bubbles: true }));
+    field.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowLeft', bubbles: true }));
+
+    expect(popoverTitle()).toBe('The field');
+  });
+
+  it('still advances on an arrow pressed outside the field', async () => {
+    mountField('<input id="field" />');
+    startTour(fieldSteps);
+    await vi.waitFor(() => expect(document.activeElement?.id).toBe('field'));
+
+    // Focus back on the page body, as after a click somewhere neutral: the
+    // press does not originate from a text-entry control, so it navigates.
+    (document.activeElement as HTMLElement).blur();
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowRight', bubbles: true }));
+
+    expect(popoverTitle()).toBe('Second');
+  });
+
+  it('still exits on Escape pressed in the field', async () => {
+    mountField('<input id="field" />');
+    const onExit = vi.fn();
+    startTour(fieldSteps, { onExit });
+    const field = document.querySelector<HTMLInputElement>('#field')!;
+    await vi.waitFor(() => expect(document.activeElement).toBe(field));
+
+    field.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape', bubbles: true }));
+
+    expect(onExit).toHaveBeenCalledExactlyOnceWith('dismissed', undefined);
+  });
+});
+
 describe('exiting', () => {
   it('reports a dismissal from the close button', () => {
     const onExit = vi.fn();

--- a/apps/web/src/features/onboarding/lib/tour-engine.ts
+++ b/apps/web/src/features/onboarding/lib/tour-engine.ts
@@ -545,6 +545,78 @@ function isGatedStep(index: number): boolean {
 }
 
 /**
+ * The input types a caret cannot live in. Everything else an `<input>` renders
+ * is something the user types into — text, number, search, email and the rest —
+ * and the two behaviours below treat "typed into" as one question with one
+ * answer.
+ */
+const NON_TEXT_INPUT_TYPES = new Set([
+  'button',
+  'checkbox',
+  'color',
+  'file',
+  'hidden',
+  'image',
+  'radio',
+  'range',
+  'reset',
+  'submit',
+]);
+
+/**
+ * A CONTROL THE USER TYPES IN — one predicate for two decisions that must not
+ * come apart: which highlighted target the tour moves the caret into
+ * (`focusStepTarget`), and which focused element's arrow keys belong to the
+ * caret rather than the tour (`handleKeyup`). Deciding them separately is how
+ * the tour could put focus somewhere and then fight the user for the keys.
+ *
+ * Buttons, radios, checkboxes and Radix's trigger buttons are deliberately NOT
+ * here: focusing them invites Enter and arrow presses the step never asked for.
+ */
+function isTextEntry(element: Element): boolean {
+  if (element instanceof HTMLTextAreaElement) return true;
+  if (element instanceof HTMLInputElement) return !NON_TEXT_INPUT_TYPES.has(element.type);
+  return element instanceof HTMLElement && element.matches('[contenteditable="true"]');
+}
+
+/**
+ * MOVE THE CARET WHERE THE TOUR IS POINTING — for a step highlighting a field
+ * the user is being asked to type into, and for nothing else.
+ *
+ * The reported gap: the account set walks `#name`, then the selects, then
+ * `#startingBalance`, and a user whose last click was the name field is still
+ * typing THERE when the tour says "initial balance". The popover's copy moved;
+ * the caret did not. So a text-entry target takes focus when highlighted, and a
+ * prefilled value is selected so typing replaces it — "0" in a balance field
+ * must not become "01000" for a user doing exactly what the step asked.
+ *
+ * Called from `handleHighlighted`, which is AFTER driver.js has rendered the
+ * popover and focused its own first button — the only ordering that lets this
+ * write win. driver.js's Tab trap already cycles between the popover and the
+ * highlighted element, so focus starting in the field stays inside the trap.
+ *
+ * Skipped for a control that is disabled or gone — a caret in a dead field is
+ * an instruction to type into something that will not take it.
+ */
+function focusStepTarget(index: number): void {
+  const target = activeSteps[index]?.target;
+  if (target === undefined) return;
+
+  const element = document.querySelector(target);
+  if (element === null || !isTextEntry(element)) return;
+  if (element.matches(':disabled, [aria-disabled="true"], [data-disabled]')) return;
+  if (element === document.activeElement) return;
+
+  (element as HTMLElement).focus();
+  if (
+    (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) &&
+    element.value !== ''
+  ) {
+    element.select();
+  }
+}
+
+/**
  * Classify the step the user left from, so the ending can be explained rather
  * than merely happening.
  *
@@ -584,9 +656,11 @@ function recordBlock(index: number): void {
  * do, so the two paths cannot drift: the gate is `isGatedStep`, advancing is
  * `advanceFromUser()`, and exiting is `stop()`. `keyup` rather than `keydown` matches
  * what driver.js listened for, so holding a key still moves one step rather than
- * racing through the set. Nothing filters by event target, also as before: the
- * highlighted control is interactive (`disableActiveInteraction: false`) and a
- * user typing in it was already moving the tour with the arrow keys.
+ * racing through the set. THE ARROWS are filtered by event target, and only
+ * the arrows: the engine itself moves focus into a text-entry target
+ * (`focusStepTarget`), so a caret move in the very field a step asked the user
+ * to fill must not double as tour navigation. Escape is not filtered — it ends
+ * the tour from anywhere, exactly as before.
  */
 function handleKeyup(event: KeyboardEvent): void {
   const running = instance;
@@ -598,6 +672,8 @@ function handleKeyup(event: KeyboardEvent): void {
     stop();
     return;
   }
+  // Arrows in a field are the caret's, not the tour's — see the comment above.
+  if (event.target instanceof Element && isTextEntry(event.target)) return;
   if (event.key === 'ArrowRight') {
     if (isGatedStep(running.getActiveIndex() ?? -1)) return;
     advanceFromUser();
@@ -704,9 +780,15 @@ const handleHighlightStarted: DriverHook = (element, _driveStep, opts) => {
  * closes that window: driver.js has finished putting the popover up, so the
  * button is disabled and the instruction is present the first time either is
  * painted.
+ *
+ * The render this hook follows is also where driver.js focuses the popover's
+ * own first button, which is why the caret move comes here and last: it is the
+ * final write, so the field wins.
  */
 const handleHighlighted: DriverHook = (_element, _driveStep, opts) => {
-  syncGateAffordance(opts.index ?? -1);
+  const index = opts.index ?? -1;
+  syncGateAffordance(index);
+  focusStepTarget(index);
 };
 
 const handleNextClick: DriverHook = (_element, _driveStep, opts) => {

--- a/e2e/tests/user-onboarding.spec.ts
+++ b/e2e/tests/user-onboarding.spec.ts
@@ -257,6 +257,22 @@ async function tabTo(page: Page, selector: string): Promise<void> {
 }
 
 /**
+ * Tab within driver.js's focus trap until the popover's Next button holds
+ * focus. Asserted by position, not press count: the trap cycles
+ * [close, previous, next, highlighted target], driver.js focuses close on
+ * render, and the engine then moves focus into a text-entry target — so where
+ * Tab starts varies by step and timing; only the destination is stable.
+ */
+async function tabToPopoverNext(page: Page): Promise<void> {
+  const next = popoverNext(page);
+  for (let presses = 0; presses < 6; presses += 1) {
+    if (await next.evaluate((el) => el === document.activeElement)) return;
+    await page.keyboard.press('Tab');
+  }
+  await expect(next).toBeFocused();
+}
+
+/**
  * Walk the account set from its first step to `stopAt`, opening the account
  * dialog on the way because the six field steps anchor to controls that only
  * exist once it is open.
@@ -1145,21 +1161,37 @@ test.describe('user onboarding', () => {
     await page.goto('/dashboard');
     await expect(page.getByTestId('activation-checklist')).toBeVisible();
 
-    // And a set whose steps all live on one screen traverses on the arrow keys
-    // alone — the account set cannot, because its field steps need a dialog the
-    // user opens by activating the highlighted control.
+    // And a set whose steps live on one screen still traverses by keyboard
+    // alone — with one change: the tour now moves the caret into each field it
+    // describes, so the arrows pressed THERE edit the value, and traversal
+    // happens from the popover's own Next button, inside driver.js's focus
+    // trap. Each press is still asserted on its own: this is where a dropped
+    // press shows up.
     await tabTo(page, '[data-checklist-action="calculator"]');
     await page.keyboard.press('Enter');
     await expect(popoverTitle(page)).toHaveText(CALCULATOR_STEP_TITLES[0]);
-    // Consecutive presses, each asserted on its own: this is where a dropped
-    // press shows up, because every press after the first follows a transition
-    // that has only just painted the title the one before it produced.
+
+    // The caret followed the tour into the field — the feature itself…
+    await expect(page.locator('#entryPrice')).toBeFocused();
+    // …and an arrow pressed there is caret movement, not tour navigation.
+    await page.keyboard.press('ArrowRight');
+    await expect(popoverTitle(page)).toHaveText(CALCULATOR_STEP_TITLES[0]);
+
+    await tabToPopoverNext(page);
     await pressToTitle(page, 'ArrowRight', CALCULATOR_STEP_TITLES[1]);
+    await expect(page.locator('#stopLoss')).toBeFocused();
+    await tabToPopoverNext(page);
     await pressToTitle(page, 'ArrowRight', CALCULATOR_STEP_TITLES[2]);
+    await expect(page.locator('#targetPrice')).toBeFocused();
+    await tabToPopoverNext(page);
     await pressToTitle(page, 'ArrowLeft', CALCULATOR_STEP_TITLES[1]);
+    await expect(page.locator('#stopLoss')).toBeFocused();
+    await tabToPopoverNext(page);
     await pressToTitle(page, 'ArrowLeft', CALCULATOR_STEP_TITLES[0]);
-    // The first step is the front of the set, and the key that would run off it
-    // does nothing rather than ending the tour.
+    await expect(page.locator('#entryPrice')).toBeFocused();
+    // The first step is the front of the set, and the key that would run off
+    // it does nothing rather than ending the tour.
+    await tabToPopoverNext(page);
     await page.keyboard.press('ArrowLeft');
     await expect(popoverTitle(page)).toHaveText(CALCULATOR_STEP_TITLES[0]);
     await escapeTour(page);


### PR DESCRIPTION
## What

When the guided walkthrough highlights a field the user is being asked to type into (`#name`, `#startingBalance`, the calculator's price fields…), keyboard focus now moves into that field, and a prefilled value is selected so typing replaces it. Previously the caret stayed wherever the user last clicked, so following the tour's copy meant typing into the wrong field.

## How

All in the tour engine (`tour-engine.ts`):

- One `isTextEntry` predicate decides both behaviors so they cannot drift: which targets take focus on highlight (`focusStepTarget`, called after driver.js has rendered the popover and focused its own button, so the field wins), and whose arrow keys belong to the caret rather than the tour (the engine's document-level keyup handler now ignores ArrowLeft/ArrowRight coming from a text-entry control; Escape still exits from anywhere).
- Buttons, radios, checkboxes and Radix select triggers deliberately do not take focus — that would invite Enter/arrow presses the step never asked for.
- Disabled or absent targets are skipped; driver.js's Tab trap and focus restore are untouched.

## Tests

- 7 new engine tests (focus moves / value selected / button target untouched / disabled untouched / arrows-in-field inert / arrows outside still navigate / Escape-in-field still exits); full onboarding scope 530 green.
- e2e keyboard-traversal test reworked: asserts focus follows each calculator field, an arrow pressed in the field edits rather than navigates, and traversal happens from the popover's Next inside driver.js's focus trap (new `tabToPopoverNext` helper).
- `tsc` (web + e2e) and `eslint` clean.