### PR TITLE
test(calculator): wait for the first-use write instead of racing it

### DIFF
--- a/apps/web/src/features/calculator/components/CalculatorForm.test.tsx
+++ b/apps/web/src/features/calculator/components/CalculatorForm.test.tsx
@@ -7,7 +7,7 @@ import {
   createRouter,
   RouterProvider,
 } from '@tanstack/react-router';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -1307,7 +1307,11 @@ describe('CalculatorForm — first calculator use (the one stored checklist fact
     await results(user, 'Dollar', dollarCalc);
     expect(await screen.findByText('500', undefined, { timeout: 2000 })).toBeTruthy();
 
-    expect(onboarding.patch).toHaveBeenCalledTimes(1);
+    // The write is an effect gated on the preference read, so it can land a
+    // beat after the numbers paint — asserted with a wait, not synchronously.
+    // Asserted at exactly one for the same reason as before: a second call
+    // here would be the repeated-write defect the next test pins.
+    await waitFor(() => expect(onboarding.patch).toHaveBeenCalledTimes(1));
     const [body] = onboarding.patch.mock.calls[0] as [Record<string, string>];
     // ONLY this key. The other three checklist items are derived from the
     // user's real rows and must never acquire a flag alongside it.


### PR DESCRIPTION
The `calculatorFirstUsedAt` write is a fire-and-forget effect gated on the onboarding preference read, so it can land a beat after the calculation result paints. The test asserted the spy synchronously right after `findByText('500')` and lost that race once on main's CI (test-web on the v0.12.0 release commit), blocking the release gate until a rerun. The assertion now waits, still pinned at exactly one call.