### PR TITLE
feat(calculator): add "Save as draft trade" button

### DIFF
--- a/apps/web/src/features/calculator/components/CalculatorForm.test.tsx
+++ b/apps/web/src/features/calculator/components/CalculatorForm.test.tsx
@@ -166,6 +166,23 @@ vi.mock('@/features/options/components/OptionsChainViewer', () => ({
   ),
 }));
 
+// The "Save as draft trade" button's create flow. Mocked at the hook boundary
+// so no network is hit and the payload passed to the mutation is assertable;
+// `getPositionErrorCode` keeps its real shape so the tier-refusal branch is
+// exercised end to end.
+const positions = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  isPending: { current: false },
+}));
+vi.mock('@/features/positions/hooks/usePositions', () => ({
+  useCreatePosition: () => ({ mutate: positions.mutate, isPending: positions.isPending.current }),
+  getPositionErrorCode: (err: unknown) =>
+    (err as { error?: { code?: string } } | null | undefined)?.error?.code,
+}));
+
+const sonnerToast = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn() }));
+vi.mock('sonner', () => ({ toast: sonnerToast }));
+
 import { CalculatorForm } from './CalculatorForm';
 
 // ---- Fixtures ---------------------------------------------------------------
@@ -299,6 +316,9 @@ beforeEach(() => {
   onboarding.query.current = { data: { status: 'pending', coachMarksSeen: [] } };
   onboarding.patch.mockClear();
   onboarding.options.current = undefined;
+  positions.mutate.mockReset();
+  positions.isPending.current = false;
+  sonnerToast.error.mockClear();
 });
 
 afterEach(() => {
@@ -1402,5 +1422,123 @@ describe('CalculatorForm — first calculator use (the one stored checklist fact
     ).toBeTruthy();
 
     expect(onboarding.patch).not.toHaveBeenCalled();
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Save as draft trade — creates a draft position (no fills) from the planned
+// instrument. Sends only what CreatePositionSchema accepts; entry price and the
+// derived size are calculator-only and are not part of a draft.
+// -----------------------------------------------------------------------------
+
+describe('CalculatorForm — save as draft trade', () => {
+  beforeEach(resetQuoteFixtures);
+
+  function saveButton(): HTMLButtonElement {
+    return screen.getByRole('button', { name: 'Save as draft trade' }) as HTMLButtonElement;
+  }
+
+  it('is disabled with a guiding hint until an account and a symbol are set', async () => {
+    setAccounts({ data: [CAD_ACCOUNT] });
+    await mount();
+
+    expect(saveButton().disabled).toBe(true);
+    expect(screen.getByText('Select an account to save a draft.')).toBeTruthy();
+
+    // Account selected — now the symbol is what's missing.
+    fireEvent.change(selectByOptionValue(CAD_ACCOUNT.id), { target: { value: CAD_ACCOUNT.id } });
+    expect(saveButton().disabled).toBe(true);
+    expect(screen.getByText('Enter a symbol to save a draft.')).toBeTruthy();
+
+    // Symbol entered — enabled, and the hint is gone.
+    fireEvent.change(input('Symbol'), { target: { value: 'AAPL' } });
+    expect(saveButton().disabled).toBe(false);
+    expect(screen.queryByText(/to save a draft/)).toBeNull();
+  });
+
+  it('creates a stock draft carrying the account, symbol, side, and stop/target plan', async () => {
+    setAccounts({ data: [CAD_ACCOUNT] });
+    await mount();
+
+    fireEvent.change(selectByOptionValue(CAD_ACCOUNT.id), { target: { value: CAD_ACCOUNT.id } });
+    fireEvent.change(input('Symbol'), { target: { value: 'aapl' } });
+    fill('Stop loss', '48');
+    fill('Target price (optional)', '55');
+
+    fireEvent.click(saveButton());
+
+    expect(positions.mutate).toHaveBeenCalledTimes(1);
+    expect(positions.mutate.mock.calls[0][0]).toEqual({
+      accountId: CAD_ACCOUNT.id,
+      symbol: 'AAPL',
+      side: 'long',
+      assetType: 'stock',
+      stopLoss: '48',
+      targetPrice: '55',
+    });
+  });
+
+  it('carries the short side and omits target/stop when left blank', async () => {
+    const user = userEvent.setup();
+    setAccounts({ data: [CAD_ACCOUNT] });
+    await mount();
+
+    fireEvent.change(selectByOptionValue(CAD_ACCOUNT.id), { target: { value: CAD_ACCOUNT.id } });
+    fireEvent.change(input('Symbol'), { target: { value: 'TSLA' } });
+    await user.click(screen.getByRole('tab', { name: 'Short' }));
+
+    fireEvent.click(saveButton());
+
+    expect(positions.mutate.mock.calls[0][0]).toEqual({
+      accountId: CAD_ACCOUNT.id,
+      symbol: 'TSLA',
+      side: 'short',
+      assetType: 'stock',
+    });
+  });
+
+  it('creates an option draft from the handed-off OCC contract', async () => {
+    const user = userEvent.setup();
+    setAccounts({ data: [CAD_ACCOUNT] });
+    quote.contracts.current = [{ option_symbol: 'AAPL  250620C00150000', premium: 3.25 }];
+    await mount();
+
+    fireEvent.change(selectByOptionValue(CAD_ACCOUNT.id), { target: { value: CAD_ACCOUNT.id } });
+    await user.click(screen.getByRole('tab', { name: 'Options' }));
+
+    // No contract picked yet — the hint names what's missing in options mode.
+    expect(saveButton().disabled).toBe(true);
+    expect(screen.getByText('Select a contract to save a draft.')).toBeTruthy();
+
+    await user.click(screen.getByRole('button', { name: 'Select from options chain' }));
+    await user.click(screen.getByRole('button', { name: /Use AAPL/ }));
+    fill('Stop loss', '2.50');
+
+    fireEvent.click(saveButton());
+
+    expect(positions.mutate.mock.calls[0][0]).toEqual({
+      accountId: CAD_ACCOUNT.id,
+      symbol: 'AAPL  250620C00150000',
+      side: 'long',
+      assetType: 'option',
+      stopLoss: '2.50',
+    });
+  });
+
+  it('surfaces a tier refusal as a toast — the shared hook stays silent on it', async () => {
+    setAccounts({ data: [CAD_ACCOUNT] });
+    positions.mutate.mockImplementation(
+      (_payload: unknown, opts?: { onError?: (e: unknown) => void }) =>
+        opts?.onError?.({
+          error: { code: 'TIER_LIMIT_POSITIONS', message: "You've reached your plan's limit." },
+        }),
+    );
+    await mount();
+
+    fireEvent.change(selectByOptionValue(CAD_ACCOUNT.id), { target: { value: CAD_ACCOUNT.id } });
+    fireEvent.change(input('Symbol'), { target: { value: 'AAPL' } });
+    fireEvent.click(saveButton());
+
+    expect(sonnerToast.error).toHaveBeenCalledWith("You've reached your plan's limit.");
   });
 });

--- a/apps/web/src/features/calculator/components/CalculatorForm.tsx
+++ b/apps/web/src/features/calculator/components/CalculatorForm.tsx
@@ -2,6 +2,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Link } from '@tanstack/react-router';
 import { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
 
 import {
   type Account,
@@ -9,6 +10,7 @@ import {
   type CalculatorInput,
   CalculatorInputSchema,
   type CalculatorOutput,
+  type CreatePositionInput,
   FeeScheduleSchema,
   parseOccSymbol,
 } from '@tradr/shared';
@@ -38,6 +40,7 @@ import { useBuyingPowerBasisQuery } from '@/features/calculator/hooks/useBuyingP
 import { useOnboardingPatch, useOnboardingQuery } from '@/features/onboarding/hooks/useOnboarding';
 import { OptionsChainViewer } from '@/features/options/components/OptionsChainViewer';
 import type { OptionContract } from '@/features/options/hooks/useOptionsChain';
+import { getPositionErrorCode, useCreatePosition } from '@/features/positions/hooks/usePositions';
 import { useStockQuote } from '@/hooks/useStockQuote';
 import { useStockQuoteConfig } from '@/hooks/useStockQuoteConfig';
 import { formatMoney } from '@/lib/format';
@@ -124,6 +127,8 @@ export function CalculatorForm() {
 
   const accountsQuery = useAccounts();
   const accounts = accountsQuery.data ?? [];
+
+  const createPosition = useCreatePosition();
 
   // Which account figure the buying-power cap sizes against. Defaults to 'cash'
   // while the preference is in flight so a slow settings fetch cannot silently
@@ -524,6 +529,51 @@ export function CalculatorForm() {
     </div>
   );
 
+  // "Save as draft trade" — persist the planned instrument as a draft position
+  // (a position with no fills). Sends what CreatePositionSchema accepts: the
+  // account, symbol, side (direction), asset type (mode), and the stop/target
+  // plan annotations. Entry price and the derived size are calculator-only and
+  // are recorded later on the entry fill, so they are not part of a draft.
+  // Reuses the positions create flow so caches and the success toast stay
+  // consistent with the rest of the app.
+  const draftSymbol = mode === 'options' ? (handedOffOcc ?? '') : symbol.trim().toUpperCase();
+  const canSaveDraft = selectedAccount !== null && draftSymbol !== '';
+  const saveDraftHint =
+    selectedAccount === null
+      ? 'Select an account to save a draft.'
+      : draftSymbol === ''
+        ? mode === 'options'
+          ? 'Select a contract to save a draft.'
+          : 'Enter a symbol to save a draft.'
+        : null;
+
+  const handleSaveDraft = () => {
+    if (!selectedAccount || draftSymbol === '') return;
+    const payload: CreatePositionInput = {
+      accountId: selectedAccount.id,
+      symbol: draftSymbol,
+      side: direction,
+      assetType: mode === 'options' ? 'option' : 'stock',
+    };
+    const stop = values.stopLoss.trim();
+    if (stop) payload.stopLoss = stop;
+    const target = values.targetPrice?.trim();
+    if (target) payload.targetPrice = target;
+
+    createPosition.mutate(payload, {
+      // The shared hook stays silent on tier refusals so the create DIALOG can
+      // render them inline; the calculator has no such slot, so surface them
+      // as a toast rather than let the click fail silently.
+      onError: (err) => {
+        const code = getPositionErrorCode(err);
+        if (code === 'TIER_LIMIT_POSITIONS' || code === 'TIER_ACCOUNT_NOT_WRITABLE') {
+          const message = (err as { error?: { message?: string } }).error?.message;
+          toast.error(message ?? "You've reached your plan's position limit.");
+        }
+      },
+    });
+  };
+
   return (
     <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
       <form className="space-y-6" onSubmit={(e) => e.preventDefault()}>
@@ -820,6 +870,18 @@ export function CalculatorForm() {
               )}
             </div>
           )}
+        </div>
+
+        <div className="space-y-2">
+          <Button
+            type="button"
+            className="w-full cursor-pointer"
+            disabled={!canSaveDraft || createPosition.isPending}
+            onClick={handleSaveDraft}
+          >
+            {createPosition.isPending ? 'Saving…' : 'Save as draft trade'}
+          </Button>
+          {saveDraftHint && <p className="text-sm text-muted-foreground">{saveDraftHint}</p>}
         </div>
       </form>
 


### PR DESCRIPTION
## What

Adds a **Save as draft trade** button to the trade calculator (`/calculator`).
It saves the trade you've planned as a draft position — a position with no
fills yet — so you can size a trade and keep it for later without re-entering
everything on the Positions page.

## Details

- Reuses the existing create-position flow (`useCreatePosition` →
  `POST /positions`), which already defaults new positions to `draft` status.
- Sends what `CreatePositionSchema` accepts: `accountId`, `symbol` (the stock
  symbol, or the handed-off OCC contract in options mode), `side` (direction),
  `assetType` (mode), and the optional `stopLoss` / `targetPrice` plan
  annotations.
- Entry price and the derived position size are calculator-only and aren't part
  of a draft — they're recorded later on the entry fill.
- The button is gated on a selected account and a symbol, with an inline hint
  naming whatever's still missing.
- Tier refusals (position cap / read-only account) are surfaced as a toast,
  since the calculator has no inline slot for them like the create dialog does.

## Tests

Adds 5 tests to `CalculatorForm.test.tsx` covering the disabled/hint states, the
stock and options payloads, the short side, and the tier-refusal toast. The full
file (65 tests) is green; web typecheck and lint are clean.
