### PR TITLE
feat(calculator): adopt the selected account's fee structure

### DIFF
--- a/apps/web/src/features/calculator/components/CalculatorForm.test.tsx
+++ b/apps/web/src/features/calculator/components/CalculatorForm.test.tsx
@@ -647,6 +647,152 @@ describe('CalculatorForm — default-account preselection', () => {
   });
 });
 
+describe('CalculatorForm — account fee adoption', () => {
+  // The account's own fee arrangement: a brokerage carrying a schedule, and an
+  // account attached to it. Selecting that account must do what clicking the
+  // brokerage under Fees does — no re-picking what the account already states.
+  const FEE_SCHEDULE = {
+    stockPerShareCommission: '0.01',
+    stockMinPerFill: '1.00',
+    stockMaxPerFill: '5.00',
+    optionsPerContractCommission: '0.65',
+    optionsPerContractExchangeFee: '0.10',
+    optionsMinPerFill: '1.00',
+    optionsMaxPerFill: '10.00',
+  };
+  const BROKERAGE = { id: 'brk-1', name: 'Fee Broker', feeSchedule: FEE_SCHEDULE };
+  const BROKERED_ACCOUNT = {
+    id: 'acc-brk',
+    name: 'Brokered',
+    currency: 'USD',
+    balance: '50000',
+    brokerageId: 'brk-1',
+  };
+
+  function setBrokerages(data: unknown[]): void {
+    state.brokerages.current = { data, isLoading: false, isError: false };
+  }
+
+  function feeTab(name: 'None' | 'Brokerage' | 'Manual'): HTMLElement {
+    return screen.getByRole('tab', { name });
+  }
+
+  it('selecting an account with a brokerage adopts its fee structure', async () => {
+    setAccounts({ data: [BROKERED_ACCOUNT] });
+    setBrokerages([BROKERAGE]);
+    await mount();
+
+    fireEvent.change(selectByOptionValue(BROKERED_ACCOUNT.id), {
+      target: { value: BROKERED_ACCOUNT.id },
+    });
+
+    expect(feeTab('Brokerage').getAttribute('aria-selected')).toBe('true');
+    expect(selectByOptionValue(BROKERAGE.id).value).toBe(BROKERAGE.id);
+    // The schedule landed on the form: the "Select a brokerage" hint renders
+    // exactly when feeMode is 'brokerage' with no schedule set.
+    expect(screen.queryByText(/Select a brokerage to see fee estimates/)).toBeNull();
+  });
+
+  it('the default-account preselect adopts too', async () => {
+    setAccounts({ data: [{ ...BROKERED_ACCOUNT, isDefault: true }] });
+    setBrokerages([BROKERAGE]);
+    await mount();
+
+    expect(selectByOptionValue(BROKERED_ACCOUNT.id).value).toBe(BROKERED_ACCOUNT.id);
+    expect(feeTab('Brokerage').getAttribute('aria-selected')).toBe('true');
+    expect(selectByOptionValue(BROKERAGE.id).value).toBe(BROKERAGE.id);
+  });
+
+  it('an account with no brokerage leaves the fee mode untouched', async () => {
+    setAccounts({ data: [CAD_ACCOUNT] });
+    setBrokerages([BROKERAGE]);
+    await mount();
+
+    fireEvent.change(selectByOptionValue(CAD_ACCOUNT.id), {
+      target: { value: CAD_ACCOUNT.id },
+    });
+
+    expect(feeTab('None').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('withdraws ADOPTED fees when switching to a brokerage-less account', async () => {
+    setAccounts({ data: [BROKERED_ACCOUNT, CAD_ACCOUNT] });
+    setBrokerages([BROKERAGE]);
+    await mount();
+
+    fireEvent.change(selectByOptionValue(BROKERED_ACCOUNT.id), {
+      target: { value: BROKERED_ACCOUNT.id },
+    });
+    expect(feeTab('Brokerage').getAttribute('aria-selected')).toBe('true');
+
+    // The switch: this account states no fee structure, and pricing its
+    // estimate on the previous account's schedule would be silently wrong.
+    fireEvent.change(selectByOptionValue(CAD_ACCOUNT.id), {
+      target: { value: CAD_ACCOUNT.id },
+    });
+    expect(feeTab('None').getAttribute('aria-selected')).toBe('true');
+    // The brokerage picker (and the old selection with it) is gone.
+    expect(screen.queryByText('Fee Broker')).toBeNull();
+  });
+
+  it('user-chosen fees survive a switch to a brokerage-less account', async () => {
+    const user = userEvent.setup();
+    setAccounts({ data: [BROKERED_ACCOUNT, CAD_ACCOUNT] });
+    setBrokerages([BROKERAGE]);
+    await mount();
+
+    fireEvent.change(selectByOptionValue(BROKERED_ACCOUNT.id), {
+      target: { value: BROKERED_ACCOUNT.id },
+    });
+    // The user takes over: Manual is their call, not the adoption's.
+    await user.click(feeTab('Manual'));
+    expect(feeTab('Manual').getAttribute('aria-selected')).toBe('true');
+
+    fireEvent.change(selectByOptionValue(CAD_ACCOUNT.id), {
+      target: { value: CAD_ACCOUNT.id },
+    });
+    expect(feeTab('Manual').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('a fee choice made after selecting the account is not overridden', async () => {
+    const user = userEvent.setup();
+    setAccounts({ data: [BROKERED_ACCOUNT] });
+    setBrokerages([BROKERAGE]);
+    await mount();
+
+    fireEvent.change(selectByOptionValue(BROKERED_ACCOUNT.id), {
+      target: { value: BROKERED_ACCOUNT.id },
+    });
+    expect(feeTab('Brokerage').getAttribute('aria-selected')).toBe('true');
+
+    // The user walks the adoption back to None; re-renders (any state change
+    // re-runs the adoption effect) must not re-adopt for the same account.
+    await user.click(feeTab('None'));
+    expect(feeTab('None').getAttribute('aria-selected')).toBe('true');
+    await switchBasis(user, 'Percent');
+    expect(feeTab('None').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('adopts when the brokerages land after the account was selected', async () => {
+    setAccounts({ data: [BROKERED_ACCOUNT] });
+    state.brokerages.current = { data: undefined, isLoading: true, isError: false };
+    await mount();
+
+    fireEvent.change(selectByOptionValue(BROKERED_ACCOUNT.id), {
+      target: { value: BROKERED_ACCOUNT.id },
+    });
+    // Nothing to adopt from yet.
+    expect(feeTab('None').getAttribute('aria-selected')).toBe('true');
+
+    // The brokerages query resolves; any re-render picks it up.
+    setBrokerages([BROKERAGE]);
+    fireEvent.change(input('Entry price'), { target: { value: '50' } });
+
+    expect(feeTab('Brokerage').getAttribute('aria-selected')).toBe('true');
+    expect(selectByOptionValue(BROKERAGE.id).value).toBe(BROKERAGE.id);
+  });
+});
+
 // -----------------------------------------------------------------------------
 // Task 13 — symbol-search / quote integration
 // -----------------------------------------------------------------------------

--- a/apps/web/src/features/calculator/components/CalculatorForm.tsx
+++ b/apps/web/src/features/calculator/components/CalculatorForm.tsx
@@ -92,6 +92,20 @@ export function CalculatorForm() {
   const [riskBasis, setRiskBasis] = useState<RiskBasis>('dollar');
   const [selectedAccount, setSelectedAccount] = useState<Account | null>(null);
 
+  // Which account's fee arrangement the form last settled, and WHOSE call it
+  // was — the adoption effect below ('adopted'), or the user making a fee
+  // choice of their own while that account was selected ('user', written by the
+  // two handlers). One value serves both so they cannot fight: adoption runs
+  // once per selected account, never over a choice the user has made since —
+  // and the source is what lets a later account switch tell fees the form
+  // borrowed from an old account (withdraw them) apart from fees the user
+  // asked for (keep them). `accountId` is null for a choice made before any
+  // account was selected.
+  const feeAdoptionFor = useRef<{
+    accountId: string | null;
+    source: 'adopted' | 'user';
+  } | null>(null);
+
   // Stock-mode symbol is UI-only local state (OD#4) — NOT a form field, so
   // CalculatorInputSchema and the calculator endpoint stay untouched (REQ-1.5).
   const [symbol, setSymbol] = useState<string>('');
@@ -230,6 +244,8 @@ export function CalculatorForm() {
     setValue('manualFees', undefined, { shouldValidate: true });
     setSelectedBrokerageId('');
     setFeeMode(nextMode);
+    // A mode the user chose outranks the adoption below — see feeAdoptionFor.
+    feeAdoptionFor.current = { accountId: selectedAccount?.id ?? null, source: 'user' };
   };
 
   // Mode-switch clear (REQ-5.5). ORDER IS LOAD-BEARING: clear the three
@@ -300,6 +316,9 @@ export function CalculatorForm() {
     const parsed = FeeScheduleSchema.parse(brokerage.feeSchedule);
     setSelectedBrokerageId(brokerageId);
     setValue('feeSchedule', parsed, { shouldValidate: true });
+    // Same claim as a mode change: a brokerage the user picked by hand is
+    // theirs, whatever the selected account is attached to.
+    feeAdoptionFor.current = { accountId: selectedAccount?.id ?? null, source: 'user' };
   };
 
   // Seed the risk percent from the account's own rule, at the two points that
@@ -373,6 +392,65 @@ export function CalculatorForm() {
     // the guards above make the effect idempotent.
     handleAccountSelect(defaultAccount.id);
   }, [selectedAccount, defaultAccount]);
+
+  // ADOPT THE SELECTED ACCOUNT'S FEE STRUCTURE. The account names a brokerage
+  // and the brokerage carries the fee schedule, yet the Fees tab used to sit on
+  // "none" until the user re-picked by hand what their account already states.
+  // Selecting an account — by click or the default preselect above, both of
+  // which land in `selectedAccount` — now does exactly what choosing that
+  // brokerage under Fees does: mode 'brokerage', the account's brokerage
+  // selected, its schedule on the form.
+  //
+  // An account with NO brokerage adopts nothing of its own — "None is
+  // perfectly valid" is the account form's promise, and those users keep
+  // entering fees per calculation. But it does not inherit either: fees the
+  // form ADOPTED from a previously selected account are withdrawn on the
+  // switch, because silently pricing this account's estimate on another
+  // account's fee schedule is exactly the confusion adoption exists to remove.
+  // A fee arrangement the USER chose stands, on this switch as on any other.
+  //
+  // Once per selected account, via `feeAdoptionFor`: a fee mode or brokerage
+  // the user chooses afterwards stands until they switch accounts, which
+  // re-settles. In the effect rather than `handleAccountSelect` because the
+  // brokerages arrive on their own query — an account selected before they
+  // land adopts the moment they do, the ref keeps the late arrival from
+  // overriding anything the user did in between, and an unresolved brokerage
+  // id is only treated as "no fee structure" once that query has actually
+  // answered (a dangling id after a landed list means a deleted brokerage).
+  useEffect(() => {
+    if (!selectedAccount) return;
+    const claim = feeAdoptionFor.current;
+    if (claim?.accountId === selectedAccount.id) return;
+
+    const brokerage = selectedAccount.brokerageId
+      ? brokerages.find((b) => b.id === selectedAccount.brokerageId)
+      : undefined;
+
+    if (brokerage) {
+      feeAdoptionFor.current = { accountId: selectedAccount.id, source: 'adopted' };
+      setFeeMode('brokerage');
+      setSelectedBrokerageId(brokerage.id);
+      setValue('feeSchedule', FeeScheduleSchema.parse(brokerage.feeSchedule), {
+        shouldValidate: true,
+      });
+      setValue('manualFees', undefined, { shouldValidate: true });
+      return;
+    }
+
+    // Still waiting on the brokerages for an id that may yet resolve — settle
+    // nothing, so the adoption above runs the moment they land.
+    if (selectedAccount.brokerageId && !brokeragesQuery.isSuccess) return;
+
+    // This account states no fee structure. Withdraw one the form only had by
+    // adoption; leave one the user asked for.
+    if (claim?.source === 'adopted') {
+      feeAdoptionFor.current = { accountId: selectedAccount.id, source: 'adopted' };
+      setFeeMode('none');
+      setSelectedBrokerageId('');
+      setValue('feeSchedule', undefined, { shouldValidate: true });
+      setValue('manualFees', undefined, { shouldValidate: true });
+    }
+  }, [selectedAccount, brokerages, brokeragesQuery.isSuccess, setValue]);
 
   // Rendered in BOTH risk bases. In the percent basis it also supplies the
   // balance to size against; in the dollar basis it supplies only the cap figure

--- a/apps/web/src/features/onboarding/lib/steps/calculator.ts
+++ b/apps/web/src/features/onboarding/lib/steps/calculator.ts
@@ -129,7 +129,9 @@ export const calculatorSteps: readonly WalkthroughStepSource[] = [
     body:
       'Pick the account you are trading. Under Percent it supplies the balance to size against, ' +
       'and in either basis it supplies the currency and caps the position at the buying power ' +
-      'the account actually has.',
+      'the account actually has. An account with a brokerage attached also brings that ' +
+      'brokerage&rsquo;s fee schedule into the estimate for you — under Fees you can still ' +
+      'change or clear it.',
   },
   {
     // Whichever field the basis chosen two steps ago renders; exactly one of the


### PR DESCRIPTION
## What

The calculator stops forcing a manual fee-structure pick when the selected account already states one. Selecting an account (by hand, or via the default-account preselect from #97) whose brokerage is attached now does exactly what choosing that brokerage under Fees does: fee mode flips to Brokerage, the account's brokerage is selected, and its fee schedule lands on the form.

Rules:
- Adoption settles once per selected account; a fee mode or brokerage the user chooses afterwards stands until they switch accounts.
- Switching to an account with **no** brokerage withdraws fees the form only had by adoption (back to "none") — another account's schedule is never silently applied — while a fee arrangement the user chose survives the switch.
- Brokerages load on their own query: an account selected before they land adopts the moment they do, and a dangling brokerage id only counts as "no fee structure" once the list has actually answered.

Positions and fills already derive fees from the account's brokerage server-side (read-only calculated fee + override in the fill dialog), so the calculator was the one surface with this gap.

The calculator walkthrough's Account step copy now mentions the adoption.

## Tests

- 7 new CalculatorForm tests (hand-pick adoption, preselect adoption, no-brokerage account stays "none", user choice survives re-renders and the brokerage-less switch, adopted fees withdrawn on that switch, late-landing brokerages adopt on arrival); calculator scope 66 green, onboarding scope 530 green (step-claim tests accept the copy).
- `check-types` and `eslint` clean; no e2e changes needed (the onboarding calculator traversal uses an account with no brokerage).