### PR TITLE
feat(accounts): default account preselects every account picker

### DIFF
--- a/apps/api/src/db/migrations/0031_account_is_default.sql
+++ b/apps/api/src/db/migrations/0031_account_is_default.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "accounts" ADD COLUMN "is_default" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "accounts_one_default_per_user" ON "accounts" USING btree ("user_id") WHERE is_default = true;

--- a/apps/api/src/db/migrations/0032_account_default_backfill.sql
+++ b/apps/api/src/db/migrations/0032_account_default_backfill.sql
@@ -1,0 +1,35 @@
+-- Give every existing user a default account.
+--
+-- 0031 added `accounts.is_default` with a fast NOT NULL DEFAULT false, so at
+-- this point NO existing account is anyone's default — but the feature's rule
+-- is "the first account a user creates is the default", and for every user who
+-- already has accounts that moment has passed. This is the one-time correction,
+-- exactly as 0028 was for the onboarding status: apply the rule to the rows
+-- that predate it, using the trace that still exists.
+--
+-- WHO GETS ONE: each user's oldest non-demo account (created_at, then id, so
+-- the pick is total even under same-transaction timestamp ties). The sample
+-- account never qualifies — it is not an account the user chose, and making it
+-- the default would preselect invented data in every picker.
+--
+-- IDEMPOTENT AND RACE-SAFE BY THE SAME PREDICATE: the NOT EXISTS arm skips any
+-- user who already has a default, so a re-run is a no-op, and a user whose
+-- first account is created mid-deploy (new code sets is_default on create) is
+-- left alone rather than double-flagged. The partial unique index from 0031
+-- (`accounts_one_default_per_user`) backstops all of it.
+--
+-- ADDITIVE AND ROLLING-DEPLOY SAFE: no DDL, and an instance running the old
+-- build never reads the column.
+UPDATE "accounts" a
+SET "is_default" = true,
+    "updated_at" = now()
+WHERE a."id" = (
+    SELECT b."id" FROM "accounts" b
+    WHERE b."user_id" = a."user_id" AND b."is_demo" = false
+    ORDER BY b."created_at" ASC, b."id" ASC
+    LIMIT 1
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM "accounts" c
+    WHERE c."user_id" = a."user_id" AND c."is_default" = true
+  );

--- a/apps/api/src/db/migrations/meta/0031_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0031_snapshot.json
@@ -1,0 +1,3476 @@
+{
+  "id": "21cd69af-270b-44e1-bbe5-4e81376c734a",
+  "prevId": "ec2fbaeb-7d47-41ef-bd11-3e2d1d196b9a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.exchange_rates": {
+      "name": "exchange_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_currency": {
+          "name": "base_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_currency": {
+          "name": "quote_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(24, 12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exchange_rates_user_pair_date_unique": {
+          "name": "exchange_rates_user_pair_date_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "base_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exchange_rates_user_id_users_id_fk": {
+          "name": "exchange_rates_user_id_users_id_fk",
+          "tableFrom": "exchange_rates",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "exchange_rates_distinct_currencies_chk": {
+          "name": "exchange_rates_distinct_currencies_chk",
+          "value": "\"exchange_rates\".\"base_currency\" <> \"exchange_rates\".\"quote_currency\""
+        },
+        "exchange_rates_rate_positive_chk": {
+          "name": "exchange_rates_rate_positive_chk",
+          "value": "\"exchange_rates\".\"rate\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ledger_entries": {
+      "name": "ledger_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_id": {
+          "name": "position_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reverses_group_id": {
+          "name": "reverses_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ledger_user_id_idx": {
+          "name": "ledger_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_account_id_idx": {
+          "name": "ledger_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_user_account_occurred_pnl_idx": {
+          "name": "ledger_user_account_occurred_pnl_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"occurred_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ledger_entries\".\"entry_type\" IN ('position_pnl', 'position_pnl_reversal', 'balance_adjustment')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_user_account_direction_amount_pnl_idx": {
+          "name": "ledger_user_account_direction_amount_pnl_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ledger_entries\".\"entry_type\" IN ('position_pnl', 'position_pnl_reversal', 'balance_adjustment')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ledger_reverses_group_id_idx": {
+          "name": "ledger_reverses_group_id_idx",
+          "columns": [
+            {
+              "expression": "reverses_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"ledger_entries\".\"reverses_group_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ledger_entries_user_id_users_id_fk": {
+          "name": "ledger_entries_user_id_users_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ledger_entries_account_id_accounts_id_fk": {
+          "name": "ledger_entries_account_id_accounts_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "ledger_entries_position_id_positions_id_fk": {
+          "name": "ledger_entries_position_id_positions_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "positions",
+          "columnsFrom": ["position_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ledger_amount_nonneg_chk": {
+          "name": "ledger_amount_nonneg_chk",
+          "value": "\"ledger_entries\".\"amount\" >= 0"
+        },
+        "ledger_direction_chk": {
+          "name": "ledger_direction_chk",
+          "value": "\"ledger_entries\".\"direction\" IN ('credit', 'debit')"
+        },
+        "ledger_entry_type_chk": {
+          "name": "ledger_entry_type_chk",
+          "value": "\"ledger_entries\".\"entry_type\" IN ('position_pnl', 'position_pnl_reversal', 'balance_adjustment')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "brokerage_id": {
+          "name": "brokerage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_balance": {
+          "name": "starting_balance",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "default_risk_percent": {
+          "name": "default_risk_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_demo": {
+          "name": "is_demo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_id_name_unique": {
+          "name": "accounts_user_id_name_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_brokerage_id_idx": {
+          "name": "accounts_brokerage_id_idx",
+          "columns": [
+            {
+              "expression": "brokerage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_one_default_per_user": {
+          "name": "accounts_one_default_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_brokerage_id_brokerages_id_fk": {
+          "name": "accounts_brokerage_id_brokerages_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "brokerages",
+          "columnsFrom": ["brokerage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_email": {
+          "name": "target_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_created_idx": {
+          "name": "admin_audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_actor_user_id_users_id_fk": {
+          "name": "admin_audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_audit_log_target_user_id_users_id_fk": {
+          "name": "admin_audit_log_target_user_id_users_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["target_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "admin_audit_log_action_chk": {
+          "name": "admin_audit_log_action_chk",
+          "value": "\"admin_audit_log\".\"action\" IN ('admin_toggle', 'factory_reset')"
+        },
+        "admin_audit_log_toggle_values_chk": {
+          "name": "admin_audit_log_toggle_values_chk",
+          "value": "\"admin_audit_log\".\"action\" <> 'admin_toggle' OR (\"admin_audit_log\".\"old_value\" IS NOT NULL AND \"admin_audit_log\".\"new_value\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.advisor_image_counters": {
+      "name": "advisor_image_counters",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_count": {
+          "name": "image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "advisor_image_counters_user_id_users_id_fk": {
+          "name": "advisor_image_counters_user_id_users_id_fk",
+          "tableFrom": "advisor_image_counters",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "advisor_image_counters_user_id_period_key_pk": {
+          "name": "advisor_image_counters_user_id_period_key_pk",
+          "columns": ["user_id", "period_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_turn_counters": {
+      "name": "advisor_turn_counters",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "allowance_turns": {
+          "name": "allowance_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "advisor_turn_counters_user_id_users_id_fk": {
+          "name": "advisor_turn_counters_user_id_users_id_fk",
+          "tableFrom": "advisor_turn_counters",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "advisor_turn_counters_user_id_period_key_pk": {
+          "name": "advisor_turn_counters_user_id_period_key_pk",
+          "columns": ["user_id", "period_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_conversations": {
+      "name": "advisor_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_conversations_user_updated_idx": {
+          "name": "advisor_conversations_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_conversations_user_id_users_id_fk": {
+          "name": "advisor_conversations_user_id_users_id_fk",
+          "tableFrom": "advisor_conversations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "advisor_conversations_persona_id_advisor_personas_id_fk": {
+          "name": "advisor_conversations_persona_id_advisor_personas_id_fk",
+          "tableFrom": "advisor_conversations",
+          "tableTo": "advisor_personas",
+          "columnsFrom": ["persona_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_messages": {
+      "name": "advisor_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_parts": {
+          "name": "content_parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_message_id": {
+          "name": "client_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_messages_conv_created_idx": {
+          "name": "advisor_messages_conv_created_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "advisor_messages_idem": {
+          "name": "advisor_messages_idem",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "role = 'user' AND client_message_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "advisor_messages_assistant_pair_uniq": {
+          "name": "advisor_messages_assistant_pair_uniq",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "role = 'assistant' AND client_message_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_messages_conversation_id_advisor_conversations_id_fk": {
+          "name": "advisor_messages_conversation_id_advisor_conversations_id_fk",
+          "tableFrom": "advisor_messages",
+          "tableTo": "advisor_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "advisor_messages_role_chk": {
+          "name": "advisor_messages_role_chk",
+          "value": "\"advisor_messages\".\"role\" IN ('user', 'assistant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.advisor_personas": {
+      "name": "advisor_personas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_personas_one_default_per_user": {
+          "name": "advisor_personas_one_default_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true AND user_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_personas_user_id_users_id_fk": {
+          "name": "advisor_personas_user_id_users_id_fk",
+          "tableFrom": "advisor_personas",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_provider_keys": {
+      "name": "advisor_provider_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hint_tail": {
+          "name": "key_hint_tail",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_provider_keys_user_provider_uniq": {
+          "name": "advisor_provider_keys_user_provider_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_provider_keys_user_id_users_id_fk": {
+          "name": "advisor_provider_keys_user_id_users_id_fk",
+          "tableFrom": "advisor_provider_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.advisor_summaries": {
+      "name": "advisor_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prose": {
+          "name": "prose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trade_data_figures": {
+          "name": "trade_data_figures",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered_through_message_id": {
+          "name": "covered_through_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered_through_created_at": {
+          "name": "covered_through_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "advisor_summaries_conversation_uniq": {
+          "name": "advisor_summaries_conversation_uniq",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "advisor_summaries_conversation_id_advisor_conversations_id_fk": {
+          "name": "advisor_summaries_conversation_id_advisor_conversations_id_fk",
+          "tableFrom": "advisor_summaries",
+          "tableTo": "advisor_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_api_keys": {
+      "name": "external_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hint_tail": {
+          "name": "key_hint_tail",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_api_keys_user_provider_uniq": {
+          "name": "external_api_keys_user_provider_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_api_keys_user_id_users_id_fk": {
+          "name": "external_api_keys_user_id_users_id_fk",
+          "tableFrom": "external_api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brokerages": {
+      "name": "brokerages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brokerages_user_id_idx": {
+          "name": "brokerages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brokerages_user_id_name_unique": {
+          "name": "brokerages_user_id_name_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"brokerages\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brokerages_system_name_unique": {
+          "name": "brokerages_system_name_unique",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"brokerages\".\"is_system\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brokerages_user_id_users_id_fk": {
+          "name": "brokerages_user_id_users_id_fk",
+          "tableFrom": "brokerages",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_schedules": {
+      "name": "fee_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "brokerage_id": {
+          "name": "brokerage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_per_share_commission": {
+          "name": "stock_per_share_commission",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "stock_min_per_fill": {
+          "name": "stock_min_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "stock_max_per_fill": {
+          "name": "stock_max_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_per_contract_commission": {
+          "name": "options_per_contract_commission",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_per_contract_exchange_fee": {
+          "name": "options_per_contract_exchange_fee",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_min_per_fill": {
+          "name": "options_min_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "options_max_per_fill": {
+          "name": "options_max_per_fill",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_schedules_brokerage_id_brokerages_id_fk": {
+          "name": "fee_schedules_brokerage_id_brokerages_id_fk",
+          "tableFrom": "fee_schedules",
+          "tableTo": "brokerages",
+          "columnsFrom": ["brokerage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_schedules_brokerage_id_unique": {
+          "name": "fee_schedules_brokerage_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["brokerage_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.csv_import_counters": {
+      "name": "csv_import_counters",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "committed_count": {
+          "name": "committed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "csv_import_counters_user_id_users_id_fk": {
+          "name": "csv_import_counters_user_id_users_id_fk",
+          "tableFrom": "csv_import_counters",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.csv_import_staging": {
+      "name": "csv_import_staging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'staged'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committed_result": {
+          "name": "committed_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "csv_import_staging_one_active_per_user_idx": {
+          "name": "csv_import_staging_one_active_per_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"csv_import_staging\".\"status\" IN ('staged', 'committing')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "csv_import_staging_user_id_idx": {
+          "name": "csv_import_staging_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "csv_import_staging_expires_at_idx": {
+          "name": "csv_import_staging_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "csv_import_staging_user_id_users_id_fk": {
+          "name": "csv_import_staging_user_id_users_id_fk",
+          "tableFrom": "csv_import_staging",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "csv_import_staging_account_id_accounts_id_fk": {
+          "name": "csv_import_staging_account_id_accounts_id_fk",
+          "tableFrom": "csv_import_staging",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_layouts": {
+      "name": "dashboard_layouts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgets": {
+          "name": "widgets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_layouts_user_id_users_id_fk": {
+          "name": "dashboard_layouts_user_id_users_id_fk",
+          "tableFrom": "dashboard_layouts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_tokens": {
+      "name": "email_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_tokens_user_purpose_idx": {
+          "name": "email_tokens_user_purpose_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_tokens_one_live_per_user_purpose": {
+          "name": "email_tokens_one_live_per_user_purpose",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "consumed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_tokens_user_id_users_id_fk": {
+          "name": "email_tokens_user_id_users_id_fk",
+          "tableFrom": "email_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_tokens_token_hash_unique": {
+          "name": "email_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_tokens_purpose_chk": {
+          "name": "email_tokens_purpose_chk",
+          "value": "\"email_tokens\".\"purpose\" IN ('password_reset','email_verification')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.expenses": {
+      "name": "expenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "expenses_user_id_idx": {
+          "name": "expenses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "expenses_user_occurred_idx": {
+          "name": "expenses_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"occurred_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "expenses_user_id_users_id_fk": {
+          "name": "expenses_user_id_users_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "expenses_amount_positive_chk": {
+          "name": "expenses_amount_positive_chk",
+          "value": "\"expenses\".\"amount\" > 0"
+        },
+        "expenses_category_chk": {
+          "name": "expenses_category_chk",
+          "value": "category IN ('data_subscription', 'platform_fee', 'software', 'education', 'hardware', 'other')"
+        },
+        "expenses_currency_chk": {
+          "name": "expenses_currency_chk",
+          "value": "currency IN ('USD', 'EUR', 'GBP', 'CAD', 'AUD', 'JPY', 'CHF', 'HKD', 'SGD', 'NZD', 'SEK', 'NOK', 'DKK', 'MXN', 'BRL', 'INR', 'KRW', 'TWD', 'ZAR')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public._post_migrations_journal": {
+      "name": "_post_migrations_journal",
+      "schema": "",
+      "columns": {
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fills": {
+      "name": "fills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "position_id": {
+          "name": "position_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fees": {
+          "name": "fees",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filled_at": {
+          "name": "filled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fills_position_id_idx": {
+          "name": "fills_position_id_idx",
+          "columns": [
+            {
+              "expression": "position_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fills_position_id_positions_id_fk": {
+          "name": "fills_position_id_positions_id_fk",
+          "tableFrom": "fills",
+          "tableTo": "positions",
+          "columnsFrom": ["position_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.positions": {
+      "name": "positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_price": {
+          "name": "target_price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_loss": {
+          "name": "stop_loss",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_flat_at": {
+          "name": "last_flat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_flat_net_pnl": {
+          "name": "last_flat_net_pnl",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "positions_user_id_idx": {
+          "name": "positions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "positions_account_id_idx": {
+          "name": "positions_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "positions_user_id_status_updated_at_idx": {
+          "name": "positions_user_id_status_updated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "positions_user_status_closed_at_idx": {
+          "name": "positions_user_status_closed_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "positions_user_id_users_id_fk": {
+          "name": "positions_user_id_users_id_fk",
+          "tableFrom": "positions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "positions_account_id_accounts_id_fk": {
+          "name": "positions_account_id_accounts_id_fk",
+          "tableFrom": "positions",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "positions_closed_at_when_closed_chk": {
+          "name": "positions_closed_at_when_closed_chk",
+          "value": "\"positions\".\"status\" <> 'closed' OR \"positions\".\"closed_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.symbol_sync_state": {
+      "name": "symbol_sync_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "smallint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncing": {
+          "name": "syncing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "syncing_started_at": {
+          "name": "syncing_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "symbol_count": {
+          "name": "symbol_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "symbol_sync_state_singleton": {
+          "name": "symbol_sync_state_singleton",
+          "value": "\"symbol_sync_state\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.symbols": {
+      "name": "symbols",
+      "schema": "",
+      "columns": {
+        "ticker": {
+          "name": "ticker",
+          "type": "varchar(16)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exchange": {
+          "name": "exchange",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cik": {
+          "name": "cik",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "symbols_ticker_prefix_idx": {
+          "name": "symbols_ticker_prefix_idx",
+          "columns": [
+            {
+              "expression": "ticker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "varchar_pattern_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed": {
+          "name": "last_accessed",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_currency": {
+          "name": "display_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_jurisdiction": {
+          "name": "tax_jurisdiction",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "buying_power_basis": {
+          "name": "buying_power_basis",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cash'"
+        },
+        "advisor_default_persona_id": {
+          "name": "advisor_default_persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advisor_trade_data_consent": {
+          "name": "advisor_trade_data_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "writable_account_id": {
+          "name": "writable_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changelog_viewed_at": {
+          "name": "changelog_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding": {
+          "name": "onboarding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_tax_jurisdiction_chk": {
+          "name": "users_tax_jurisdiction_chk",
+          "value": "\"users\".\"tax_jurisdiction\" IS NULL OR \"users\".\"tax_jurisdiction\" IN ('US', 'CA', 'other')"
+        },
+        "users_theme_chk": {
+          "name": "users_theme_chk",
+          "value": "\"users\".\"theme\" IN ('light','dark','system')"
+        },
+        "users_buying_power_basis_chk": {
+          "name": "users_buying_power_basis_chk",
+          "value": "\"users\".\"buying_power_basis\" IN ('cash','balance')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_customers": {
+      "name": "billing_customers",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_customers_user_id_users_id_fk": {
+          "name": "billing_customers_user_id_users_id_fk",
+          "tableFrom": "billing_customers",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_customers_stripe_customer_id_unique": {
+          "name": "billing_customers_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_customer_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_unit_amount": {
+          "name": "price_unit_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_currency": {
+          "name": "price_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_created_at": {
+          "name": "stripe_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entered_past_due_at": {
+          "name": "entered_past_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_created": {
+          "name": "last_event_created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_subscription_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_cost": {
+          "name": "credit_cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_cost": {
+          "name": "raw_cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_records_user_created_idx": {
+          "name": "usage_records_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_records_created_idx": {
+          "name": "usage_records_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_user_id_users_id_fk": {
+          "name": "usage_records_user_id_users_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_records_conversation_id_advisor_conversations_id_fk": {
+          "name": "usage_records_conversation_id_advisor_conversations_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "advisor_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "usage_records_message_id_advisor_messages_id_fk": {
+          "name": "usage_records_message_id_advisor_messages_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "advisor_messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_transactions": {
+      "name": "wallet_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_record_id": {
+          "name": "usage_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_transactions_user_created_idx": {
+          "name": "wallet_transactions_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transactions_payment_intent_idx": {
+          "name": "wallet_transactions_payment_intent_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_transactions_user_id_users_id_fk": {
+          "name": "wallet_transactions_user_id_users_id_fk",
+          "tableFrom": "wallet_transactions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_transactions_usage_record_id_usage_records_id_fk": {
+          "name": "wallet_transactions_usage_record_id_usage_records_id_fk",
+          "tableFrom": "wallet_transactions",
+          "tableTo": "usage_records",
+          "columnsFrom": ["usage_record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "wallet_transactions_kind_chk": {
+          "name": "wallet_transactions_kind_chk",
+          "value": "\"wallet_transactions\".\"kind\" IN ('credit', 'debit', 'reversal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "reserved": {
+          "name": "reserved",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallets_user_id_users_id_fk": {
+          "name": "wallets_user_id_users_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "wallets_reserved_nonneg_chk": {
+          "name": "wallets_reserved_nonneg_chk",
+          "value": "\"wallets\".\"reserved\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_events_stripe_event_id_unique": {
+          "name": "webhook_events_stripe_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_event_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webhook_events_status_chk": {
+          "name": "webhook_events_status_chk",
+          "value": "\"webhook_events\".\"status\" IN ('received', 'processed', 'ignored', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -218,6 +218,20 @@
       "when": 1788120859351,
       "tag": "0030_admin_factory_reset_audit",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1788210364071,
+      "tag": "0031_account_is_default",
+      "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1788210365071,
+      "tag": "0032_account_default_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema/accounts.schema.ts
+++ b/apps/api/src/db/schema/accounts.schema.ts
@@ -56,6 +56,13 @@ export const accounts = pgTable(
     // this flag from the stored row before deleting anything, and never trust a
     // query parameter, header or body field claiming an account is a demo.
     isDemo: boolean('is_demo').notNull().default(false),
+    // The user's default account — what account pickers preselect. Exactly one
+    // per user (partial unique index below): the first account a user creates
+    // takes it, `PUT /api/accounts/default` moves it, and deleting the default
+    // promotes the oldest remaining non-demo account. Server-set only, like
+    // is_demo — no request body can claim it — and never true on the sample
+    // account, which is not an account the user chose.
+    isDefault: boolean('is_default').notNull().default(false),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
@@ -63,5 +70,11 @@ export const accounts = pgTable(
     index('accounts_user_id_idx').on(table.userId),
     uniqueIndex('accounts_user_id_name_unique').on(table.userId, sql`lower(${table.name})`),
     index('accounts_brokerage_id_idx').on(table.brokerageId),
+    // One default per user, enforced where it cannot race. The
+    // advisor_personas_one_default_per_user precedent, minus the NULL guard —
+    // user_id here is NOT NULL.
+    uniqueIndex('accounts_one_default_per_user')
+      .on(table.userId)
+      .where(sql`is_default = true`),
   ],
 );

--- a/apps/api/src/features/accounts/accounts.query.ts
+++ b/apps/api/src/features/accounts/accounts.query.ts
@@ -120,6 +120,9 @@ export function findAccountsByUser(db: Database | Transaction, userId: string) {
       // the wrong account the day it moved. This flag is read-only on the way
       // out: nothing a client sends can set it.
       isDemo: accounts.isDemo,
+      // Which account pickers preselect. Read-only on the way out, like isDemo:
+      // it moves via PUT /api/accounts/default, never via create/update bodies.
+      isDefault: accounts.isDefault,
       createdAt: accounts.createdAt,
       updatedAt: accounts.updatedAt,
       balance: balanceProjection,
@@ -148,6 +151,9 @@ export function findAccountById(db: Database | Transaction, id: string, userId: 
       // The sample-data flag — see findAccountsByUser. Also carried here so the
       // account this endpoint returns after seeding identifies itself.
       isDemo: accounts.isDemo,
+      // See findAccountsByUser. Carried here so the account the create endpoint
+      // returns says whether it just became the default.
+      isDefault: accounts.isDefault,
       createdAt: accounts.createdAt,
       updatedAt: accounts.updatedAt,
       balance: balanceProjection,
@@ -177,6 +183,9 @@ export function insertAccount(
     // everything booked against it, so a client that could set it could talk
     // its way past the guard protecting a real account.
     isDemo?: boolean;
+    // Only createAccount passes this, for the user's first account. Never
+    // derived from request input, same as isDemo.
+    isDefault?: boolean;
   },
 ) {
   return tx.insert(accounts).values(data).returning();
@@ -217,9 +226,9 @@ export function deleteAccount(tx: Transaction, id: string, userId: string) {
 }
 
 /**
- * One owned account's stored sample-data flag, without the balance LATERALs the
- * full projection carries — the delete path needs to know what kind of account
- * it is holding, not what it is worth.
+ * One owned account's stored sample-data and default flags, without the balance
+ * LATERALs the full projection carries — the delete path needs to know what
+ * kind of account it is holding, not what it is worth.
  *
  * `undefined` is the same answer for an account belonging to somebody else as
  * for one that never existed, which is what keeps a deletion attempt from
@@ -229,13 +238,73 @@ export async function selectOwnedAccountDemoFlag(
   db: Database | Transaction,
   id: string,
   userId: string,
-): Promise<{ id: string; isDemo: boolean } | undefined> {
+): Promise<{ id: string; isDemo: boolean; isDefault: boolean } | undefined> {
   const rows = await db
-    .select({ id: accounts.id, isDemo: accounts.isDemo })
+    .select({ id: accounts.id, isDemo: accounts.isDemo, isDefault: accounts.isDefault })
     .from(accounts)
     .where(and(eq(accounts.id, id), eq(accounts.userId, userId)))
     .limit(1);
   return rows[0];
+}
+
+/**
+ * Does this user already have a default account? Existence only — the create
+ * path needs to know whether the account it is inserting takes the
+ * designation, not which account holds it. Backed by
+ * `accounts_one_default_per_user`, and stopped at the first row.
+ */
+export async function userHasDefaultAccount(
+  db: Database | Transaction,
+  userId: string,
+): Promise<boolean> {
+  const rows = await db
+    .select({ one: sql<number>`1` })
+    .from(accounts)
+    .where(and(eq(accounts.userId, userId), eq(accounts.isDefault, true)))
+    .limit(1);
+  return rows.length > 0;
+}
+
+/**
+ * Flip the default designation to exactly this account, in one statement, so
+ * there is no window in which the user has two defaults for the partial unique
+ * index to reject — the `setDefaultPersona` idiom. The demo account is left
+ * out of the flip entirely: it can never gain the flag here, and it never
+ * carries it to lose.
+ */
+export async function setDefaultAccountId(
+  tx: Transaction,
+  userId: string,
+  accountId: string,
+): Promise<void> {
+  await tx.execute(sql`
+    UPDATE accounts
+    SET is_default = (id = ${accountId}), updated_at = now()
+    WHERE user_id = ${userId} AND is_demo = false
+  `);
+}
+
+/**
+ * Give the designation to the user's oldest remaining non-demo account, if any
+ * — the delete path's promotion, run after the default account is gone. The
+ * (created_at, id) order matches the backfill migration, so "the first account
+ * the user created" means the same row everywhere; same-transaction creation
+ * produces exact created_at ties, hence the id tiebreak.
+ */
+export async function promoteOldestAccountToDefault(
+  tx: Transaction,
+  userId: string,
+): Promise<void> {
+  await tx.execute(sql`
+    UPDATE accounts
+    SET is_default = true, updated_at = now()
+    WHERE id = (
+      SELECT id FROM accounts
+      WHERE user_id = ${userId} AND is_demo = false
+      ORDER BY created_at ASC, id ASC
+      LIMIT 1
+    )
+  `);
 }
 
 /**

--- a/apps/api/src/features/accounts/accounts.route.ts
+++ b/apps/api/src/features/accounts/accounts.route.ts
@@ -1,7 +1,11 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 
-import { CreateAccountSchema, UpdateAccountSchema } from '@tradr/shared/schemas/account';
+import {
+  CreateAccountSchema,
+  SetDefaultAccountSchema,
+  UpdateAccountSchema,
+} from '@tradr/shared/schemas/account';
 import { SetWritableAccountSchema } from '@tradr/shared/schemas/tier';
 
 import { db } from '@/db';
@@ -17,6 +21,7 @@ import {
   createAccount,
   editAccount,
   removeAccount,
+  setDefaultAccount,
   setWritableAccount,
 } from './accounts.service';
 
@@ -197,6 +202,51 @@ accounts.put('/writable', validate('json', SetWritableAccountSchema), async (c) 
   const userId = c.get('userId');
   const { accountId } = c.req.valid('json');
   const result = await setWritableAccount(db, userId, accountId);
+  return c.json(result, 200);
+});
+
+/**
+ * @swagger
+ * /api/accounts/default:
+ *   put:
+ *     summary: Set the default account.
+ *     description: >
+ *       Authed. Moves the default-account designation — the account the app's
+ *       pickers preselect — to the named account. Exactly one account holds it
+ *       at a time: setting a new default clears the old one in the same
+ *       statement. The first account a user creates takes the designation
+ *       automatically, and deleting the default hands it to the oldest
+ *       remaining account, so this endpoint is only ever a *move*.
+ *
+ *
+ *       The account must belong to the current user (404 otherwise), and the
+ *       sample account is refused with `400 DEMO_ACCOUNT_NOT_DEFAULTABLE` — a
+ *       preselected sample account would put invented data behind every new
+ *       position by default.
+ *
+ *
+ *       Every account read carries a boolean `isDefault`; it is server-set and
+ *       cannot be sent in on create or update.
+ *     tags: [Accounts]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [accountId]
+ *             properties:
+ *               accountId: { type: string, format: uuid }
+ *     responses:
+ *       200: { description: '{ defaultAccountId } — the stored designation.' }
+ *       400: { description: 'Validation error, or DEMO_ACCOUNT_NOT_DEFAULTABLE (the sample account).' }
+ *       404: { description: Account not found (or not owned by the user). }
+ */
+// Same mount-order pin as `/writable` above: registered BEFORE `PUT /:id`.
+accounts.put('/default', validate('json', SetDefaultAccountSchema), async (c) => {
+  const userId = c.get('userId');
+  const { accountId } = c.req.valid('json');
+  const result = await setDefaultAccount(db, userId, accountId);
   return c.json(result, 200);
 });
 

--- a/apps/api/src/features/accounts/accounts.service.ts
+++ b/apps/api/src/features/accounts/accounts.service.ts
@@ -28,8 +28,11 @@ import {
   accountHasLedgerEntries,
   countAccountsByUser,
   lockUserForAccountChange,
+  promoteOldestAccountToDefault,
   selectOwnedAccountDemoFlag,
+  setDefaultAccountId,
   setWritableAccountId,
+  userHasDefaultAccount,
   userHasDemoAccount,
 } from './accounts.query';
 
@@ -120,7 +123,13 @@ export async function createAccount(
     }
 
     try {
-      const rows = await insertAccount(tx, { userId, ...data });
+      // The first account a user creates is their default. Decided under the
+      // lock above, so two concurrent first creations serialize and exactly one
+      // takes the designation; the partial unique index backstops it. The demo
+      // account never holds the flag, so a user whose only account is the
+      // sample one still takes it with their first real account.
+      const isDefault = !(await userHasDefaultAccount(tx, userId));
+      const rows = await insertAccount(tx, { userId, ...data, isDefault });
 
       // Materialize the user's display_currency on their first account creation.
       // Race-safe first-writer-wins: the `display_currency IS NULL` predicate
@@ -216,6 +225,31 @@ export async function setWritableAccount(db: Database, userId: string, accountId
 }
 
 /**
+ * Move the default-account designation. Ownership-validated (404, like every
+ * other accounts endpoint), and refused for the sample account — the default
+ * is what pickers preselect, and preselecting invented data would put the
+ * demo account behind every new position by default. Runs under the per-user
+ * account lock so the flip cannot interleave with a create or delete deciding
+ * who holds the designation.
+ */
+export async function setDefaultAccount(db: Database, userId: string, accountId: string) {
+  return withTransaction(db, async (tx) => {
+    await lockUserForAccountChange(tx, userId);
+    const existing = await selectOwnedAccountDemoFlag(tx, accountId, userId);
+    if (!existing) throw new NotFoundError('Account', accountId);
+    if (existing.isDemo) {
+      throw new AppError(
+        400,
+        'DEMO_ACCOUNT_NOT_DEFAULTABLE',
+        'The sample account cannot be the default account.',
+      );
+    }
+    await setDefaultAccountId(tx, userId, accountId);
+    return { defaultAccountId: accountId };
+  });
+}
+
+/**
  * Delete an account.
  *
  * There are two paths through here, and which one runs is decided by the stored
@@ -242,6 +276,11 @@ export async function removeAccount(
   options: { cascade?: boolean } = {},
 ): Promise<boolean> {
   return withTransaction(db, async (tx) => {
+    // Deleting can move the default designation (the promotion below), so this
+    // serializes with the other account-set changes exactly as creation and
+    // seeding do — same lock, same ordering, taken before any read.
+    await lockUserForAccountChange(tx, userId);
+
     const existing = await selectOwnedAccountDemoFlag(tx, id, userId);
 
     if (!existing) {
@@ -265,6 +304,13 @@ export async function removeAccount(
     }
 
     await deleteAccount(tx, id, userId);
+    // Deleting the default hands the designation to the oldest remaining
+    // non-demo account — "the first account the user created", the same rule
+    // that assigned it — so a user with accounts always has a default for the
+    // pickers to preselect. No-op when nothing remains.
+    if (existing.isDefault) {
+      await promoteOldestAccountToDefault(tx, userId);
+    }
     return true;
   });
 }

--- a/apps/api/src/features/accounts/accounts.test.ts
+++ b/apps/api/src/features/accounts/accounts.test.ts
@@ -870,6 +870,21 @@ describe('accounts default designation', () => {
     const second = await createTestAccount(cookie, 'Second', 'EUR');
     const third = await createTestAccount(cookie, 'Third', 'GBP');
 
+    // Three HTTP creates can land in the same clock tick, and under an exact
+    // created_at tie the promotion's id tiebreak is free to disagree with
+    // creation order — so pin the timestamps the rule actually reads.
+    const staggered: Array<[string, string]> = [
+      [first.id, '2026-01-01T00:00:00Z'],
+      [second.id, '2026-01-02T00:00:00Z'],
+      [third.id, '2026-01-03T00:00:00Z'],
+    ];
+    for (const [id, createdAt] of staggered) {
+      await db
+        .update(accountsTable)
+        .set({ createdAt: new Date(createdAt) })
+        .where(eq(accountsTable.id, id));
+    }
+
     const res = await authedRequest('DELETE', `/api/accounts/${first.id}`, cookie);
     expect(res.status).toBe(204);
 

--- a/apps/api/src/features/accounts/accounts.test.ts
+++ b/apps/api/src/features/accounts/accounts.test.ts
@@ -790,3 +790,130 @@ describe('accounts tier enforcement + writable designation (plan-tiers L1/D18)',
     expect(await resolveWritableAccountId(db, userIdA)).toBe(own.id);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Default-account designation: first-created takes it, PUT /default moves it,
+// delete promotes the oldest remaining, the sample account never holds it.
+// ---------------------------------------------------------------------------
+
+describe('accounts default designation', () => {
+  async function listAccounts(cookie: string): Promise<Array<Record<string, unknown>>> {
+    const res = await authedRequest('GET', '/api/accounts', cookie);
+    expect(res.status).toBe(200);
+    return res.json();
+  }
+
+  it('the first account created is the default; the second is not', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const first = await createTestAccount(cookie, 'First');
+    expect(first.isDefault).toBe(true);
+
+    const second = await createTestAccount(cookie, 'Second', 'EUR');
+    expect(second.isDefault).toBe(false);
+
+    const rows = await listAccounts(cookie);
+    expect(rows.filter((a) => a.isDefault).map((a) => a.id)).toEqual([first.id]);
+  });
+
+  // Mount-order pin: a shadowed static route would be captured by PUT /:id,
+  // fail its uuid param schema, and 400 from the wrong handler.
+  it('PUT /api/accounts/default moves the designation atomically (static route not shadowed)', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const first = await createTestAccount(cookie, 'First');
+    const second = await createTestAccount(cookie, 'Second', 'EUR');
+
+    const res = await authedRequest('PUT', '/api/accounts/default', cookie, {
+      accountId: second.id,
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).defaultAccountId).toBe(second.id);
+
+    // Exactly one default, and it moved — the old one is cleared in the same
+    // statement.
+    const rows = await listAccounts(cookie);
+    expect(rows.filter((a) => a.isDefault).map((a) => a.id)).toEqual([second.id]);
+    expect(rows.find((a) => a.id === first.id)?.isDefault).toBe(false);
+  });
+
+  it('PUT /api/accounts/default refuses a non-owned account with 404, changing nothing', async () => {
+    const { cookie: cookieA } = await registerAndGetCookie();
+    const { cookie: cookieB } = await registerAndGetCookie();
+    const own = await createTestAccount(cookieA, 'Own');
+    const foreign = await createTestAccount(cookieB, 'Foreign');
+
+    const res = await authedRequest('PUT', '/api/accounts/default', cookieA, {
+      accountId: foreign.id,
+    });
+    expect(res.status).toBe(404);
+
+    const rows = await listAccounts(cookieA);
+    expect(rows.filter((a) => a.isDefault).map((a) => a.id)).toEqual([own.id]);
+  });
+
+  it('the sample account never takes the designation and cannot be made the default', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const seedRes = await authedRequest('POST', '/api/accounts/demo', cookie);
+    expect(seedRes.status).toBe(201);
+    const demo = await seedRes.json();
+    expect(demo.isDefault).toBe(false);
+
+    const res = await authedRequest('PUT', '/api/accounts/default', cookie, {
+      accountId: demo.id,
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('DEMO_ACCOUNT_NOT_DEFAULTABLE');
+  });
+
+  it('deleting the default promotes the oldest remaining account', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const first = await createTestAccount(cookie, 'First');
+    const second = await createTestAccount(cookie, 'Second', 'EUR');
+    const third = await createTestAccount(cookie, 'Third', 'GBP');
+
+    const res = await authedRequest('DELETE', `/api/accounts/${first.id}`, cookie);
+    expect(res.status).toBe(204);
+
+    // "The first account the user created" — creation order, not id order.
+    const rows = await listAccounts(cookie);
+    expect(rows.filter((a) => a.isDefault).map((a) => a.id)).toEqual([second.id]);
+    expect(rows.find((a) => a.id === third.id)?.isDefault).toBe(false);
+  });
+
+  it('deleting a non-default account leaves the designation alone', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const first = await createTestAccount(cookie, 'First');
+    const second = await createTestAccount(cookie, 'Second', 'EUR');
+
+    const res = await authedRequest('DELETE', `/api/accounts/${second.id}`, cookie);
+    expect(res.status).toBe(204);
+
+    const rows = await listAccounts(cookie);
+    expect(rows.filter((a) => a.isDefault).map((a) => a.id)).toEqual([first.id]);
+  });
+
+  it('deleting the last account leaves no default; the next create takes it again', async () => {
+    const { cookie } = await registerAndGetCookie();
+    const only = await createTestAccount(cookie, 'Only');
+    const res = await authedRequest('DELETE', `/api/accounts/${only.id}`, cookie);
+    expect(res.status).toBe(204);
+    expect(await listAccounts(cookie)).toHaveLength(0);
+
+    const next = await createTestAccount(cookie, 'Next');
+    expect(next.isDefault).toBe(true);
+  });
+
+  // Server-set only: the update schema strips the key, so a request claiming
+  // the designation changes nothing.
+  it('PUT /api/accounts/:id cannot set isDefault', async () => {
+    const { cookie } = await registerAndGetCookie();
+    await createTestAccount(cookie, 'First');
+    const second = await createTestAccount(cookie, 'Second', 'EUR');
+
+    const res = await authedRequest('PUT', `/api/accounts/${second.id}`, cookie, {
+      name: 'Second Renamed',
+      isDefault: true,
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).isDefault).toBe(false);
+  });
+});

--- a/apps/docs/src/content/docs/self-hosting/reference/db-schema.mdx
+++ b/apps/docs/src/content/docs/self-hosting/reference/db-schema.mdx
@@ -6,9 +6,9 @@ description: Every table Tradr creates, its columns, and how they reference each
 {/* GENERATED FILE — do not edit.
     Source: apps/api/src/db/migrations/meta/ (latest snapshot) · Generator: apps/docs/scripts/gen-db-schema.mjs */}
 
-Tradr's schema is **32 tables**, created by **31 migrations** that run
+Tradr's schema is **32 tables**, created by **33 migrations** that run
 automatically when the api boots. This page is generated from the Drizzle snapshot
-for the latest schema-changing migration (`0030_admin_factory_reset_audit`), so it describes the schema the migrations
+for the latest schema-changing migration (`0031_account_is_default`), so it describes the schema the migrations
 actually produce.
 
 You do not need any of this to run Tradr. It is here for writing queries against
@@ -86,6 +86,7 @@ a query you write against these tables may need updating on any release.
 | `starting_balance` | `numeric(18, 4)` | not null, default `'0'` |
 | `default_risk_percent` | `numeric(5, 2)` | — |
 | `is_demo` | `boolean` | not null, default `false` |
+| `is_default` | `boolean` | not null, default `false` |
 | `created_at` | `timestamp with time zone` | not null, default `now()` |
 | `updated_at` | `timestamp with time zone` | not null, default `now()` |
 

--- a/apps/docs/src/openapi/tradr-api.json
+++ b/apps/docs/src/openapi/tradr-api.json
@@ -181,6 +181,45 @@
         ]
       }
     },
+    "/api/accounts/default": {
+      "put": {
+        "description": "Authed. Moves the default-account designation — the account the app's pickers preselect — to the named account. Exactly one account holds it at a time: setting a new default clears the old one in the same statement. The first account a user creates takes the designation automatically, and deleting the default hands it to the oldest remaining account, so this endpoint is only ever a *move*.\n\nThe account must belong to the current user (404 otherwise), and the sample account is refused with `400 DEMO_ACCOUNT_NOT_DEFAULTABLE` — a preselected sample account would put invented data behind every new position by default.\n\nEvery account read carries a boolean `isDefault`; it is server-set and cannot be sent in on create or update.\n",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "accountId": {
+                    "format": "uuid",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "accountId"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "{ defaultAccountId } — the stored designation."
+          },
+          "400": {
+            "description": "Validation error, or DEMO_ACCOUNT_NOT_DEFAULTABLE (the sample account)."
+          },
+          "404": {
+            "description": "Account not found (or not owned by the user)."
+          }
+        },
+        "summary": "Set the default account.",
+        "tags": [
+          "Accounts"
+        ]
+      }
+    },
     "/api/accounts/demo": {
       "post": {
         "description": "Authed. Creates one flagged sample account for the current user, seeded with a fixed set of trades — closed, open and planned — driven through the normal position lifecycle so realized P&L and its ledger entries are derived exactly as they are for real trades. The fixture is identical on every run, so support, the documentation screenshots and the end-to-end tests all describe the same figures.\n\nRefused with `409` when the user already has an account. Sample figures are kept out of real ones by keeping sample and real data mutually exclusive, so there is no supported state in which both exist. Seeding is all-or-nothing: a failure leaves no account behind, and a retry is safe.\n\nAvailable identically to self-hosted and hosted deployments — it needs no optional integration configured.\n\nEvery account read — the list, the detail and this response — carries a boolean `isDemo`, which is `true` on the sample account and `false` on every real one. That is how a client identifies the sample account to label or remove it; it is server-set and cannot be sent in on create or update.\n",

--- a/apps/web/src/features/accounts/components/AccountList.test.tsx
+++ b/apps/web/src/features/accounts/components/AccountList.test.tsx
@@ -3,24 +3,28 @@
 // banner (REQ-6.4/11.6). Badges and the make-writable action appear ONLY while
 // the writability restriction is active (over-cap ∧ free ∧ gated); nothing
 // tier-related renders when gating is off (self-host parity).
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Account, TierState } from '@tradr/shared';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-const { accountsData, tierData, setWritableMutate, demoState, demoTeardown } = vi.hoisted(() => ({
-  accountsData: { current: [] as unknown[] },
-  tierData: { current: undefined as unknown },
-  setWritableMutate: vi.fn(),
-  demoState: { isDemoPresent: false, isPending: false },
-  demoTeardown: vi.fn(),
-}));
+const { accountsData, tierData, setWritableMutate, setDefaultMutate, demoState, demoTeardown } =
+  vi.hoisted(() => ({
+    accountsData: { current: [] as unknown[] },
+    tierData: { current: undefined as unknown },
+    setWritableMutate: vi.fn(),
+    setDefaultMutate: vi.fn(),
+    demoState: { isDemoPresent: false, isPending: false },
+    demoTeardown: vi.fn(),
+  }));
 
 vi.mock('../hooks/useAccounts', () => ({
   useAccounts: () => ({ data: accountsData.current, isLoading: false }),
   useDeleteAccount: () => ({ mutate: vi.fn() }),
+  useSetDefaultAccount: () => ({ mutate: setDefaultMutate, isPending: false }),
   useSetWritableAccount: () => ({ mutate: setWritableMutate, isPending: false }),
 }));
 
@@ -125,6 +129,7 @@ beforeEach(() => {
   accountsData.current = ACCOUNTS;
   tierData.current = undefined;
   setWritableMutate.mockReset();
+  setDefaultMutate.mockReset();
   demoState.isDemoPresent = false;
   demoState.isPending = false;
   demoTeardown.mockReset();
@@ -334,6 +339,61 @@ describe('AccountList — creating a real account while sample data is present',
 
     expect(demoTeardown).not.toHaveBeenCalled();
     expect(screen.queryByTestId('account-dialog')).toBeNull();
+  });
+});
+
+describe('AccountList — default-account designation', () => {
+  const withDefault: Account[] = [
+    { id: ACCOUNT_A, name: 'Main', currency: 'USD', isDefault: true } as Account,
+    { id: ACCOUNT_B, name: 'Swing', currency: 'EUR', isDefault: false } as Account,
+  ];
+
+  /** The ⋯ menu on the row that carries this account name. */
+  async function openRowMenu(name: string): Promise<HTMLElement> {
+    const row = screen.getByText(name).closest('tr')!;
+    await userEvent.click(within(row).getByRole('button', { name: '⋯' }));
+    return row;
+  }
+
+  it('badges the default account and only it', () => {
+    accountsData.current = withDefault;
+    render(<AccountList />);
+
+    expect(screen.getByTestId(`default-badge-${ACCOUNT_A}`)).toBeTruthy();
+    expect(screen.queryByTestId(`default-badge-${ACCOUNT_B}`)).toBeNull();
+  });
+
+  it('offers Make default on a non-default row and fires the mutation with its id', async () => {
+    accountsData.current = withDefault;
+    render(<AccountList />);
+
+    await openRowMenu('Swing');
+    const item = screen.getByRole('menuitem', { name: 'Make default' });
+    expect(item.className).toContain('cursor-pointer');
+    await userEvent.click(item);
+
+    expect(setDefaultMutate).toHaveBeenCalledTimes(1);
+    expect(setDefaultMutate).toHaveBeenCalledWith(ACCOUNT_B);
+  });
+
+  it('withholds Make default from the current default', async () => {
+    accountsData.current = withDefault;
+    render(<AccountList />);
+
+    await openRowMenu('Main');
+    expect(screen.getByRole('menuitem', { name: 'Edit' })).toBeTruthy();
+    expect(screen.queryByRole('menuitem', { name: 'Make default' })).toBeNull();
+  });
+
+  it('withholds Make default from the sample account (the server refuses it)', async () => {
+    accountsData.current = [
+      { id: ACCOUNT_A, name: 'Sample Data', currency: 'USD', isDemo: true } as Account,
+    ];
+    render(<AccountList />);
+
+    await openRowMenu('Sample Data');
+    expect(screen.getByRole('menuitem', { name: 'Edit' })).toBeTruthy();
+    expect(screen.queryByRole('menuitem', { name: 'Make default' })).toBeNull();
   });
 });
 

--- a/apps/web/src/features/accounts/components/AccountList.tsx
+++ b/apps/web/src/features/accounts/components/AccountList.tsx
@@ -36,7 +36,12 @@ import { UpgradeLink } from '@/features/billing/UpgradeLink';
 import { useTierState } from '@/features/billing/useTierState';
 import { useDemoAccount } from '@/features/onboarding/hooks/useDemoAccount';
 
-import { useAccounts, useDeleteAccount, useSetWritableAccount } from '../hooks/useAccounts';
+import {
+  useAccounts,
+  useDeleteAccount,
+  useSetDefaultAccount,
+  useSetWritableAccount,
+} from '../hooks/useAccounts';
 
 import { AccountDialog } from './AccountDialog';
 
@@ -44,6 +49,7 @@ export function AccountList() {
   const { data: accounts, isLoading } = useAccounts();
   const deleteAccount = useDeleteAccount();
   const setWritable = useSetWritableAccount();
+  const setDefault = useSetDefaultAccount();
   const { data: tierState } = useTierState();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editAccount, setEditAccount] = useState<Account | null>(null);
@@ -142,6 +148,14 @@ export function AccountList() {
                 <TableCell className="font-medium">
                   <div className="flex items-center gap-2">
                     <span>{account.name}</span>
+                    {/* The default account — what pickers preselect. Moved from
+                        the row menu's "Make default"; the sample account never
+                        carries it. */}
+                    {account.isDefault && (
+                      <Badge variant="secondary" data-testid={`default-badge-${account.id}`}>
+                        Default
+                      </Badge>
+                    )}
                     {/* Writability badge + make-writable action (D18) — only
                         while the restriction is active; the action is the
                         in-place remedy instead of a 403 at position create. */}
@@ -186,6 +200,17 @@ export function AccountList() {
                       >
                         Edit
                       </DropdownMenuItem>
+                      {/* Withheld from the current default (nothing to do) and
+                          from the sample account (the server refuses it). */}
+                      {!account.isDefault && !account.isDemo && (
+                        <DropdownMenuItem
+                          className="cursor-pointer"
+                          disabled={setDefault.isPending}
+                          onClick={() => setDefault.mutate(account.id)}
+                        >
+                          Make default
+                        </DropdownMenuItem>
+                      )}
                       <DropdownMenuItem
                         className="cursor-pointer text-destructive"
                         onClick={() => setDeleteTarget(account)}

--- a/apps/web/src/features/accounts/hooks/useAccounts.test.ts
+++ b/apps/web/src/features/accounts/hooks/useAccounts.test.ts
@@ -8,7 +8,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { billingKeys } from '@/features/billing/useWalletBalance';
 import { api } from '@/lib/api';
 
-import { useCreateAccount, useDeleteAccount, useSetWritableAccount } from './useAccounts';
+import {
+  useCreateAccount,
+  useDeleteAccount,
+  useSetDefaultAccount,
+  useSetWritableAccount,
+} from './useAccounts';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -75,6 +80,39 @@ describe('useAccounts — tier-key invalidation (plan-tiers)', () => {
     expect(put).toHaveBeenCalledWith('/accounts/writable', { accountId: ACCOUNT_ID });
     expect(invalidate).toHaveBeenCalledWith({ queryKey: billingKeys.tier() });
     expect(toast.success).toHaveBeenCalledWith('Writable account updated');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Default-account designation: the flag lives on the account rows themselves,
+// so it is the accounts list that must refetch — not the tier key.
+// ---------------------------------------------------------------------------
+
+describe('useSetDefaultAccount', () => {
+  it('PUTs the designation and invalidates the accounts list', async () => {
+    const put = vi.spyOn(api, 'put').mockResolvedValue({ defaultAccountId: ACCOUNT_ID });
+    const qc = makeClient();
+    const invalidate = vi.spyOn(qc, 'invalidateQueries');
+
+    const { result } = renderHook(() => useSetDefaultAccount(), { wrapper: makeWrapper(qc) });
+    await result.current.mutateAsync(ACCOUNT_ID);
+
+    expect(put).toHaveBeenCalledWith('/accounts/default', { accountId: ACCOUNT_ID });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['accounts'] });
+    expect(toast.success).toHaveBeenCalledWith('Default account updated');
+  });
+
+  it('toasts the api message on failure', async () => {
+    vi.spyOn(api, 'put').mockRejectedValue({
+      status: 400,
+      error: { code: 'DEMO_ACCOUNT_NOT_DEFAULTABLE', message: 'The sample account cannot…' },
+    });
+    const qc = makeClient();
+
+    const { result } = renderHook(() => useSetDefaultAccount(), { wrapper: makeWrapper(qc) });
+    await expect(result.current.mutateAsync(ACCOUNT_ID)).rejects.toBeTruthy();
+
+    expect(toast.error).toHaveBeenCalledWith('The sample account cannot…');
   });
 });
 

--- a/apps/web/src/features/accounts/hooks/useAccounts.ts
+++ b/apps/web/src/features/accounts/hooks/useAccounts.ts
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 import type {
   Account,
   CreateAccountInput,
+  SetDefaultAccountInput,
   SetWritableAccountInput,
   UpdateAccountInput,
 } from '@tradr/shared';
@@ -120,6 +121,28 @@ export function useDeleteAccount() {
     },
     onError: (err: unknown) => {
       toast.error(getErrorMessage(err, 'Failed to delete account'));
+    },
+  });
+}
+
+/**
+ * PUT /api/accounts/default — move the default-account designation. Unlike the
+ * writable designation below, this lives on the account rows themselves
+ * (`isDefault`), so it is the accounts list that must refetch.
+ */
+export function useSetDefaultAccount() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (accountId: string) => {
+      const body: SetDefaultAccountInput = { accountId };
+      return api.put<{ defaultAccountId: string }>('/accounts/default', body);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accounts'] });
+      toast.success('Default account updated');
+    },
+    onError: (err: unknown) => {
+      toast.error(getErrorMessage(err, 'Failed to update the default account'));
     },
   });
 }

--- a/apps/web/src/features/calculator/components/CalculatorForm.test.tsx
+++ b/apps/web/src/features/calculator/components/CalculatorForm.test.tsx
@@ -624,6 +624,29 @@ describe('CalculatorForm — account picker async states mirror the brokerage se
   });
 });
 
+describe('CalculatorForm — default-account preselection', () => {
+  it('auto-selects the default account and seeds exactly as a click would', async () => {
+    const user = userEvent.setup();
+    setAccounts({ data: [CAD_ACCOUNT, { ...RULED_ACCOUNT, isDefault: true }] });
+    await mount();
+
+    // Selected in dollar mode (the mount default): only the selection itself.
+    expect(selectByOptionValue(RULED_ACCOUNT.id).value).toBe(RULED_ACCOUNT.id);
+
+    // The percent basis then seeds balance + risk from the selected account,
+    // exactly as it does for a hand-picked one.
+    await switchBasis(user, 'Percent');
+    expect(input('Balance').value).toBe('50000');
+    expect(input('Risk percent').value).toBe('1.50');
+  });
+
+  it('selects nothing when no account carries the flag', async () => {
+    setAccounts({ data: [CAD_ACCOUNT, RULED_ACCOUNT] });
+    await mount();
+    expect(selectByOptionValue(RULED_ACCOUNT.id).value).toBe('');
+  });
+});
+
 // -----------------------------------------------------------------------------
 // Task 13 — symbol-search / quote integration
 // -----------------------------------------------------------------------------

--- a/apps/web/src/features/calculator/components/CalculatorForm.tsx
+++ b/apps/web/src/features/calculator/components/CalculatorForm.tsx
@@ -361,6 +361,19 @@ export function CalculatorForm() {
     setSelectedAccount(account);
   };
 
+  // Preselect the user's default account, through the same path a click takes
+  // so the balance/risk seeding behaves identically. Only while nothing is
+  // selected — a null `selectedAccount` is the placeholder, never a choice, so
+  // the user's own pick is never overwritten (and there is no way to unselect,
+  // so this cannot re-fire over one).
+  const defaultAccount = accounts.find((a) => a.isDefault);
+  useEffect(() => {
+    if (selectedAccount !== null || !defaultAccount) return;
+    // handleAccountSelect is recreated per render and deliberately not a dep;
+    // the guards above make the effect idempotent.
+    handleAccountSelect(defaultAccount.id);
+  }, [selectedAccount, defaultAccount]);
+
   // Rendered in BOTH risk bases. In the percent basis it also supplies the
   // balance to size against; in the dollar basis it supplies only the cap figure
   // and the display currency, because a dollar risk is typed directly and a

--- a/apps/web/src/features/csv-import/components/ImportPage.tier.test.tsx
+++ b/apps/web/src/features/csv-import/components/ImportPage.tier.test.tsx
@@ -301,6 +301,43 @@ describe('AccountPicker — writability (D18)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Default-account preselection
+// ---------------------------------------------------------------------------
+
+describe('ImportPage — default-account preselection', () => {
+  function targetAccountSelect(): HTMLSelectElement {
+    const selects = Array.from(document.querySelectorAll('select')) as HTMLSelectElement[];
+    return selects.find((s) => Array.from(s.options).some((o) => o.value === ACCOUNT_A))!;
+  }
+
+  it('preselects the default account as the import target', () => {
+    accountsData.current = [
+      { id: ACCOUNT_A, name: 'Main', currency: 'USD' },
+      { id: ACCOUNT_B, name: 'Swing', currency: 'EUR', isDefault: true },
+    ];
+    render(<ImportPage />);
+
+    expect(targetAccountSelect().value).toBe(ACCOUNT_B);
+  });
+
+  it('withholds the preselect when the default account is not writable (D18)', () => {
+    accountsData.current = [
+      { id: ACCOUNT_A, name: 'Main', currency: 'USD' },
+      { id: ACCOUNT_B, name: 'Swing', currency: 'EUR', isDefault: true },
+    ];
+    tierData.current = tierFixture({
+      accountsUsed: 2,
+      writableAccountId: ACCOUNT_A,
+      csvUsed: 0,
+    });
+    render(<ImportPage />);
+
+    // Its option is disabled, so a preselect would gate the preview on a 403.
+    expect(targetAccountSelect().value).not.toBe(ACCOUNT_B);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Commit refusal mapping — TIER_LIMIT_CSV_IMPORTS (CODE only)
 // ---------------------------------------------------------------------------
 

--- a/apps/web/src/features/csv-import/components/ImportPage.tsx
+++ b/apps/web/src/features/csv-import/components/ImportPage.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAccounts } from '@/features/accounts/hooks/useAccounts';
+import { isAccountWritable } from '@/features/billing/tier-usage';
 import { UpgradeLink } from '@/features/billing/UpgradeLink';
 import { useTierState } from '@/features/billing/useTierState';
 import { CoachMark } from '@/features/onboarding/components/CoachMark';
@@ -62,6 +63,18 @@ export function ImportPage() {
   const { data: accounts } = useAccounts();
   const { data: tierState } = useTierState();
   const currencyCode = accounts?.find((a) => a.id === accountId)?.currency ?? 'USD';
+
+  // Preselect the user's default account while none is chosen — null is the
+  // placeholder, never a choice, so a target the user picked is never
+  // overwritten. Withheld when the default is not writable on the current
+  // plan: AccountPicker disables that option, and a preselected disabled
+  // target would gate the preview on a 403.
+  const defaultAccount = accounts?.find((a) => a.isDefault);
+  useEffect(() => {
+    if (accountId !== null || !defaultAccount) return;
+    if (!isAccountWritable(tierState, defaultAccount.id)) return;
+    setAccountId(defaultAccount.id);
+  }, [accountId, defaultAccount, tierState]);
 
   // Remaining lifetime CSV imports (plan-tiers REQ-10.3) — disclosed BEFORE
   // staging. `usage` is populated only when gating is on and the user is

--- a/apps/web/src/features/positions/components/CreatePositionDialog.test.tsx
+++ b/apps/web/src/features/positions/components/CreatePositionDialog.test.tsx
@@ -396,6 +396,74 @@ describe('CreatePositionDialog — symbol entry', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Default-account preselection
+// ---------------------------------------------------------------------------
+
+describe('CreatePositionDialog — default-account preselection', () => {
+  it('preselects the default account while the field is untouched', async () => {
+    accountsData.current = [
+      { id: ACCOUNT_ID, name: 'Main', currency: 'USD' },
+      { id: ACCOUNT_B_ID, name: 'Swing', currency: 'EUR', isDefault: true },
+    ];
+    renderDialog();
+
+    await waitFor(() => {
+      expect(selectByOptionValue(ACCOUNT_ID).value).toBe(ACCOUNT_B_ID);
+    });
+  });
+
+  it('never overwrites an account the user picked', async () => {
+    accountsData.current = [
+      { id: ACCOUNT_ID, name: 'Main', currency: 'USD' },
+      { id: ACCOUNT_B_ID, name: 'Swing', currency: 'EUR', isDefault: true },
+    ];
+    const { rerender } = renderDialog();
+    await waitFor(() => {
+      expect(selectByOptionValue(ACCOUNT_ID).value).toBe(ACCOUNT_B_ID);
+    });
+
+    chooseAccount();
+    rerender(<CreatePositionDialog open onOpenChange={vi.fn()} />);
+    expect(selectByOptionValue(ACCOUNT_ID).value).toBe(ACCOUNT_ID);
+  });
+
+  // The native-select stub cannot show an empty value (it snaps to its first
+  // option), so "still empty" is proven the way the form itself proves it: a
+  // submit fails the accountId validation and the mutation never fires.
+  async function expectAccountStillEmpty(): Promise<void> {
+    fireEvent.change(screen.getByLabelText('Symbol'), { target: { value: 'AAPL' } });
+    fireEvent.click(createButton());
+    await screen.findByText('Select an account');
+    expect(mutateAsync).not.toHaveBeenCalled();
+  }
+
+  it('leaves the field empty when no account is the default', async () => {
+    accountsData.current = [
+      { id: ACCOUNT_ID, name: 'Main', currency: 'USD' },
+      { id: ACCOUNT_B_ID, name: 'Swing', currency: 'EUR' },
+    ];
+    renderDialog();
+    await expectAccountStillEmpty();
+  });
+
+  it('withholds the preselect when the default account is not writable (D18)', async () => {
+    accountsData.current = [
+      { id: ACCOUNT_ID, name: 'Main', currency: 'USD' },
+      { id: ACCOUNT_B_ID, name: 'Swing', currency: 'EUR', isDefault: true },
+    ];
+    // Over-cap on enforced free with Main designated — the default (Swing) is
+    // read-only, and preselecting a disabled option would invite the 403.
+    tierData.current = tierFixture({
+      accountsUsed: 2,
+      writableAccountId: ACCOUNT_ID,
+      positionsUsed: 0,
+    });
+    renderDialog();
+    await expectAccountStillEmpty();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Plan tiers (design Component 12; REQ-6.4, REQ-11.5/11.6)
 // ---------------------------------------------------------------------------
 

--- a/apps/web/src/features/positions/components/CreatePositionDialog.tsx
+++ b/apps/web/src/features/positions/components/CreatePositionDialog.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -164,6 +164,21 @@ export function CreatePositionDialog({ open, onOpenChange }: Props) {
   });
 
   const assetType = form.watch('assetType');
+
+  // Preselect the user's default account while the field is still untouched —
+  // an empty value is the placeholder, never a choice, so nothing the user
+  // picked is ever overwritten (a re-run with a value present is a no-op, and
+  // the reset after a successful create re-seeds the same way). Withheld when
+  // the default account is not writable on the current plan: its option is
+  // disabled below, and a preselected disabled option would invite the 403 the
+  // disabling exists to prevent.
+  const defaultAccount = accounts?.find((a) => a.isDefault);
+  useEffect(() => {
+    if (!open || !defaultAccount) return;
+    if (form.getValues('accountId') !== '') return;
+    if (!isAccountWritable(tierState, defaultAccount.id)) return;
+    form.setValue('accountId', defaultAccount.id);
+  }, [open, defaultAccount, tierState, form]);
 
   // Req 1.3: preserve side/account/notes; clear the stock symbol and all option
   // inputs; reset Type → Call. Values are NOT restored on toggle-back.

--- a/e2e/tests/option-position-entry.spec.ts
+++ b/e2e/tests/option-position-entry.spec.ts
@@ -170,7 +170,9 @@ test.describe.serial('Option position entry — full flow', () => {
     await dialog.getByLabel('Strike').fill('120');
     // Type defaults to Call — leave it (asserted on prefill below).
 
-    await chooseFromUnnamedSelect(page, dialog, 'Select account', ACCOUNT_LABEL);
+    // The account picker preselects the user's default account (their first
+    // and only one) — no manual choice needed, and the trigger says which.
+    await expect(dialog.getByRole('combobox').filter({ hasText: ACCOUNT_LABEL })).toBeVisible();
 
     await dialog.getByRole('button', { name: 'Create' }).click();
 
@@ -214,7 +216,8 @@ test.describe.serial('Option position entry — full flow', () => {
 
     // Asset Type stays Stock (default) — a bare ticker, no OCC encoding.
     await dialog.getByLabel('Symbol').fill('AAPL');
-    await chooseFromUnnamedSelect(page, dialog, 'Select account', ACCOUNT_LABEL);
+    // Preselected with the default account — see the option-flow test above.
+    await expect(dialog.getByRole('combobox').filter({ hasText: ACCOUNT_LABEL })).toBeVisible();
 
     await dialog.getByRole('button', { name: 'Create' }).click();
 

--- a/e2e/tests/user-onboarding.spec.ts
+++ b/e2e/tests/user-onboarding.spec.ts
@@ -373,10 +373,15 @@ function dialogSelect(dialog: Locator, label: string): Locator {
  */
 const CLOSE_STEP_TITLES = ['Record the exit', 'It closes itself', 'And there it is'] as const;
 
-/** An account, over the API — this suite's own guided path already covers the UI one. */
+/**
+ * An account, over the API — this suite's own guided path already covers the UI
+ * one. Funded: as the user's first account it is the default the calculator now
+ * auto-selects, and a zero-cash account caps a dollar-risk size at nothing, so
+ * the calculator traversal would never see its results render.
+ */
 async function createAccount(req: APIRequestContext, name: string): Promise<string> {
   const res = await req.post('/api/accounts', {
-    data: { name, currency: 'USD' },
+    data: { name, currency: 'USD', startingBalance: '10000' },
     headers: { 'X-Forwarded-For': uniqueIp() },
   });
   expect(res.status(), `POST /accounts ${name}`).toBe(201);

--- a/packages/shared/src/schemas/account.test.ts
+++ b/packages/shared/src/schemas/account.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { AccountSchema, CreateAccountSchema, UpdateAccountSchema } from './account';
+import {
+  AccountSchema,
+  CreateAccountSchema,
+  SetDefaultAccountSchema,
+  UpdateAccountSchema,
+} from './account';
 
 const baseCreate = { name: 'Main', currency: 'USD' };
 
@@ -124,5 +129,42 @@ describe('AccountSchema.defaultRiskPercent', () => {
     const result = AccountSchema.safeParse({ ...baseAccount, defaultRiskPercent: '3.00' });
     expect(result.success).toBe(true);
     if (result.success) expect(result.data.defaultRiskPercent).toBe('3.00');
+  });
+
+  describe('isDefault', () => {
+    it('parses when the field is absent (existing fixtures keep working)', () => {
+      const result = AccountSchema.safeParse(baseAccount);
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.isDefault).toBeUndefined();
+    });
+
+    it('parses a stored value', () => {
+      const result = AccountSchema.safeParse({ ...baseAccount, isDefault: true });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.isDefault).toBe(true);
+    });
+
+    // Server-set only, like isDemo: no request body may claim it.
+    it('is absent from CreateAccountSchema and UpdateAccountSchema', () => {
+      const created = CreateAccountSchema.safeParse({ ...baseCreate, isDefault: true });
+      expect(created.success).toBe(true);
+      if (created.success) expect(created.data).not.toHaveProperty('isDefault');
+      const updated = UpdateAccountSchema.safeParse({ isDefault: true });
+      expect(updated.success).toBe(true);
+      if (updated.success) expect(updated.data).not.toHaveProperty('isDefault');
+    });
+  });
+});
+
+describe('SetDefaultAccountSchema', () => {
+  it('accepts a uuid accountId', () => {
+    expect(
+      SetDefaultAccountSchema.safeParse({ accountId: '11111111-1111-4111-8111-111111111111' })
+        .success,
+    ).toBe(true);
+  });
+
+  it.each([[{}], [{ accountId: 'not-a-uuid' }], [{ accountId: 42 }]])('rejects %j', (body) => {
+    expect(SetDefaultAccountSchema.safeParse(body).success).toBe(false);
   });
 });

--- a/packages/shared/src/schemas/account.ts
+++ b/packages/shared/src/schemas/account.ts
@@ -130,8 +130,21 @@ export const AccountSchema = z.object({
   // UpdateAccountSchema, so no request can claim it. `.optional()` for the same
   // reason as `balance` above — existing fixtures build accounts without it.
   isDemo: z.boolean().optional(),
+  // True on the user's default account — the one pickers preselect — and on
+  // exactly one account per user. Server-set and read-only like `isDemo`: the
+  // first account created takes it, and `PUT /api/accounts/default` moves it.
+  // `.optional()` for the same reason as `balance` above.
+  isDefault: z.boolean().optional(),
+});
+
+// Body of PUT /api/accounts/default — mirrors SetWritableAccountSchema
+// (schemas/tier.ts), but the default designation is an accounts concern, so it
+// lives here.
+export const SetDefaultAccountSchema = z.object({
+  accountId: z.string().uuid(),
 });
 
 export type CreateAccountInput = z.infer<typeof CreateAccountSchema>;
 export type UpdateAccountInput = z.infer<typeof UpdateAccountSchema>;
 export type Account = z.infer<typeof AccountSchema>;
+export type SetDefaultAccountInput = z.infer<typeof SetDefaultAccountSchema>;


### PR DESCRIPTION
## What

Account pickers no longer sit on "Select an account": they preselect the user's **default account**.

- The first account a user creates becomes the default; exactly one per user, enforced by a partial unique index (`accounts_one_default_per_user`).
- The default can be moved from `/accounts` — a **Default** badge on the row and **Make default** in the row menu.
- Deleting the default promotes the oldest remaining non-demo account; the sample account can never hold the designation.
- Preselection lands in the position dialog, the calculator (through the same path a click takes, so balance/risk seeding matches), and the CSV-import target picker — withheld when the default account is read-only on the current plan, and never overwriting a value the user picked.
- Existing users are backfilled: their oldest non-demo account becomes the default.

## API

- `accounts.is_default` (server-set only, like `is_demo`) + migrations `0031_account_is_default` / `0032_account_default_backfill` (idempotent, rolling-deploy safe).
- `PUT /api/accounts/default` (`{ accountId }`), registered ahead of `PUT /:id`, with `@swagger` docs; 404 non-owned, `400 DEMO_ACCOUNT_NOT_DEFAULTABLE` for the sample account. All flips run under the per-user account lock.
- `isDefault` on both account projections; OpenAPI + db-schema reference regenerated.

## Tests

- API: 100 green in the accounts feature (8 new covering first-takes-default, atomic flip, route shadowing, demo refusal, delete-promotion, update cannot set it); shared schema 42; web sweep 395 (new AccountList/useAccounts/CreatePositionDialog/CalculatorForm/ImportPage cases).
- `drizzle-kit check`, `check:migrations`, `pnpm -r check-types`, `pnpm lint` all clean.
- e2e: `option-position-entry.spec.ts` placeholder matchers replaced with assertions pinning the preselect.